### PR TITLE
Default to unidoc for scaladoc generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ifneq (,$(RM_DIRS))
 endif
 
 scaladoc:
-	$(SBT) $(SBT_FLAGS) doc
+	$(SBT) $(SBT_FLAGS) unidoc
 
 site:
 	$(SBT) $(SBT_FLAGS) make-site

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -166,7 +166,7 @@ private[chisel3] object Builder {
 
   // Initialize any singleton objects before user code inadvertently inherits them.
   private def initializeSingletons(): Unit = {
-    val dummy = DontCare
+    val dummy = core.DontCare
   }
   def idGen: IdGen = dynamicContext.idGen
   def globalNamespace: Namespace = dynamicContext.globalNamespace


### PR DESCRIPTION
Since `sbt doc` doesn't generate scaladoc for subprojects, switch to `sbt unidoc` so we generate scaladoc for coreMacros and chiselFrontend.
Disambiguate DontCare reference in initializeSingletons() avoiding compilation error during unidoc generation.
