### PR TITLE
Change switch to emit when, elsewhen, instead of when, when

### DIFF
--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -24,10 +24,16 @@ object unless {  // scalastyle:ignore object.name
   * user-facing API.
   */
 class SwitchContext[T <: Bits](cond: T) {
+  private var whenContext: Option[WhenContext] = None
   def is(v: Iterable[T])(block: => Unit) {
     if (!v.isEmpty) {
-      when (v.map(_.asUInt === cond.asUInt).reduce(_||_)) {
-        block
+      // def instead of val so that logic ends up in legal place
+      def p = v.map(_.asUInt === cond.asUInt).reduce(_||_)
+      whenContext match {
+        case Some(w) =>
+          whenContext = Some(w.elsewhen(p)(block))
+        case None =>
+          whenContext = Some(when(p)(block))
       }
     }
   }

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+
+class MultiSwitchFireTester extends BasicTester {
+  val wire = WireInit(0.U)
+  switch (0.U) {
+    is (0.U) { wire := 1.U } // Only this one should happen
+    is (0.U) { wire := 2.U }
+  }
+  assert(wire === 1.U)
+  stop()
+}
+
+class SwitchSpec extends ChiselFlatSpec {
+  "switch" should "work for implementing FSMs" in {
+    assertTesterPasses(new MultiSwitchFireTester)
+  }
+}

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -6,18 +6,30 @@ import chisel3._
 import chisel3.util._
 import chisel3.testers.BasicTester
 
-class MultiSwitchFireTester extends BasicTester {
-  val wire = WireInit(0.U)
-  switch (0.U) {
-    is (0.U) { wire := 1.U } // Only this one should happen
-    is (0.U) { wire := 2.U }
-  }
-  assert(wire === 1.U)
-  stop()
-}
-
 class SwitchSpec extends ChiselFlatSpec {
-  "switch" should "work for implementing FSMs" in {
-    assertTesterPasses(new MultiSwitchFireTester)
+  "switch" should "require literal conditions" in {
+    a [java.lang.IllegalArgumentException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {})
+        val state = RegInit(0.U)
+        val wire = WireInit(0.U)
+        switch (state) {
+          is (wire) { state := 1.U }
+        }
+      })
+    }
+  }
+  it should "require mutually exclusive conditions" in {
+    a [java.lang.IllegalArgumentException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {})
+        val state = RegInit(0.U)
+        switch (state) {
+          is (0.U) { state := 1.U }
+          is (1.U) { state := 2.U }
+          is (0.U) { state := 3.U }
+        }
+      })
+    }
   }
 }


### PR DESCRIPTION
While theoretically emitting independent whens for each "is" *could* make better hardware, Firrtl currently just emits a bad mux tree with lots of coverage holes. This change matches common use where each "is" is mutually exclusive and users would prefer then same result as when, elsewhen. 

@terpstra 