### PR TITLE
the cloneType and chiselCloneType hot mess 🔥

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -89,10 +89,10 @@ object Vec {
     *
     * @note elements are NOT assigned by default and have no value
     */
-  def apply[T <: Data](n: Int, gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.chiselCloneType, n)
+  def apply[T <: Data](n: Int, gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.cloneTypeFull, n)
 
   @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.chiselCloneType, n)
+  def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.cloneTypeFull, n)
 
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]
     * nodes.
@@ -588,9 +588,3 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
     */
   override def toPrintable: Printable = toPrintableHelper(elements.toList.reverse)
 }
-
-private[core] object Bundle {
-  val keywords = List("flip", "asInput", "asOutput", "cloneType", "chiselCloneType", "toBits",
-    "widthOption", "signalName", "signalPathName", "signalParent", "signalComponent")
-}
-

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -85,6 +85,13 @@ object DataMirror {
   }
   // TODO: really not a reflection-style API, but a workaround for dir in the compatibility package
   def isSynthesizable(target: Data) = target.hasBinding
+
+  object internal {
+    // For those odd cases where you need to care about object reference and uniqueness
+    def chiselTypeClone[T<:Data](target: Data): T = {
+      target.cloneTypeFull.asInstanceOf[T]
+    }
+  }
 }
 
 /** Creates a clone of the super-type of the input elements. Super-type is defined as:
@@ -334,7 +341,7 @@ abstract class Data extends HasId {
     * Returns a copy of this data type, with hardware bindings (if any) removed.
     * Directionality data is still preserved.
     */
-  def cloneTypeFull: this.type = {
+  private[chisel3] def cloneTypeFull: this.type = {
     val clone = this.cloneType.asInstanceOf[this.type]  // get a fresh object, without bindings
     // Only the top-level direction needs to be fixed up, cloneType should do the rest
     clone.userDirection = userDirection

--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -20,7 +20,7 @@ object Mem {
     */
   def apply[T <: Data](size: Int, t: T): Mem[T] = macro MemTransform.apply[T]
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Mem[T] = {
-    val mt  = t.chiselCloneType
+    val mt  = t.cloneTypeFull
 
     val mem = new Mem(mt, size)
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
@@ -90,7 +90,7 @@ sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId {
 
     val port = pushCommand(
       DefMemPort(sourceInfo,
-       t.chiselCloneType, Node(this), dir, i.ref, Node(Builder.forcedClock))
+       t.cloneTypeFull, Node(this), dir, i.ref, Node(Builder.forcedClock))
     ).id
     // Bind each element of port to being a MemoryPort
     port.bind(MemoryPortBinding(Builder.forcedUserModule))
@@ -121,7 +121,7 @@ object SyncReadMem {
   def apply[T <: Data](size: Int, t: T): SyncReadMem[T] = macro MemTransform.apply[T]
 
   def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] = {
-    val mt  = t.chiselCloneType
+    val mt  = t.cloneTypeFull
     val mem = new SyncReadMem(mt, size)
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size))
     mem

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -217,7 +217,7 @@ abstract class BaseModule extends HasId {
    * TODO(twigg): Specifically walk the Data definition to call out which nodes
    * are problematic.
    */
-  protected def IO[T<:Data](iodef: T): iodef.type = {
+  protected def IO[T<:Data](iodef: T): T = {
     require(!_closed, "Can't add more ports after module close")
     requireIsChiselType(iodef, "io type")
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -217,7 +217,7 @@ abstract class BaseModule extends HasId {
    * TODO(twigg): Specifically walk the Data definition to call out which nodes
    * are problematic.
    */
-  protected def IO[T<:Data](iodef: T): T = {
+  protected def IO[T<:Data](iodef: T): iodef.type = {
     require(!_closed, "Can't add more ports after module close")
     requireIsChiselType(iodef, "io type")
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -19,7 +19,7 @@ object Reg {
     if (compileOptions.declaredTypeMustBeUnbound) {
       requireIsChiselType(t, "reg type")
     }
-    val reg = t.chiselCloneType
+    val reg = t.cloneTypeFull
     val clock = Node(Builder.forcedClock)
 
     reg.bind(RegBinding(Builder.forcedUserModule))
@@ -36,7 +36,7 @@ object RegNext {
   def apply[T <: Data](next: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (next match {
       case next: Bits => next.cloneTypeWidth(Width())
-      case next => next.chiselCloneType
+      case next => next.cloneTypeFull
     }).asInstanceOf[T]
     val reg = Reg(model)
 
@@ -52,7 +52,7 @@ object RegNext {
   def apply[T <: Data](next: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (next match {
       case next: Bits => next.cloneTypeWidth(Width())
-      case next => next.chiselCloneType
+      case next => next.cloneTypeFull
     }).asInstanceOf[T]
     val reg = RegInit(model, init)  // TODO: this makes NO sense
 
@@ -69,10 +69,10 @@ object RegInit {
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (init.litArg match {
       // For e.g. Reg(init=UInt(0, k)), fix the Reg's width to k
-      case Some(lit) if lit.forcedWidth => init.chiselCloneType
+      case Some(lit) if lit.forcedWidth => init.cloneTypeFull
       case _ => init match {
         case init: Bits => init.cloneTypeWidth(Width())
-        case init => init.chiselCloneType
+        case init => init.cloneTypeFull
       }
     }).asInstanceOf[T]
     RegInit(model, init)
@@ -84,7 +84,7 @@ object RegInit {
     if (compileOptions.declaredTypeMustBeUnbound) {
       requireIsChiselType(t, "reg type")
     }
-    val reg = t.chiselCloneType
+    val reg = t.cloneTypeFull
     val clock = Node(Builder.forcedClock)
     val reset = Node(Builder.forcedReset)
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -51,6 +51,11 @@ package object Chisel {     // scalastyle:ignore package.object.name
 
     }
   }
+  implicit class cloneTypeable[T<:Data](val target: T) extends AnyVal {
+    def chiselCloneType: target.type = {
+      target.cloneTypeFull.asInstanceOf[target.type]
+    }
+  }
 
   type ChiselException = chisel3.internal.ChiselException
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -52,8 +52,9 @@ package object Chisel {     // scalastyle:ignore package.object.name
     }
   }
   implicit class cloneTypeable[T<:Data](val target: T) extends AnyVal {
+    import chisel3.core.DataMirror
     def chiselCloneType: target.type = {
-      target.cloneTypeFull.asInstanceOf[target.type]
+      DataMirror.internal.chiselTypeClone(target).asInstanceOf[target.type]
     }
   }
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -42,10 +42,10 @@ package object Chisel {     // scalastyle:ignore package.object.name
       }
     }
   }
-  implicit class cloneTypeable[T<:Data](val target: T) extends AnyVal {
+  implicit class cloneTypeable[T <: Data](val target: T) extends AnyVal {
     import chisel3.core.DataMirror
-    def chiselCloneType: target.type = {
-      DataMirror.internal.chiselTypeClone(target).asInstanceOf[target.type]
+    def chiselCloneType: T = {
+      DataMirror.internal.chiselTypeClone(target).asInstanceOf[T]
     }
   }
 

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -57,10 +57,10 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     }
   }
 
-  implicit class cloneTypeable[T<:Data](val target: T) extends AnyVal {
+  implicit class cloneTypeable[T <: Data](val target: T) extends AnyVal {
     @deprecated("chiselCloneType is deprecated, use chiselTypeOf(...) to get the Chisel Type of a hardware object", "chisel3")
-    def chiselCloneType: target.type = {
-      target.cloneTypeFull.asInstanceOf[target.type]
+    def chiselCloneType: T = {
+      target.cloneTypeFull.asInstanceOf[T]
     }
   }
 

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -17,6 +17,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   val Input   = chisel3.core.Input
   val Output  = chisel3.core.Output
   val Flipped = chisel3.core.Flipped
+  val chiselTypeOf = chisel3.core.chiselTypeOf
 
   type Data = chisel3.core.Data
   val Wire = chisel3.core.Wire

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -43,6 +43,13 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     }
   }
 
+  implicit class cloneTypeable[T<:Data](val target: T) extends AnyVal {
+    @deprecated("chiselCloneType is deprecated, use chiselTypeOf(...) to get the Chisel Type of a hardware object", "chisel3")
+    def chiselCloneType: target.type = {
+      target.cloneTypeFull.asInstanceOf[target.type]
+    }
+  }
+
   type Aggregate = chisel3.core.Aggregate
   val Vec = chisel3.core.Vec
   type Vec[T <: Data] = chisel3.core.Vec[T]

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -269,7 +269,7 @@ object Queue
       entries: Int = 2,
       pipe: Boolean = false,
       flow: Boolean = false): DecoupledIO[T] = {
-    val q = Module(new Queue(enq.bits.cloneType, entries, pipe, flow))
+    val q = Module(new Queue(chiselTypeOf(enq.bits), entries, pipe, flow))
     q.io.enq.valid := enq.valid // not using <> so that override is allowed
     q.io.enq.bits := enq.bits
     enq.ready := q.io.enq.ready

--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -8,8 +8,7 @@ object RegEnable {
   /** Returns a register with the specified next, update enable gate, and no reset initialization.
     */
   def apply[T <: Data](next: T, enable: Bool): T = {
-    val clonedNext = next.chiselCloneType
-    val r = Reg(clonedNext)
+    val r = Reg(chiselTypeOf(next))
     when (enable) { r := next }
     r
   }

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -41,7 +41,7 @@ class ModuleVecTester(c: ModuleVec) extends Tester(c) {
 
 class ModuleWire extends Module {
   val io = IO(new SimpleIO)
-  val inc = Wire(Module(new PlusOne).io.chiselCloneType)
+  val inc = Wire(chiselTypeOf(Module(new PlusOne).io))
   inc.in := io.in
   io.out := inc.out
 }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -145,7 +145,7 @@ class ZeroEntryVecTester extends BasicTester {
   require(bundleWithZeroEntryVec.asUInt.getWidth == 1)
 
   val m = Module(new Module {
-    val io = IO(Output(bundleWithZeroEntryVec.cloneType))
+    val io = IO(Output(bundleWithZeroEntryVec))
   })
   Wire(init = m.io.bar)
 


### PR DESCRIPTION
Addresses #419 

Overview:
- cloneType is now marked (through comments only) as an internal API.
- chiselCloneType deprecated (and changed to cloneTypeFull internally, analogous to cloneTypeWidth).
- chiselTypeOf(data) introduced as the external API to get a chisel type from a hardware object
- Intended usage: cloning is an implementation detail, and chisel types and hardware objects both should act as immutable types, with operations like Input(...), Reg(...), etc returning a copy and leaving the original unchanged. Hence, the clone operations are all deprecated.
- Deletes what appears to be an unused Bundle companion object.
- Input(...), Output(...), Flipped(...) require the object to be unbound

Remaining issues:
- Several uses of chiselCloneType remain in utils and tests for compatibility reasons, chiselCloneType does not check that the input is hardware bound while chiselTypeOf(...) does check. This goes into strictness issues with #635 and needs more discussion.
- It would be nice for cloneType to return type Data, and have cloneTypeFull / etc fix up the types, because `this.type` is a nasty hack (see #193) and to avoid the `.asInstanceOf[this.type]` boilerplate needed in every cloneType implementation. It seems rocket-chip still has things that call cloneType directly so this causes compile errors. Only a small handful, though, so maybe this is something we could do? Otherwise, Scala does not seem to try implicit conversions on the wrong return type, so PML isn't a solution here.
- cloneType is not deprecate-able because it is simultaneously an internal and external API. Ideally, if the usages in rocket-chip are few, those could be fixed (with either chiselCloneType or chisel3-semantics chiselTypeOf) and the function (possibly could be?) made protected. (note, this will protect things within our control like Data.cloneType, but not user defined functions that don't explicitly protect their cloneType functions, especially Bundle sub-types)
- Cases where the user needs to define cloneType is where it get hairy, because that's where the intended abstraction does break down and users have to think about object uniqueness. Prime examples: ComplexAssign and RecordSpec test cases. Bundle annotations (or more advanced reflection-based cloning) might address some (perhaps even most) cases. Record especially might be difficult, because the elements can be defined however. This will probably be the biggest issue, especially since Bundle constructors can be deceptively wrong (what if you put a chisel type argument directly as a Bundle element and don't redefine the Bundle clone so the elements get cloned?)

This should not be merged yet, this is just a starting point to think about these issues.