### PR TITLE
Disable aggregation until we can apply it selectively

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,8 @@ lazy val chisel = (project in file(".")).
   dependsOn(coreMacros % "compile-internal;test-internal").
   dependsOn(chiselFrontend % "compile-internal;test-internal").
   // The following is required until sbt-scoverage correctly deals with inDependencies
-  aggregate(coreMacros, chiselFrontend).
+  // Unfortunately, it also revives publishing of the subproject jars. Disable until the latter is resolved (again).
+  //aggregate(coreMacros, chiselFrontend).
   settings(
     scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
     scalacOptions in Compile in doc ++= Seq(


### PR DESCRIPTION
 or sbt-scoverage is updated to deal with dependencies.
Unfortunately, enabling this revives the publishing of the coreMacros and chiselFrontend jars and we don't want that.