### PR TITLE
Add compileOptions to Module.apply, use for invalidating submod ports

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -80,7 +80,7 @@ abstract class ExtModule(val params: Map[String, Param] = Map.empty[String, Para
     component
   }
 
-  private[core] def initializeInParent() {
+  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
     for (x <- getModulePorts) {
@@ -165,7 +165,7 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     component
   }
 
-  private[core] def initializeInParent() {
+  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
     for ((_, port) <- io.elements) {
       pushCommand(DefInvalid(UnlocatableSourceInfo, port.ref))
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -80,7 +80,7 @@ abstract class ExtModule(val params: Map[String, Param] = Map.empty[String, Para
     component
   }
 
-  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+  private[core] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
     for (x <- getModulePorts) {
@@ -165,7 +165,7 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     component
   }
 
-  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+  private[core] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     for ((_, port) <- io.elements) {
       pushCommand(DefInvalid(UnlocatableSourceInfo, port.ref))
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -126,7 +126,7 @@ abstract class BaseModule extends HasId {
 
   /** Sets up this module in the parent context
     */
-  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit
+  private[core] def initializeInParent(parentCompileOptions: CompileOptions): Unit
 
   //
   // Chisel Internals

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -23,7 +23,9 @@ object Module {
     */
   def apply[T <: BaseModule](bc: => T): T = macro InstTransform.apply[T]
 
-  def do_apply[T <: BaseModule](bc: => T)(implicit sourceInfo: SourceInfo): T = {
+  def do_apply[T <: BaseModule](bc: => T)
+                               (implicit sourceInfo: SourceInfo,
+                                         compileOptions: CompileOptions): T = {
     if (Builder.readyForModuleConstr) {
       throwException("Error: Called Module() twice without instantiating a Module." +
                      sourceInfo.makeMessage(" See " + _))
@@ -62,7 +64,7 @@ object Module {
     // Handle connections at enclosing scope
     if(!Builder.currentModule.isEmpty) {
       pushCommand(DefInstance(sourceInfo, module, component.ports))
-      module.initializeInParent()
+      module.initializeInParent(compileOptions)
     }
     module
   }
@@ -124,7 +126,7 @@ abstract class BaseModule extends HasId {
 
   /** Sets up this module in the parent context
     */
-  private[core] def initializeInParent()
+  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit
 
   //
   // Chisel Internals

--- a/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
@@ -81,10 +81,10 @@ abstract class UserModule(implicit moduleCompileOptions: CompileOptions)
     component
   }
 
-  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+  private[core] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    if (!instanceCompileOptions.explicitInvalidate) {
+    if (!parentCompileOptions.explicitInvalidate) {
       for (port <- getModulePorts) {
         pushCommand(DefInvalid(sourceInfo, port.ref))
       }
@@ -107,10 +107,10 @@ abstract class ImplicitModule(implicit moduleCompileOptions: CompileOptions)
   // Setup ClockAndReset
   Builder.currentClockAndReset = Some(ClockAndReset(clock, reset))
 
-  private[core] override def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+  private[core] override def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    super.initializeInParent(instanceCompileOptions)
+    super.initializeInParent(parentCompileOptions)
     clock := Builder.forcedClock
     reset := Builder.forcedReset
   }
@@ -176,12 +176,12 @@ abstract class LegacyModule(implicit moduleCompileOptions: CompileOptions)
     super.generateComponent()
   }
 
-  private[core] override def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+  private[core] override def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     // Don't generate source info referencing parents inside a module, since this interferes with
     // module de-duplication in FIRRTL emission.
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    if (!instanceCompileOptions.explicitInvalidate) {
+    if (!parentCompileOptions.explicitInvalidate) {
       pushCommand(DefInvalid(sourceInfo, io.ref))
     }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
@@ -81,8 +81,15 @@ abstract class UserModule(implicit moduleCompileOptions: CompileOptions)
     component
   }
 
-  // There is no initialization to be done by default.
-  private[core] def initializeInParent() {}
+  private[core] def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
+    implicit val sourceInfo = UnlocatableSourceInfo
+
+    if (!instanceCompileOptions.explicitInvalidate) {
+      for (port <- getModulePorts) {
+        pushCommand(DefInvalid(sourceInfo, port.ref))
+      }
+    }
+  }
 }
 
 /** Abstract base class for Modules, which behave much like Verilog modules.
@@ -100,14 +107,10 @@ abstract class ImplicitModule(implicit moduleCompileOptions: CompileOptions)
   // Setup ClockAndReset
   Builder.currentClockAndReset = Some(ClockAndReset(clock, reset))
 
-  private[core] override def initializeInParent() {
+  private[core] override def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    if (!compileOptions.explicitInvalidate) {
-      for (port <- getModulePorts) {
-        pushCommand(DefInvalid(sourceInfo, port.ref))
-      }
-    }
+    super.initializeInParent(instanceCompileOptions)
     clock := Builder.forcedClock
     reset := Builder.forcedReset
   }
@@ -173,12 +176,12 @@ abstract class LegacyModule(implicit moduleCompileOptions: CompileOptions)
     super.generateComponent()
   }
 
-  private[core] override def initializeInParent() {
+  private[core] override def initializeInParent(instanceCompileOptions: CompileOptions): Unit = {
     // Don't generate source info referencing parents inside a module, since this interferes with
     // module de-duplication in FIRRTL emission.
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    if (!compileOptions.explicitInvalidate) {
+    if (!instanceCompileOptions.explicitInvalidate) {
       pushCommand(DefInvalid(sourceInfo, io.ref))
     }
 

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -38,7 +38,7 @@ class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
 class InstTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](bc: c.Tree): c.Tree = {
-    q"$thisObj.do_apply($bc)($implicitSourceInfo)"
+    q"$thisObj.do_apply($bc)($implicitSourceInfo, $implicitCompileOptions)"
   }
 }
 

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -217,5 +217,27 @@ class CompatibiltyInteroperabilitySpec extends ChiselFlatSpec {
       stop()
     })
   }
+
+  "An instance of a chisel3.Module inside a Chisel.Module" should "have its inputs invalidated" in {
+    compile {
+      import Chisel._
+      new Module {
+        val io = new Bundle {
+          val in = UInt(INPUT, width = 32)
+          val cond = Bool(INPUT)
+          val out = UInt(OUTPUT, width = 32)
+        }
+        val children = Seq(Module(new PassthroughModule),
+                           Module(new PassthroughMultiIOModule),
+                           Module(new PassthroughRawModule))
+        io.out := children.map(_.io.out).reduce(_ + _)
+        children.foreach { child =>
+          when (io.cond) {
+            child.io.in := io.in
+          }
+        }
+      }
+    }
+  }
 }
 

--- a/src/test/scala/chiselTests/Util.scala
+++ b/src/test/scala/chiselTests/Util.scala
@@ -1,0 +1,22 @@
+// Useful utilities for tests
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental._
+
+class PassthroughModuleIO extends Bundle {
+  val in = Input(UInt(32.W))
+  val out = Output(UInt(32.W))
+}
+
+trait AbstractPassthroughModule extends RawModule {
+  val io = IO(new PassthroughModuleIO)
+  io.out := io.in
+}
+
+class PassthroughModule extends Module with AbstractPassthroughModule
+class PassthroughMultiIOModule extends MultiIOModule with AbstractPassthroughModule
+class PassthroughRawModule extends RawModule with AbstractPassthroughModule
+
+

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.experimental.RawModule
 import chisel3.core.Binding.BindingException
 import chisel3.testers.BasicTester
 import chisel3.util._
@@ -151,16 +152,6 @@ class ZeroEntryVecTester extends BasicTester {
   WireInit(m.io.bar)
 
   stop()
-}
-
-class PassthroughModuleIO extends Bundle {
-  val in = Input(UInt(32.W))
-  val out = Output(UInt(32.W))
-}
-
-class PassthroughModule extends Module {
-  val io = IO(new PassthroughModuleIO)
-  io.out := io.in
 }
 
 class PassthroughModuleTester extends Module {

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -76,6 +76,23 @@ class NoOtherwiseOverlappedWhenTester() extends BasicTester {
   }
 }
 
+class SubmoduleWhenTester extends BasicTester {
+  val (cycle, done) = Counter(true.B, 3)
+  when (done) { stop() }
+  val children = Seq(Module(new PassthroughModule),
+                     Module(new PassthroughMultiIOModule),
+                     Module(new PassthroughRawModule))
+  children.foreach { child =>
+    when (cycle === 1.U) {
+      child.io.in := "hdeadbeef".U
+      assert(child.io.out === "hdeadbeef".U)
+    } .otherwise {
+      child.io.in := "h0badcad0".U
+      assert(child.io.out === "h0badcad0".U)
+    }
+  }
+}
+
 class WhenSpec extends ChiselFlatSpec {
   "When, elsewhen, and otherwise with orthogonal conditions" should "work" in {
     assertTesterPasses{ new WhenTester }
@@ -85,5 +102,8 @@ class WhenSpec extends ChiselFlatSpec {
   }
   "When and elsewhen without otherwise with overlapped conditions" should "work" in {
     assertTesterPasses{ new NoOtherwiseOverlappedWhenTester }
+  }
+  "Conditional connections to submodule ports" should "be handled properly" in {
+    assertTesterPasses(new SubmoduleWhenTester)
   }
 }


### PR DESCRIPTION
Fixes #746
Also add test for https://github.com/freechipsproject/firrtl/issues/705

Basically, for invalidating ports of a submodule, we need to use the compile options for where the module is constructed, not defined. I added this to Module.apply and used it in initializeInParent

* **Type of change**
  - [x] Bug ~~report~~ **fix**
  - [ ] Feature request
  - [ ] Other enhancement

* **Impact**
  - [x] no functional change
  - [ ] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Fix bug where chisel3.Modules instantiated in Chisel.Modules would not have their inputs properly invalidated