### PR TITLE
More of the bindings refactor

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -410,7 +410,6 @@ object WireInit {
 
   def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     implicit val noSourceInfo = UnlocatableSourceInfo
-    requireIsChiselType(t)
     val x = Wire(t)
     requireIsHardware(init, "wire initializer")
     x := init

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -380,7 +380,9 @@ abstract class Data extends HasId {
 
 trait WireFactory {
   def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-    requireIsChiselType(t)
+    if (compileOptions.declaredTypeMustBeUnbound) {
+      requireIsChiselType(t, "wire type")
+    }
     val x = t.chiselCloneType
 
     // Bind each element of x to being a Wire

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -380,6 +380,7 @@ abstract class Data extends HasId {
 
 trait WireFactory {
   def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    requireIsChiselType(t)
     val x = t.chiselCloneType
 
     // Bind each element of x to being a Wire
@@ -391,6 +392,7 @@ trait WireFactory {
     x
   }
 }
+
 object Wire extends WireFactory
 
 object WireInit {
@@ -408,6 +410,7 @@ object WireInit {
 
   def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     implicit val noSourceInfo = UnlocatableSourceInfo
+    requireIsChiselType(t)
     val x = Wire(t)
     requireIsHardware(init, "wire initializer")
     x := init

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -83,8 +83,11 @@ object DataMirror {
     requireIsHardware(target, "node requested directionality on")
     target.direction
   }
-  // TODO: really not a reflection-style API, but a workaround for dir in the compatibility package
-  def isSynthesizable(target: Data) = target.hasBinding
+
+  // Internal reflection-style APIs, subject to change and removal whenever.
+  object internal {
+    def isSynthesizable(target: Data) = target.hasBinding
+  }
 }
 
 /** Creates a clone of the super-type of the input elements. Super-type is defined as:

--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -20,8 +20,8 @@ object Mem {
     */
   def apply[T <: Data](size: Int, t: T): Mem[T] = macro MemTransform.apply[T]
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Mem[T] = {
+    requireIsChiselType(t, "memory type")
     val mt  = t.chiselCloneType
-
     val mem = new Mem(mt, size)
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
     mem
@@ -121,6 +121,7 @@ object SyncReadMem {
   def apply[T <: Data](size: Int, t: T): SyncReadMem[T] = macro MemTransform.apply[T]
 
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] = {
+    requireIsChiselType(t, "memory type")
     val mt  = t.chiselCloneType
     val mem = new SyncReadMem(mt, size)
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size))

--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -20,7 +20,9 @@ object Mem {
     */
   def apply[T <: Data](size: Int, t: T): Mem[T] = macro MemTransform.apply[T]
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Mem[T] = {
-    requireIsChiselType(t, "memory type")
+    if (compileOptions.declaredTypeMustBeUnbound) {
+      requireIsChiselType(t, "memory type")
+    }
     val mt  = t.chiselCloneType
     val mem = new Mem(mt, size)
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
@@ -121,7 +123,9 @@ object SyncReadMem {
   def apply[T <: Data](size: Int, t: T): SyncReadMem[T] = macro MemTransform.apply[T]
 
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] = {
-    requireIsChiselType(t, "memory type")
+    if (compileOptions.declaredTypeMustBeUnbound) {
+      requireIsChiselType(t, "memory type")
+    }
     val mt  = t.chiselCloneType
     val mem = new SyncReadMem(mt, size)
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size))

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -40,6 +40,7 @@ object RegNext {
     }).asInstanceOf[T]
     val reg = Reg(model)
 
+    requireIsHardware(next, "reg next")
     reg := next
 
     reg
@@ -56,6 +57,7 @@ object RegNext {
     }).asInstanceOf[T]
     val reg = RegInit(model, init)  // TODO: this makes NO sense
 
+    requireIsHardware(next, "reg next")
     reg := next
 
     reg

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -57,6 +57,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   type Data = chisel3.core.Data
   object Wire extends chisel3.core.WireFactory {
     import chisel3.core.CompileOptions
+
     def apply[T <: Data](dummy: Int = 0, init: T)(implicit compileOptions: CompileOptions): T =
       chisel3.core.WireInit(init)
 
@@ -105,7 +106,6 @@ package object Chisel {     // scalastyle:ignore package.object.name
     @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
     def apply[T <: Data](gen: T, n: Int)(implicit compileOptions: CompileOptions): Vec[T] =
       apply(n, gen)
-
 
     /** Creates a new [[Vec]] of length `n` composed of the result of the given
       * function repeatedly applied.

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -31,7 +31,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   implicit class AddDirMethodToData[T<:Data](val target: T) extends AnyVal {
     import chisel3.core.{DataMirror, ActualDirection, UserDirection}
     def dir: Direction = {
-      DataMirror.isSynthesizable(target) match {
+      DataMirror.internal.isSynthesizable(target) match {
         case true => target match {
           case e: Element => DataMirror.directionOf(e) match {
             case ActualDirection.Unspecified => NODIR
@@ -115,7 +115,6 @@ package object Chisel {     // scalastyle:ignore package.object.name
       * @param gen function that generates the [[Data]] that becomes the output
       * element
       */
-    @deprecated("Vec.fill(n)(gen) is deprecated. Please use Vec(Seq.fill(n)(gen))", "chisel3")
     def fill[T <: Data](n: Int)(gen: => T)(implicit compileOptions: CompileOptions): Vec[T] =
       apply(Seq.fill(n)(gen))
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -123,11 +123,13 @@ package object Chisel {     // scalastyle:ignore package.object.name
       chisel3.core.VecInit(elts)
 
     def apply[T <: Data](elt0: T, elts: T*): Vec[T] = macro VecTransform.apply_elt0
-    def do_apply[T <: Data](elt0: T, elts: T*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    def do_apply[T <: Data](elt0: T, elts: T*)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit(elt0 +: elts.toSeq)
 
     def tabulate[T <: Data](n: Int)(gen: (Int) => T): Vec[T] = macro VecTransform.tabulate
-    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit.tabulate(n)(gen)
   }
   type Vec[T <: Data] = chisel3.core.Vec[T]
@@ -525,11 +527,11 @@ package object Chisel {     // scalastyle:ignore package.object.name
     * Because its contents won't necessarily have the same level of stability and support as
     * non-experimental, you must explicitly import this package to use its contents.
     */
-  object experimental {
+  object experimental {  // scalastyle:ignore object.name
     import scala.annotation.compileTimeOnly
 
-    class dump extends chisel3.internal.naming.dump
-    class treedump extends chisel3.internal.naming.treedump
-    class chiselName extends chisel3.internal.naming.chiselName
+    class dump extends chisel3.internal.naming.dump  // scalastyle:ignore class.name
+    class treedump extends chisel3.internal.naming.treedump  // scalastyle:ignore class.name
+    class chiselName extends chisel3.internal.naming.chiselName  // scalastyle:ignore class.name
   }
 }

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -21,6 +21,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   type Data = chisel3.core.Data
   object Wire extends chisel3.core.WireFactory {
     import chisel3.core.CompileOptions
+
     @deprecated("Wire(init=init) is deprecated, use WireInit(init) instead", "chisel3")
     def apply[T <: Data](dummy: Int = 0, init: T)(implicit compileOptions: CompileOptions): T =
       chisel3.core.WireInit(init)
@@ -61,15 +62,6 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       apply(n, gen)
 
-
-    /** Creates a new [[Vec]] of length `n` composed of the result of the given
-      * function repeatedly applied.
-      *
-      * @param n number of elements (amd the number of times the function is
-      * called)
-      * @param gen function that generates the [[Data]] that becomes the output
-      * element
-      */
     @deprecated("Vec.fill(n)(gen) is deprecated, use Vec(Seq.fill(n)(gen)) instead", "chisel3")
     def fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       apply(Seq.fill(n)(gen))
@@ -79,7 +71,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     def do_apply[T <: Data](elts: Seq[T])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit(elts)
 
-    @deprecated("Vec(elts) is deprecated, use VecInit(elts) instead", "chisel3")
+    @deprecated("Vec(elt0, ...) is deprecated, use VecInit(elt0, ...) instead", "chisel3")
     def apply[T <: Data](elt0: T, elts: T*): Vec[T] = macro VecTransform.apply_elt0
     def do_apply[T <: Data](elt0: T, elts: T*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit(elt0 +: elts.toSeq)

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -19,7 +19,16 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   val Flipped = chisel3.core.Flipped
 
   type Data = chisel3.core.Data
-  val Wire = chisel3.core.Wire
+  object Wire extends chisel3.core.WireFactory {
+    import chisel3.core.CompileOptions
+    @deprecated("Wire(init=init) is deprecated, use WireInit(init) instead", "chisel3")
+    def apply[T <: Data](dummy: Int = 0, init: T)(implicit compileOptions: CompileOptions): T =
+      chisel3.core.WireInit(init)
+
+    @deprecated("Wire(t, init) is deprecated, use WireInit(t, init) instead", "chisel3")
+    def apply[T <: Data](t: T, init: T)(implicit compileOptions: CompileOptions): T =
+      chisel3.core.WireInit(t, init)
+  }
   val Clock = chisel3.core.Clock
   type Clock = chisel3.core.Clock
 
@@ -43,7 +52,44 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   }
 
   type Aggregate = chisel3.core.Aggregate
-  val Vec = chisel3.core.Vec
+  object Vec extends chisel3.core.VecFactory {
+    import scala.language.experimental.macros
+    import chisel3.core.CompileOptions
+    import chisel3.internal.sourceinfo._
+
+    @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
+    def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+      apply(n, gen)
+
+
+    /** Creates a new [[Vec]] of length `n` composed of the result of the given
+      * function repeatedly applied.
+      *
+      * @param n number of elements (amd the number of times the function is
+      * called)
+      * @param gen function that generates the [[Data]] that becomes the output
+      * element
+      */
+    @deprecated("Vec.fill(n)(gen) is deprecated, use Vec(Seq.fill(n)(gen)) instead", "chisel3")
+    def fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+      apply(Seq.fill(n)(gen))
+
+    @deprecated("Vec(elts) is deprecated, use VecInit(elts) instead", "chisel3")
+    def apply[T <: Data](elts: Seq[T]): Vec[T] = macro VecTransform.apply_elts
+    def do_apply[T <: Data](elts: Seq[T])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+      chisel3.core.VecInit(elts)
+
+    @deprecated("Vec(elts) is deprecated, use VecInit(elts) instead", "chisel3")
+    def apply[T <: Data](elt0: T, elts: T*): Vec[T] = macro VecTransform.apply_elt0
+    def do_apply[T <: Data](elt0: T, elts: T*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+      chisel3.core.VecInit(elt0 +: elts.toSeq)
+
+    @deprecated("Vec.tabulate(n)(gen) is deprecated, use VecInit.tabulate(n)(gen) instead", "chisel3")
+    def tabulate[T <: Data](n: Int)(gen: (Int) => T): Vec[T] = macro VecTransform.tabulate
+    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+      chisel3.core.VecInit.tabulate(n)(gen)
+  }
+  val VecInit = chisel3.core.VecInit
   type Vec[T <: Data] = chisel3.core.Vec[T]
   type VecLike[T <: Data] = chisel3.core.VecLike[T]
   type Bundle = chisel3.core.Bundle

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -1,4 +1,3 @@
-import chisel3.core.CompileOptions
 // See LICENSE for license details.
 
 /** The chisel3 package contains the chisel3 API.
@@ -13,6 +12,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
   import chisel3.util._
   import chisel3.internal.firrtl.Port
+  import chisel3.core.CompileOptions
 
   val Input   = chisel3.core.Input
   val Output  = chisel3.core.Output
@@ -75,12 +75,14 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
     @deprecated("Vec(elt0, ...) is deprecated, use VecInit(elt0, ...) instead", "chisel3")
     def apply[T <: Data](elt0: T, elts: T*): Vec[T] = macro VecTransform.apply_elt0
-    def do_apply[T <: Data](elt0: T, elts: T*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    def do_apply[T <: Data](elt0: T, elts: T*)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit(elt0 +: elts.toSeq)
 
     @deprecated("Vec.tabulate(n)(gen) is deprecated, use VecInit.tabulate(n)(gen) instead", "chisel3")
     def tabulate[T <: Data](n: Int)(gen: (Int) => T): Vec[T] = macro VecTransform.tabulate
-    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       chisel3.core.VecInit.tabulate(n)(gen)
   }
   val VecInit = chisel3.core.VecInit
@@ -321,9 +323,12 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     final def != (that: BitPat): Bool = macro SourceInfoTransform.thatArg
     final def =/= (that: BitPat): Bool = macro SourceInfoTransform.thatArg
 
-    def do_=== (that: BitPat)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that === x    // scalastyle:ignore method.name
-    def do_!= (that: BitPat)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that != x      // scalastyle:ignore method.name
-    def do_=/= (that: BitPat)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that =/= x    // scalastyle:ignore method.name
+    def do_=== (that: BitPat)  // scalastyle:ignore method.name
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that === x
+    def do_!= (that: BitPat)  // scalastyle:ignore method.name
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that != x
+    def do_=/= (that: BitPat)  // scalastyle:ignore method.name
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that =/= x
   }
 
 
@@ -340,7 +345,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     * Because its contents won't necessarily have the same level of stability and support as
     * non-experimental, you must explicitly import this package to use its contents.
     */
-  object experimental {
+  object experimental {  // scalastyle:ignore object.name
     type Param = chisel3.core.Param
     type IntParam = chisel3.core.IntParam
     val IntParam = chisel3.core.IntParam
@@ -403,8 +408,8 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
     import scala.annotation.compileTimeOnly
 
-    class dump extends chisel3.internal.naming.dump
-    class treedump extends chisel3.internal.naming.treedump
-    class chiselName extends chisel3.internal.naming.chiselName
+    class dump extends chisel3.internal.naming.dump  // scalastyle:ignore class.name
+    class treedump extends chisel3.internal.naming.treedump  // scalastyle:ignore class.name
+    class chiselName extends chisel3.internal.naming.chiselName  // scalastyle:ignore class.name
   }
 }

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -30,6 +30,8 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     def apply[T <: Data](t: T, init: T)(implicit compileOptions: CompileOptions): T =
       chisel3.core.WireInit(t, init)
   }
+  val WireInit = chisel3.core.WireInit
+
   val Clock = chisel3.core.Clock
   type Clock = chisel3.core.Clock
 
@@ -62,7 +64,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       apply(n, gen)
 
-    @deprecated("Vec.fill(n)(gen) is deprecated, use Vec(Seq.fill(n)(gen)) instead", "chisel3")
+    @deprecated("Vec.fill(n)(gen) is deprecated, use VecInit(Seq.fill(n)(gen)) instead", "chisel3")
     def fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
       apply(Seq.fill(n)(gen))
 

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -70,7 +70,7 @@ class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[
     (0 until n).map(i => ctrl(i) && grantMask(i) || ctrl(i + n))
   }
 
-  override protected lazy val choice = Wire(init=(n-1).asUInt)
+  override protected lazy val choice = WireInit((n-1).asUInt)
   for (i <- n-2 to 0 by -1)
     when (io.in(i).valid) { choice := i.asUInt }
   for (i <- n-1 to 1 by -1)
@@ -81,7 +81,7 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
   protected def grant: Seq[Bool] = ArbiterCtrl(io.in.map(_.valid))
 
-  override protected lazy val choice = Wire(init=(n-1).asUInt)
+  override protected lazy val choice = WireInit((n-1).asUInt)
   for (i <- n-2 to 0 by -1)
     when (io.in(i).valid) { choice := i.asUInt }
 }

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -94,7 +94,10 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) {
   @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")
   def != (that: UInt): Bool = macro SourceInfoTransform.thatArg
 
-  def do_=== (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = value.asUInt === (that & mask.asUInt)    // scalastyle:ignore method.name
-  def do_=/= (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = !(this === that)    // scalastyle:ignore method.name
-  def do_!= (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this =/= that        // scalastyle:ignore method.name
+  def do_=== (that: UInt)  // scalastyle:ignore method.name
+      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = value.asUInt === (that & mask.asUInt)
+  def do_=/= (that: UInt)  // scalastyle:ignore method.name
+      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = !(this === that)
+  def do_!= (that: UInt)  // scalastyle:ignore method.name
+      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this =/= that
 }

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -211,7 +211,7 @@ class Queue[T <: Data](gen: T,
 
   val io = IO(new QueueIO(genType, entries))
 
-  private val ram = Mem(entries, gen)
+  private val ram = Mem(entries, genType)
   private val enq_ptr = Counter(entries)
   private val deq_ptr = Counter(entries)
   private val maybe_full = RegInit(false.B)

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -206,8 +206,8 @@ class Queue[T <: Data](gen: T,
   private val ptr_match = enq_ptr.value === deq_ptr.value
   private val empty = ptr_match && !maybe_full
   private val full = ptr_match && maybe_full
-  private val do_enq = Wire(init=io.enq.fire())
-  private val do_deq = Wire(init=io.deq.fire())
+  private val do_enq = WireInit(io.enq.fire())
+  private val do_deq = WireInit(io.deq.fire())
 
   when (do_enq) {
     ram(enq_ptr.value) := io.enq.bits

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -179,7 +179,7 @@ class AnalogSpec extends ChiselFlatSpec {
   it should "work with blackboxes at different levels of the module hierarchy" in {
     assertTesterPasses(new AnalogTester {
       val mods = Seq(Module(new AnalogReaderBlackBox), Module(new AnalogReaderWrapper))
-      val busWire = Wire(writer.io.bus)
+      val busWire = Wire(writer.io.bus.cloneType)
       attach(writer.io.bus, mods(0).io.bus, mods(1).io.bus)
       mods.foreach(check(_))
     }, Seq("/chisel3/AnalogBlackBox.v"))

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -118,7 +118,7 @@ class AnalogSpec extends ChiselFlatSpec {
   it should "NOT be connectable to UInts" in {
     a [Exception] should be thrownBy {
       runTester { new BasicTester {
-        val uint = Wire(init = 0.U(32.W))
+        val uint = WireInit(0.U(32.W))
         val sint = Wire(Analog(32.W))
         sint := uint
       }}

--- a/src/test/scala/chiselTests/BetterNamingTests.scala
+++ b/src/test/scala/chiselTests/BetterNamingTests.scala
@@ -26,12 +26,12 @@ class PerNameIndexing(count: Int) extends NamedModuleTester {
 // Note this only checks Iterable[Chisel.Data] which excludes Maps
 class IterableNaming extends NamedModuleTester {
   val seq = Seq.tabulate(3) { i =>
-    Seq.tabulate(2) { j => expectName(Wire(init = (i * j).U), s"seq_${i}_${j}") }
+    Seq.tabulate(2) { j => expectName(WireInit((i * j).U), s"seq_${i}_${j}") }
   }
-  val optSet = Some(Set(expectName(Wire(init = 0.U), "optSet_0"),
-                        expectName(Wire(init = 1.U), "optSet_1"),
-                        expectName(Wire(init = 2.U), "optSet_2"),
-                        expectName(Wire(init = 3.U), "optSet_3")))
+  val optSet = Some(Set(expectName(WireInit(0.U), "optSet_0"),
+                        expectName(WireInit(1.U), "optSet_1"),
+                        expectName(WireInit(2.U), "optSet_2"),
+                        expectName(WireInit(3.U), "optSet_3")))
 
   val stack = mutable.Stack[Module]()
   for (i <- 0 until 4) {

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -26,7 +26,7 @@ class HasDeadCode(withDontTouch: Boolean) extends Module {
   val inst = Module(new HasDeadCodeChild(withDontTouch))
   inst.io.a := io.a
   io.b := inst.io.b
-  val dead = Wire(init = io.a + 1.U)
+  val dead = WireInit(io.a + 1.U)
   if (withDontTouch) {
     dontTouch(dead)
   }

--- a/src/test/scala/chiselTests/EnumSpec.scala
+++ b/src/test/scala/chiselTests/EnumSpec.scala
@@ -11,7 +11,7 @@ class EnumSpec extends ChiselFlatSpec {
   "1-entry Enums" should "work" in {
     assertTesterPasses(new BasicTester {
       val onlyState :: Nil = Enum(1)
-      val wire = Wire(init = onlyState)
+      val wire = WireInit(onlyState)
       chisel3.assert(wire === onlyState)
       stop()
     })

--- a/src/test/scala/chiselTests/IOCompatibility.scala
+++ b/src/test/scala/chiselTests/IOCompatibility.scala
@@ -21,7 +21,7 @@ class IOCModuleVec(val n: Int) extends Module {
     val ins  = Vec(n, Input(UInt(32.W)))
     val outs = Vec(n, Output(UInt(32.W)))
   })
-  val pluses = Vec.fill(n){ Module(new IOCPlusOne).io }
+  val pluses = VecInit(Seq.fill(n){ Module(new IOCPlusOne).io })
   for (i <- 0 until n) {
     pluses(i).in := io.ins(i)
     io.outs(i)   := pluses(i).out

--- a/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
+++ b/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
@@ -22,9 +22,9 @@ class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
     class TestTop extends Module {
       val io = IO(new Bundle {})
 
-      val subs = Vec.fill(2) {
+      val subs = VecInit(Seq.fill(2) {
         Module(new Test).io
-      }
+      })
     }
 
     elaborate(new TestTop)

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -16,8 +16,8 @@ class PlusOne extends Module {
 
 class ModuleVec(val n: Int) extends Module {
   val io = IO(new Bundle {
-    val ins  = Input(Vec(n, 32.U))
-    val outs = Output(Vec(n, 32.U))
+    val ins  = Input(Vec(n, UInt(32.W)))
+    val outs = Output(Vec(n, UInt(32.W)))
   })
   val pluses = Vec.fill(n){ Module(new PlusOne).io }
   for (i <- 0 until n) {

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -19,7 +19,7 @@ class ModuleVec(val n: Int) extends Module {
     val ins  = Input(Vec(n, UInt(32.W)))
     val outs = Output(Vec(n, UInt(32.W)))
   })
-  val pluses = Vec.fill(n){ Module(new PlusOne).io }
+  val pluses = VecInit(Seq.fill(n){ Module(new PlusOne).io })
   for (i <- 0 until n) {
     pluses(i).in := io.ins(i)
     io.outs(i)   := pluses(i).out

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -54,7 +54,7 @@ class MultiClockSubModuleTest extends BasicTester {
 
 /** Test withReset changing the reset of a Reg */
 class WithResetTest extends BasicTester {
-  val reset2 = Wire(init = false.B)
+  val reset2 = WireInit(false.B)
   val reg = withReset(reset2 || reset) { RegInit(0.U(8.W)) }
   reg := reg + 1.U
 

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -126,10 +126,10 @@ object Agg1 extends HasMakeLit[Agg1] {
     val (d: Double, e: Double, f: Double, g: Double) = (x, x * 2.0, x * 3.0, x * 4.0)
 
     val w = Wire(new Agg1)
-    w.v(0) := Wire(d.F(4.BP))
-    w.v(1) := Wire(e.F(4.BP))
-    w.a.f1 := Wire(f.F(3.BP))
-    w.a.f2 := Wire(g.F(5.BP))
+    w.v(0) := d.F(4.BP)
+    w.v(1) := e.F(4.BP)
+    w.a.f1 := f.F(3.BP)
+    w.a.f2 := g.F(5.BP)
     w
   }
 }
@@ -147,10 +147,10 @@ object Agg2 extends HasMakeLit[Agg2] {
     val (d: Double, e: Double, f: Double, g: Double) = (x, x * 2.0, x * 3.0, x * 4.0)
 
     val w = Wire(new Agg2)
-    w.v(0) := Wire(d.F(4.BP))
-    w.v(1) := Wire(e.F(4.BP))
-    w.a.f1 := Wire(f.F(3.BP))
-    w.a.f2 := Wire(g.F(5.BP))
+    w.v(0) := d.F(4.BP)
+    w.v(1) := e.F(4.BP)
+    w.a.f1 := f.F(3.BP)
+    w.a.f2 := g.F(5.BP)
     w
   }
 }

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -67,7 +67,7 @@ class PrintableSpec extends FlatSpec with Matchers {
   }
   it should "generate proper printf for simple Decimal printing" in {
     class MyModule extends BasicTester {
-      val myWire = Wire(init = 1234.U)
+      val myWire = WireInit(1234.U)
       printf(p"myWire = ${Decimal(myWire)}")
     }
     val firrtl = Driver.emit(() => new MyModule)
@@ -144,8 +144,8 @@ class PrintableSpec extends FlatSpec with Matchers {
   }
   it should "print UInts and SInts as Decimal by default" in {
     class MyModule extends BasicTester {
-      val myUInt = Wire(init = 0.U)
-      val mySInt = Wire(init = -1.S)
+      val myUInt = WireInit(0.U)
+      val mySInt = WireInit(-1.S)
       printf(p"$myUInt & $mySInt")
     }
     val firrtl = Driver.emit(() => new MyModule)

--- a/src/test/scala/chiselTests/TesterDriverSpec.scala
+++ b/src/test/scala/chiselTests/TesterDriverSpec.scala
@@ -21,7 +21,7 @@ class FinishTester extends BasicTester {
     stop()
   }
 
-  val test_wire = Wire(init=1.U(test_wire_width.W))
+  val test_wire = WireInit(1.U(test_wire_width.W))
 
   // though we just set test_wire to 1, the assert below will pass because
   // the finish will change its value

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -36,7 +36,7 @@ class OneBitUnitRegVec extends Module {
   val io = IO(new Bundle {
     val out = Output(UInt(1.W))
   })
-  val oneBitUnitRegVec = Reg(Vec(1, 1.U))
+  val oneBitUnitRegVec = Reg(Vec(1, UInt(1.W)))
   oneBitUnitRegVec(0) := 1.U(1.W)
   io.out := oneBitUnitRegVec(0)
 }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -12,7 +12,7 @@ class LitTesterMod(vecSize: Int) extends Module {
   val io = IO(new Bundle {
     val out = Output(Vec(vecSize, UInt()))
   })
-  io.out := Vec(Seq.fill(vecSize){0.U})
+  io.out := VecInit(Seq.fill(vecSize){0.U})
 }
 
 class RegTesterMod(vecSize: Int) extends Module {
@@ -78,8 +78,8 @@ class IOTesterModFill(vecSize: Int) extends Module {
   // This should generate a BindingException when we attempt to wire up the Vec.fill elements
   //  since they're pure types and hence unsynthesizeable.
   val io = IO(new Bundle {
-    val in = Input(Vec.fill(vecSize) {UInt()})
-    val out = Output(Vec.fill(vecSize) {UInt()})
+    val in = Input(VecInit(Seq.fill(vecSize) {UInt()}))
+    val out = Output(VecInit(Seq.fill(vecSize) {UInt()}))
   })
   io.out := io.in
 }
@@ -147,7 +147,7 @@ class ZeroEntryVecTester extends BasicTester {
   val m = Module(new Module {
     val io = IO(Output(bundleWithZeroEntryVec.cloneType))
   })
-  Wire(init = m.io.bar)
+  WireInit(m.io.bar)
 
   stop()
 }
@@ -171,7 +171,7 @@ class PassthroughModuleTester extends Module {
 
 
 class ModuleIODynamicIndexTester(n: Int) extends BasicTester {
-  val duts = Vec.fill(n)(Module(new PassthroughModule).io)
+  val duts = VecInit(Seq.fill(n)(Module(new PassthroughModule).io))
   val tester = Module(new PassthroughModuleTester)
 
   val (cycle, done) = Counter(true.B, n)

--- a/src/test/scala/examples/ImplicitStateVendingMachine.scala
+++ b/src/test/scala/examples/ImplicitStateVendingMachine.scala
@@ -9,7 +9,7 @@ import chisel3._
 class ImplicitStateVendingMachine extends SimpleVendingMachine {
   // We let the value of nickel be 1 and dime be 2 for efficiency reasons
   val value = RegInit(0.asUInt(3.W))
-  val incValue = Wire(init = 0.asUInt(3.W))
+  val incValue = WireInit(0.asUInt(3.W))
   val doDispense = value >= 4.U // 4 * nickel as 1 == $0.20
 
   when (doDispense) {

--- a/src/test/scala/examples/VendingMachineGenerator.scala
+++ b/src/test/scala/examples/VendingMachineGenerator.scala
@@ -54,7 +54,7 @@ class VendingMachineGenerator(
 
   val width = log2Ceil(maxValue + 1).W
   val value = RegInit(0.asUInt(width))
-  val incValue = Wire(init = 0.asUInt(width))
+  val incValue = WireInit(0.asUInt(width))
   val doDispense = value >= (sodaCost / minCoin).U
 
   when (doDispense) {


### PR DESCRIPTION
Rest of the Bindings refactor
- Separate out initialization constructors, with deprecation:
  - Wire(init=...) => WireInit
  - Vec(elts) => VecInit
- Require Vec, Wire, and Mem constructors to take a chisel type, not a hardware type.
- Fixes to test suite to make it pass, because it was creating Wires from hardware types

Tests with rocket-chip pending, will fix the use cases in chisel test suite soon so they stop spewing deprecated warnings.

It's likely that rocket-chip will need some fixes to match the new semantics. That list to come soon...

Part 2 (of probably 3?) in a series of PRs for #578