### PR TITLE
Use test_run_dir for InvalidateAPISpec tests.

### DIFF
--- a/src/test/scala/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala/chiselTests/InvalidateAPISpec.scala
@@ -13,8 +13,8 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with BackendCompila
 
   def myGenerateFirrtl(t: => Module): String = Driver.emit(() => t)
   def compileFirrtl(t: => Module): Unit = {
-    val testDir = createTestDirectory(this.getClass.getSimpleName)
-    Driver.execute(Array[String]("-td", testDir.getAbsolutePath, "--compiler", "verilog"), () => t)
+    val testDir = createTestDirectory("test_run_dir/InvalidateAPISpec")
+    Driver.execute(Array[String]("--target-dir", testDir.getAbsolutePath, "--compiler", "verilog"), () => t)
   }
   class TrivialInterface extends Bundle {
     val in  = Input(Bool())


### PR DESCRIPTION
* **Related issue** (if applicable)

* **Type of change**
  - [ ] Bug report
  - [x] Feature request
  - [ ] Other enhancement

* **Impact**
  - [x] no functional change
  - [ ] API addition (no impact on existing code)
  - [ ] API modification
This changes the output directory used for InvalidateAPISpec tests. It avoids leaving test droppings that provoke git status warnings about untracked files.

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
