### PR TITLE
Remove unused BuildInfo.BuildTime.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,6 @@ lazy val chisel = (project in file(".")).
   enablePlugins(ScalaUnidocPlugin).
   settings(
     buildInfoPackage := name.value,
-    buildInfoOptions += BuildInfoOption.BuildTime,
     buildInfoUsePackageAsPath := true,
     buildInfoKeys := Seq[BuildInfoKey](buildInfoPackage, version, scalaVersion, sbtVersion)
   ).


### PR DESCRIPTION
`BuildInfo.BuildTime` appears to cause sbt to always recompile `BuildInfo` to get the latest time, which causes a recompile on any package that depends on chisel3. This is quite painful for doing development on any Chisel projects. BuildTime doesn't actually appear to be in use, and removing it fixes the unnecessary recompilation issue.

* **Related issue** (if applicable)

* **Type of change**
  - [x] Bug report
  - [ ] Feature request
  - [ ] Other enhancement

* **Impact**
Changes the firrtl file header, removing the chisel build time.

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Removed unused `BuildInfoOption.BuildTime`, which causes sbt to unnecessarily recompile Chisel and all dependent projects. 
