### PR TITLE
Fix chisel3.Driver example documentation

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -23,8 +23,8 @@ import _root_.firrtl.annotations.AnnotationYamlProtocol._
   * @example
   *          {{{
   *          val optionsManager = new ExecutionOptionsManager("chisel3")
-  *              with FirrtlExecutionOptions
-  *              with ChiselExecutionOptions {
+  *              with HasFirrtlOptions
+  *              with HasChiselExecutionOptions {
   *            commonOptions = CommonOption(targetDirName = "my_target_dir")
   *            chiselOptions = ChiselExecutionOptions(runFirrtlCompiler = false)
   *          }


### PR DESCRIPTION
The chisel3.Driver example was mixing in case classes as opposed to the traits that were (assumedly) intended. This corrects that.