### PR TITLE
Black box top-level IO fix

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -75,7 +75,7 @@ abstract class ExtModule(val params: Map[String, Param] = Map.empty[String, Para
     }
 
     val firrtlPorts = getModulePorts map {port => Port(port, port.userDirection)}
-    val component = DefBlackBox(this, name, firrtlPorts, params)
+    val component = DefBlackBox(this, name, firrtlPorts, UserDirection.Unspecified, params)
     _component = Some(component)
     component
   }
@@ -160,7 +160,7 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     }
 
     val firrtlPorts = namedPorts map {namedPort => Port(namedPort._2, namedPort._2.userDirection)}
-    val component = DefBlackBox(this, name, firrtlPorts, params)
+    val component = DefBlackBox(this, name, firrtlPorts, io.userDirection, params)
     _component = Some(component)
     component
   }

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -19,7 +19,7 @@ object UserDirection {
   /** Node and its children are forced as output
     */
   case object Output extends UserDirection
-  /** Node and ites children are forced as inputs
+  /** Node and its children are forced as inputs
     */
   case object Input extends UserDirection
   /** Mainly for containers, children are flipped.

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -274,6 +274,6 @@ abstract class Component extends Arg {
   def ports: Seq[Port]
 }
 case class DefModule(id: UserModule, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component
-case class DefBlackBox(id: BaseBlackBox, name: String, ports: Seq[Port], params: Map[String, Param]) extends Component
+case class DefBlackBox(id: BaseBlackBox, name: String, ports: Seq[Port], topDir: UserDirection, params: Map[String, Param]) extends Component
 
 case class Circuit(name: String, components: Seq[Component], annotations: Seq[Annotation] = Seq.empty)

--- a/src/test/resources/chisel3/BlackBoxTest.v
+++ b/src/test/resources/chisel3/BlackBoxTest.v
@@ -12,6 +12,13 @@ module BlackBoxPassthrough(
   assign out = in;
 endmodule
 
+module BlackBoxPassthrough2(
+    input  [0:0] in,
+    output [0:0] out
+);
+  assign out = in;
+endmodule
+
 module BlackBoxMinus(
     input  [15:0] in1,
     input  [15:0] in2,

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -25,6 +25,14 @@ class BlackBoxPassthrough extends BlackBox {
   })
 }
 
+// Test Flip on top-level IO
+class BlackBoxPassthrough2 extends BlackBox {
+  val io = IO(Flipped(new Bundle() {
+    val in = Output(Bool())
+    val out = Input(Bool())
+  }))
+}
+
 class BlackBoxRegister extends BlackBox {
   val io = IO(new Bundle() {
     val clock = Input(Clock())
@@ -42,6 +50,14 @@ class BlackBoxTester extends BasicTester {
 
   assert(blackBoxNeg.io.out === 1.U)
   assert(blackBoxPos.io.out === 0.U)
+  stop()
+}
+
+class BlackBoxFlipTester extends BasicTester {
+  val blackBox = Module(new BlackBoxPassthrough2)
+
+  blackBox.io.in := 1.U
+  assert(blackBox.io.out === 1.U)
   stop()
 }
 
@@ -138,6 +154,10 @@ class BlackBoxWithParamsTester extends BasicTester {
 class BlackBoxSpec extends ChiselFlatSpec {
   "A BlackBoxed inverter" should "work" in {
     assertTesterPasses({ new BlackBoxTester },
+        Seq("/chisel3/BlackBoxTest.v"))
+  }
+  "A BlackBoxed with flipped IO" should "work" in {
+    assertTesterPasses({ new BlackBoxFlipTester },
         Seq("/chisel3/BlackBoxTest.v"))
   }
   "Multiple BlackBoxes" should "work" in {

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -36,6 +36,12 @@ class BadSubDirection extends DirectionHaver {
   io.inBundle.out := 0.U
 }
 
+class TopDirectionOutput extends Module {
+  val io = IO(Output(new DirectionedBundle))
+  io.in := 42.U
+  io.out := 117.U
+}
+
 class DirectionSpec extends ChiselPropSpec with Matchers {
 
   //TODO: In Chisel3 these are actually FIRRTL errors. Remove from tests?
@@ -51,5 +57,9 @@ class DirectionSpec extends ChiselPropSpec with Matchers {
     a[Exception] should be thrownBy {
      elaborate(new BadSubDirection)
     }
+  }
+
+  property("Top-level forced outputs should be assignable") {
+    elaborate(new TopDirectionOutput)
   }
 }


### PR DESCRIPTION
Resolves #282 in a hack-patchy way (direction of the top-level io object added to the DefBlackBox, since the io object itself is dropped during BlackBox generateComponent).

Also adds a test for a similar issue with regular Module direction, which may have been broken for entirely different reasons.