### PR TITLE
Aggregates can now be marked as literals.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -34,8 +34,8 @@ sealed abstract class Aggregate extends Data {
   }
 
   protected[core] override def hasBinding = {
-   checkBinding
-   super.hasBinding
+    checkBinding
+    super.hasBinding
   }
 
   protected[core] override def binding = {

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -57,7 +57,6 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   }
 
   type Aggregate = chisel3.core.Aggregate
-  val Aggregate = chisel3.core.Aggregate
   object Vec extends chisel3.core.VecFactory {
     import scala.language.experimental.macros
     import chisel3.core.CompileOptions

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -57,6 +57,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   }
 
   type Aggregate = chisel3.core.Aggregate
+  val Aggregate = chisel3.core.Aggregate
   object Vec extends chisel3.core.VecFactory {
     import scala.language.experimental.macros
     import chisel3.core.CompileOptions

--- a/src/main/scala/chisel3/testers/BasicTester.scala
+++ b/src/main/scala/chisel3/testers/BasicTester.scala
@@ -13,7 +13,7 @@ import internal.sourceinfo.SourceInfo
 
 class BasicTester extends Module() {
   // The testbench has no IOs, rather it should communicate using printf, assert, and stop.
-  val io = IO(new Bundle())
+  val io = IO(new Bundle {val dummy = Input(UInt(0.W))})
 
   def popCount(n: Long): Int = n.toBinaryString.count(_=='1')
 

--- a/src/test/scala/chiselTests/BundleLiterals.scala
+++ b/src/test/scala/chiselTests/BundleLiterals.scala
@@ -1,0 +1,66 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import org.scalatest._
+
+class BundleWithLit(lit: Option[Int]=None) extends Bundle {
+  val internal = lit.map(_.U).getOrElse(UInt(4.W))
+  override def cloneType = new BundleWithLit(lit).asInstanceOf[this.type]
+}
+
+object BundleWithLit {
+  def apply(x: Int) = {
+    val ret = new BundleWithLit(Some(x))
+    Aggregate.LitBind(ret)
+    ret
+  }
+  def apply() = {
+    new BundleWithLit()
+  }
+}
+
+class BundleWithBundleWithLit(lit: Option[Int]=None) extends Bundle {
+  val internal = lit.map(BundleWithLit(_)).getOrElse(BundleWithLit())
+  override def cloneType = new BundleWithBundleWithLit(lit).asInstanceOf[this.type]
+}
+
+object BundleWithBundleWithLit {
+  def apply(x: Int) = {
+    val ret = new BundleWithBundleWithLit(Some(x))
+    Aggregate.LitBind(ret)
+    ret
+  }
+  def apply() = {
+    new BundleWithBundleWithLit()
+  }
+}
+
+class BundleWithLitModule extends Module {
+  val io = IO(new Bundle {
+    val out = Output(BundleWithLit())
+  })
+  io.out := BundleWithLit(3)
+}
+
+class BundleWithBundleWithLitModule extends Module {
+  val io = IO(new Bundle {
+    val out = Output(BundleWithBundleWithLit())
+  })
+  io.out := BundleWithBundleWithLit(3)
+}
+
+class BundleLiteralsSpec extends FlatSpec with Matchers {
+  behavior of "Bundle literals"
+
+  it should "build the module without crashing" in {
+    println(chisel3.Driver.emitVerilog( new BundleWithLitModule ))
+  }
+
+  behavior of "Bundle literals with bundle literals inside"
+
+  it should "build the module without crashing" in {
+    println(chisel3.Driver.emitVerilog( new BundleWithBundleWithLitModule ))
+  }
+}


### PR DESCRIPTION
This is inspired by dsptools DspReal(), which is implemented as a Bundle with a UInt inside. Bundles currently can't be literals, which causes problems because it is totally natural to want a literal DspReal().

This is an initial stab at making literal bundles work in this context. It doesn't go anywhere towards addressing #417, although I think it does address #418 to an extent. This is also related to ucb-bar/dsptools#55 and perhaps ucb-bar/dsptools#87.

The big difference between how lits need to work for Aggregates and UInt/SInt/etc. is that UInt/SInt/etc aren't meant to be subclassed, whereas Aggregates are (especially Bundle and Record). Some API needs to be provided for users to mark things as literals (checking that they actually are).

Currently, I check by calling isLit() on all children. This is fine for UInt/SInt/etc., but is problematic for Aggregates because they currently don't mark themselves as lits. I added a private var that gets set to something when you try to mark an Aggregate as a lit, but the actual value is ignored because I don't do anything with it. I'm not a fan of doing this, but not familiar enough with the backend to know what a better alternative would be.

@ducky64 @jackkoenig @chick 