### PR TITLE
More Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,9 @@ yaourt -S firrtl-git verilator sbt
 
 ### Mac OS X
 
-1. Install sbt:
-
-    ```
-    brew install sbt
-    ```
-
-1. Install Verilator:
-
-    ```
-    brew install verilator
-    ```
+```
+brew install sbt verilator
+```
 
 ## Getting Started
 If you are migrating to Chisel3 from Chisel2, please visit


### PR DESCRIPTION
This is a follow up to https://github.com/ucb-bar/chisel3/pull/575.

To review this pull request, have a look at the `README.md` as rendered by GitHub at [https://github.com/yep/chisel3](https://github.com/yep/chisel3).

The sections `Mac OS X` and `Arch Linux` have been changed slightly.

For `Mac OS X`, use one command instead of two.

For `Arch Linux`, removed ``` in front and after the code block.

Section `(Ubuntu-like) Linux` could need some cleanup as well. The numbers shown next to the install instruction steps are not monotonically increasing (`1.`,  `1.`,  `2.`,  `1.`,  `1.`,  `1.`) and there more instances of ``` . I can have a look at that next.