### PR TITLE
Remove warning in Queue for compatibility code

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -202,7 +202,6 @@ class Queue[T <: Data](gen: T,
     gen
   } else {
     if (DataMirror.internal.isSynthesizable(gen)) {
-      println("WARNING: gen in new Queue(gen, ...) must be a Chisel type, not hardware")
       gen.chiselCloneType
     } else {
       gen


### PR DESCRIPTION
This warning doesn't give any line number or other information so it's not very helpful and just spams the screen for rocket-chip designs.