### PR TITLE
Give default direction to children of Vecs in compatibility code

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -235,9 +235,11 @@ abstract class BaseModule extends HasId {
         case data: Aggregate => data.userDirection match {
           // Recurse into children to ensure explicit direction set somewhere
           case UserDirection.Unspecified | UserDirection.Flip => data match {
-            case data: Record if (!data.compileOptions.dontAssumeDirectionality) =>
-              data.getElements.foreach(assignCompatDir(_, true))
-            case _ => data.getElements.foreach(assignCompatDir(_, false))
+            case record: Record =>
+              val compatRecord = !record.compileOptions.dontAssumeDirectionality
+              record.getElements.foreach(assignCompatDir(_, compatRecord))
+            case vec: Vec[_] =>
+              vec.getElements.foreach(assignCompatDir(_, insideCompat))
           }
           case UserDirection.Input | UserDirection.Output => // forced assign, nothing to do
         }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -249,4 +249,15 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
     }
     elaborate { new DirectionLessConnectionModule() }
   }
+
+  "Vec ports" should "give default directions to children so they can be used in chisel3.util" in {
+    import Chisel._
+    elaborate(new Module {
+      val io = new Bundle {
+        val in = Vec(1, UInt(width = 8)).flip
+        val out = UInt(width = 8)
+      }
+      io.out := RegEnable(io.in(0), true.B)
+    })
+  }
 }


### PR DESCRIPTION
Basically, in compatibility mode direction assigning, Vecs were being treated like Records/Bundles defined in `chisel3._` code and thus not actually assigning default directions to their children.