### PR TITLE
Bump SBT to 1.0.4 and update plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
     //  switch to support our anonymous Bundle definitions:
     //  https://github.com/scala/bug/issues/10047
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Int)) if scalaMajor < 12 => Seq()
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
       case _ => Seq("-Xsource:2.11")
     }
   }
@@ -22,7 +22,7 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
     //  Java 7 compatible code for Scala 2.11
     //  for compatibility with old clients.
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Int)) if scalaMajor < 12 =>
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
         Seq("-source", "1.7", "-target", "1.7")
       case _ =>
         Seq("-source", "1.8", "-target", "1.8")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 


### PR DESCRIPTION
This requires anyone including chisel as a submodule to bump their version of sbt as well.

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [x] Other enhancement

* **Impact**
  - [ ] no functional change
  - [ ] API addition (no impact on existing code)
  - [x] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Bump SBT version
