### PR TITLE
Don't assign default direction to Analog in Chisel._

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -202,10 +202,11 @@ abstract class Data extends HasId {
     * DO NOT USE OUTSIDE THIS PURPOSE. THIS OPERATION IS DANGEROUS!
     */
   private[core] def _assignCompatibilityExplicitDirection: Unit = {
-    _userDirection match {
-      case UserDirection.Unspecified => _userDirection = UserDirection.Output
-      case UserDirection.Flip => _userDirection = UserDirection.Input
-      case UserDirection.Input | UserDirection.Output => // nothing to do
+    (this, _userDirection) match {
+      case (_: Analog, _) => // nothing to do
+      case (_, UserDirection.Unspecified) => _userDirection = UserDirection.Output
+      case (_, UserDirection.Flip) => _userDirection = UserDirection.Input
+      case (_, UserDirection.Input | UserDirection.Output) => // nothing to do
     }
   }
 

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -161,6 +161,14 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
     elaborate { new Chisel2CompatibleRisc }
   }
 
+  it should "not try to assign directions to Analog" in {
+    elaborate(new Module {
+      val io = new Bundle {
+        val port = chisel3.experimental.Analog(32.W)
+      }
+    })
+  }
+
 
   class SmallBundle extends Bundle {
     val f1 = UInt(width = 4)


### PR DESCRIPTION
While it is true that Analog is a chisel3 feature, for pragmatic reasons you generally want to be able to pass Analog ports through compatibility code without having to migrate your entire code base. 