### PR TITLE
Properly invalidate submodule IOs in tests

### DIFF
--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -32,6 +32,7 @@ class PipeInternalWires extends Module {
 
 class CrossConnectTester(inType: Data, outType: Data) extends BasicTester {
   val dut = Module(new CrossConnects(inType, outType))
+  dut.io := DontCare
   stop()
 }
 

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -61,6 +61,7 @@ trait RecordSpecUtils {
 
   class RecordQueueTester extends BasicTester {
     val queue = Module(new Queue(fooBarType, 4))
+    queue.io <> DontCare
     queue.io.enq.valid := false.B
     val (cycle, done) = Counter(true.B, 4)
 

--- a/src/test/scala/chiselTests/VectorPacketIO.scala
+++ b/src/test/scala/chiselTests/VectorPacketIO.scala
@@ -51,7 +51,8 @@ class BrokenVectorPacketModule extends Module {
 }
 
 class VectorPacketIOUnitTester extends BasicTester {
-  val device_under_test = Module(new BrokenVectorPacketModule)
+  val dut = Module(new BrokenVectorPacketModule)
+  dut.io <> DontCare
 
   // This counter just makes the test end quicker
   val c = Counter(1)


### PR DESCRIPTION
Needed for https://github.com/freechipsproject/firrtl/pull/706
Firrtl wasn't properly checking that submodule ports were invalidated, now it will. The Firrtl PR is failing the Chisel tests without this fix.

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [x] Other enhancement

* **Impact**
  - [x] no functional change
  - [ ] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Fix tests