### PR TITLE
Stop Queue while reset is high

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -233,8 +233,8 @@ class Queue[T <: Data](gen: T,
     maybe_full := do_enq
   }
 
-  io.deq.valid := !empty
-  io.enq.ready := !full
+  io.deq.valid := !reset & !empty
+  io.enq.ready := !reset & !full
   io.deq.bits := ram(deq_ptr.value)
 
   if (flow) {

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -233,8 +233,12 @@ class Queue[T <: Data](gen: T,
     maybe_full := do_enq
   }
 
-  io.deq.valid := !reset & !empty
-  io.enq.ready := !reset & !full
+  io.deq.valid := !empty
+  io.enq.ready := !full
+  when (reset) {
+    io.deq.valid := false.B
+    io.enq.ready := false.B
+  }
   io.deq.bits := ram(deq_ptr.value)
 
   if (flow) {


### PR DESCRIPTION
`enq.ready` and `deq.valid` of `Queue` should never be true while reset is high.