### PR TITLE
Change clonetype test to be autoclonetype friendly

### DIFF
--- a/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
+++ b/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
@@ -9,13 +9,11 @@ class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
   ( the[ChiselException] thrownBy {
     import chisel3._
 
-    class TestIO(w: Int) extends Bundle {
-      val a = Input(Vec(4, UInt(w.W)))
-
-      //override def cloneType = (new TestIO(w)).asInstanceOf[this.type]
-    }
-
     class Test extends Module {
+      class TestIO(w: Int) extends Bundle {
+        val a = Input(Vec(4, UInt(w.W)))
+      }
+          
       val io = IO(new TestIO(32))
     }
 
@@ -34,13 +32,11 @@ class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
   ( the[ChiselException] thrownBy {
     import Chisel._
 
-    class TestIO(w: Int) extends Bundle {
-      val a = Vec(4, UInt(width = w)).asInput
-
-      //override def cloneType = (new TestIO(w)).asInstanceOf[this.type]
-    }
-
     class Test extends Module {
+      class TestIO(w: Int) extends Bundle {
+        val a = Vec(4, UInt(width = w)).asInput
+      }
+      
       val io = IO(new TestIO(32))
     }
 


### PR DESCRIPTION
Fixes a 2.12 issue discovered on the after-party discussion for #723, by structuring the tests to be autoclonetype friendly.

@ucbjrl can you verify that this indeed does fix things for 2.12?

* **Type of change**
  - [x] Bug report
  - [ ] Feature request
  - [ ] Other enhancement

* **Impact**
  - [x] no functional change
  - [ ] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
