### PR TITLE
Memoize autoclonetype

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -245,6 +245,7 @@ abstract class Data extends HasId {
   // This information is supplemental (more than is necessary to generate FIRRTL) and is used to
   // perform checks in Chisel, where more informative error messages are possible.
   private var _binding: Option[Binding] = None
+  private[core] def bindingOpt = _binding
   private[core] def hasBinding = _binding.isDefined
   // Only valid after node is bound (synthesizable), crashes otherwise
   private[core] def binding = _binding.get

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -35,6 +35,11 @@ class BaseBundleNonVal(i: Int) extends Bundle {
 class SubBundleVal(val i: Int, val i2: Int) extends BaseBundleNonVal(i) {
   val inner2 = UInt(i2.W)
 }
+class BundleWithAnonymousInner extends Bundle {
+  val inner = new Bundle {
+    val in = UInt(8.W)
+  }
+}
 
 class ModuleWithInner extends Module {
   class InnerBundle(val i: Int) extends Bundle {
@@ -111,5 +116,14 @@ class AutoClonetypeSpec extends ChiselFlatSpec {
 
   "Inner bundles with Scala args" should "not need clonetype" in {
     elaborate { new ModuleWithInner }
+  }
+
+  "Anonymous inner Bundles of bound Bundles" should "not need clonetype" in {
+    elaborate(new Module {
+      val io = IO(new Bundle {})
+      val w0 = Wire(new BundleWithAnonymousInner)
+      val w1 = WireInit(w0)
+      val w2 = WireInit(w0.inner)
+    })
   }
 }


### PR DESCRIPTION
**Note the target of this PR is autoclonetype**

Improves performance and allows potentially non-autoclonetypeable clones
of clonetypeble parents to be cloned.

The current autoclonetype implementation does not support cloning anonymous inner bundles of other bundles. I think this is actually an important thing to support since clonetype is called when doing things like muxing, `WireInit` or `RegNext`.

When bound, inner bundles have `ChildBinding` which points to the parent. This provides us with the correct outer instance. The problem is that when you call WireInit or any of that, the bound Bundle is cloned, and then cloned again! The second cloning fails because the cloned instance is not bound. However, if we memoize cloneType, that actually makes it possible to clone it anyway. This does mean that each clone of a cloned Bundle actually uses references from the original one, but it should give the same result. This has the nice side effect of avoiding lots of unnecessary reflection and it should improve performance.
