### PR TITLE
Add support for autoclonetype of bound, anonymous inner Bundles

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -208,11 +208,6 @@ abstract class Data extends HasId {
     }
   }
 
-  // If this Data is an instance of an inner class, record enclosing class
-  // This is only used for cloneType, and is mutable to allow autoCloneType to preserve the
-  // original outerModule.
-  private[core] var outerModule: Option[BaseModule] = Builder.currentModule
-
   // User-specified direction, local at this node only.
   // Note that the actual direction of this node can differ from child and parent specifiedDirection.
   private var _specifiedDirection: SpecifiedDirection = SpecifiedDirection.Unspecified
@@ -245,6 +240,7 @@ abstract class Data extends HasId {
   // This information is supplemental (more than is necessary to generate FIRRTL) and is used to
   // perform checks in Chisel, where more informative error messages are possible.
   private var _binding: Option[Binding] = None
+  private[core] def bindingOpt = _binding
   private[core] def hasBinding = _binding.isDefined
   // Only valid after node is bound (synthesizable), crashes otherwise
   private[core] def binding = _binding.get


### PR DESCRIPTION
Also change Data.outerModule to Bundle._outerInst since it is only used
in autoclonetype. _outerInst is also Option[Object] instead of
Option[BaseModule] because the outer object could also be a Bundle.

**Note that the target of this PR is autoclonetype**
Replaces #751 

This still provides the functionality I wanted but without attempting to address the more complex problem of how to memoize autoclonetype. I did benchmark memoize-autoclonetype on a large Chisel design and it had virtually no effect so I think doing the simpler thing for now is fine.