### PR TITLE
Refactor Annotations

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
@@ -26,16 +26,16 @@ case class ChiselAnnotation(component: InstanceId, transformClass: Class[_ <: Tr
 @deprecated("Use LazyAnnotation instead", "3.1")
 object ChiselAnnotation
 
-final case class LazyAnnotation[T] private (arg: T, toFirrtl: (T) => Annotation) {
-  def get: Annotation = toFirrtl(arg)
+final case class LazyAnnotation private (f: () => Annotation) {
+  def get: Annotation = f()
 }
 
 object annotate { // scalastyle:ignore object.name
-  def apply(anno: LazyAnnotation[_]): Unit = {
+  def apply(anno: LazyAnnotation): Unit = {
     Builder.annotations += anno
   }
   def apply(anno: Annotation): Unit = {
-    Builder.annotations += LazyAnnotation[Unit](Unit, Unit => anno)
+    Builder.annotations += LazyAnnotation(() => anno)
   }
 }
 
@@ -68,7 +68,7 @@ object dontTouch { // scalastyle:ignore object.name
     if (compileOptions.checkSynthesizable) {
       requireIsHardware(data, "Data marked dontTouch")
     }
-    annotate(LazyAnnotation[T](data, (d) => DontTouchAnnotation(d.toNamed)))
+    annotate(LazyAnnotation(() => DontTouchAnnotation(data.toNamed)))
     data
   }
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -198,7 +198,7 @@ object Flipped {
   * time) of bits, and must have methods to pack / unpack structured data to /
   * from bits.
   */
-abstract class Data extends HasId {
+abstract class Data extends HasId with NamedComponent {
   // This is a bad API that punches through object boundaries.
   @deprecated("pending removal once all instances replaced", "chisel3")
   private[chisel3] def flatten: IndexedSeq[Element] = {

--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -31,7 +31,7 @@ object Mem {
   }
 }
 
-sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId {
+sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId with NamedComponent {
   // REVIEW TODO: make accessors (static/dynamic, read/write) combinations consistent.
 
   /** Creates a read accessor into the memory with static addressing. See the

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -13,6 +13,8 @@ import chisel3.internal.Builder._
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{InstTransform, SourceInfo}
 
+import _root_.firrtl.annotations.{CircuitName, ModuleName}
+
 object Module {
   /** A wrapper method that all Module instantiations must be wrapped in
     * (necessary to help Chisel track internal state).
@@ -139,6 +141,11 @@ abstract class BaseModule extends HasId {
   /** Legalized name of this module. */
   final val name = Builder.globalNamespace.name(desiredName)
 
+  /** Returns a FIRRTL ModuleName that references this object
+    * @note Should not be called until circuit elaboration is complete
+    */
+  final def toNamed: ModuleName = ModuleName(this.name, CircuitName(this.circuitName))
+
   /** Called at the Module.apply(...) level after this Module has finished elaborating.
     * Returns a map of nodes -> names, for named nodes.
     *
@@ -196,8 +203,9 @@ abstract class BaseModule extends HasId {
   //
   // BaseModule User API functions
   //
+  @deprecated("Use chisel3.experimental.annotate instead", "3.1")
   protected def annotate(annotation: ChiselAnnotation): Unit = {
-    Builder.annotations += annotation
+    Builder.annotations += LazyAnnotation[ChiselAnnotation](annotation, (anno) => anno.toFirrtl)
   }
 
   /**

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -205,7 +205,7 @@ abstract class BaseModule extends HasId {
   //
   @deprecated("Use chisel3.experimental.annotate instead", "3.1")
   protected def annotate(annotation: ChiselAnnotation): Unit = {
-    Builder.annotations += LazyAnnotation(() => annotation.toFirrtl)
+    Builder.annotations += annotation
   }
 
   /**

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -205,7 +205,7 @@ abstract class BaseModule extends HasId {
   //
   @deprecated("Use chisel3.experimental.annotate instead", "3.1")
   protected def annotate(annotation: ChiselAnnotation): Unit = {
-    Builder.annotations += LazyAnnotation[ChiselAnnotation](annotation, (anno) => anno.toFirrtl)
+    Builder.annotations += LazyAnnotation(() => annotation.toFirrtl)
   }
 
   /**

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -164,7 +164,7 @@ private[chisel3] class DynamicContext() {
   val idGen = new IdGen
   val globalNamespace = Namespace.empty
   val components = ArrayBuffer[Component]()
-  val annotations = ArrayBuffer[LazyAnnotation]()
+  val annotations = ArrayBuffer[ChiselAnnotation]()
   var currentModule: Option[BaseModule] = None
   // Set by object Module.apply before calling class Module constructor
   // Used to distinguish between no Module() wrapping, multiple wrappings, and rewrapping
@@ -188,7 +188,7 @@ private[chisel3] object Builder {
   def idGen: IdGen = dynamicContext.idGen
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components: ArrayBuffer[Component] = dynamicContext.components
-  def annotations: ArrayBuffer[LazyAnnotation] = dynamicContext.annotations
+  def annotations: ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
   def namingStack: internal.naming.NamingStack = dynamicContext.namingStack
 
   def currentModule: Option[BaseModule] = dynamicContext.currentModule
@@ -263,7 +263,7 @@ private[chisel3] object Builder {
       errors.checkpoint()
       errors.info("Done elaborating.")
 
-      Circuit(components.last.name, components, annotations.map(_.get))
+      Circuit(components.last.name, components, annotations)
     }
   }
   initializeSingletons()

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -164,7 +164,7 @@ private[chisel3] class DynamicContext() {
   val idGen = new IdGen
   val globalNamespace = Namespace.empty
   val components = ArrayBuffer[Component]()
-  val annotations = ArrayBuffer[LazyAnnotation[_]]()
+  val annotations = ArrayBuffer[LazyAnnotation]()
   var currentModule: Option[BaseModule] = None
   // Set by object Module.apply before calling class Module constructor
   // Used to distinguish between no Module() wrapping, multiple wrappings, and rewrapping
@@ -188,7 +188,7 @@ private[chisel3] object Builder {
   def idGen: IdGen = dynamicContext.idGen
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components: ArrayBuffer[Component] = dynamicContext.components
-  def annotations: ArrayBuffer[LazyAnnotation[_]] = dynamicContext.annotations
+  def annotations: ArrayBuffer[LazyAnnotation] = dynamicContext.annotations
   def namingStack: internal.naming.NamingStack = dynamicContext.namingStack
 
   def currentModule: Option[BaseModule] = dynamicContext.currentModule

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -7,8 +7,6 @@ import core._
 import chisel3.internal._
 import chisel3.internal.sourceinfo.{SourceInfo, NoSourceInfo}
 
-import _root_.firrtl.annotations.Annotation
-
 case class PrimOp(val name: String) {
   override def toString: String = name
 }
@@ -278,4 +276,4 @@ abstract class Component extends Arg {
 case class DefModule(id: UserModule, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component
 case class DefBlackBox(id: BaseBlackBox, name: String, ports: Seq[Port], topDir: SpecifiedDirection, params: Map[String, Param]) extends Component
 
-case class Circuit(name: String, components: Seq[Component], annotations: Seq[Annotation] = Seq.empty)
+case class Circuit(name: String, components: Seq[Component], annotations: Seq[ChiselAnnotation] = Seq.empty)

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -442,7 +442,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     @deprecated("Use LazyAnnotation instead", "3.1")
     val ChiselAnnotation = chisel3.core.ChiselAnnotation
 
-    type LazyAnnotation[T] = chisel3.core.LazyAnnotation[T]
+    type LazyAnnotation = chisel3.core.LazyAnnotation
     val LazyAnnotation = chisel3.core.LazyAnnotation
 
     val annotate = chisel3.core.annotate

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -437,8 +437,15 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     type FixedPoint = chisel3.core.FixedPoint
     val FixedPoint = chisel3.core.FixedPoint
 
+    @deprecated("Use LazyAnnotation instead", "3.1")
     type ChiselAnnotation = chisel3.core.ChiselAnnotation
+    @deprecated("Use LazyAnnotation instead", "3.1")
     val ChiselAnnotation = chisel3.core.ChiselAnnotation
+
+    type LazyAnnotation[T] = chisel3.core.LazyAnnotation[T]
+    val LazyAnnotation = chisel3.core.LazyAnnotation
+
+    val annotate = chisel3.core.annotate
 
     val DataMirror = chisel3.core.DataMirror
     val requireIsHardware = chisel3.core.requireIsHardware

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -437,13 +437,9 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     type FixedPoint = chisel3.core.FixedPoint
     val FixedPoint = chisel3.core.FixedPoint
 
-    @deprecated("Use LazyAnnotation instead", "3.1")
     type ChiselAnnotation = chisel3.core.ChiselAnnotation
-    @deprecated("Use LazyAnnotation instead", "3.1")
     val ChiselAnnotation = chisel3.core.ChiselAnnotation
-
-    type LazyAnnotation = chisel3.core.LazyAnnotation
-    val LazyAnnotation = chisel3.core.LazyAnnotation
+    type RunFirrtlTransform = chisel3.core.RunFirrtlTransform
 
     val annotate = chisel3.core.annotate
 

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -11,7 +11,7 @@ trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>
 
   def setResource(blackBoxResource: String): Unit = {
-    val anno = LazyAnnotation[BlackBox](self, (s) => BlackBoxResourceAnno(s.toNamed, blackBoxResource))
+    val anno = LazyAnnotation(() => BlackBoxResourceAnno(self.toNamed, blackBoxResource))
     chisel3.experimental.annotate(anno)
     chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }
@@ -21,8 +21,7 @@ trait HasBlackBoxInline extends BlackBox {
   self: BlackBox =>
 
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
-    val anno = LazyAnnotation[BlackBox](self, (s) =>
-        BlackBoxInlineAnno(s.toNamed, blackBoxName, blackBoxInline))
+    val anno = LazyAnnotation(() => BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline))
     chisel3.experimental.annotate(anno)
     chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -3,14 +3,17 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.core.ChiselAnnotation
-import firrtl.transforms.{BlackBoxSourceHelper}
+import chisel3.experimental.LazyAnnotation
+import firrtl.transforms.{BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper}
+import firrtl.annotations.RunTransformAnnotation
 
 trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>
 
   def setResource(blackBoxResource: String): Unit = {
-    annotate(ChiselAnnotation(self, classOf[BlackBoxSourceHelper], s"resource\n$blackBoxResource"))
+    val anno = LazyAnnotation[BlackBox](self, (s) => BlackBoxResourceAnno(s.toNamed, blackBoxResource))
+    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }
 }
 
@@ -18,7 +21,9 @@ trait HasBlackBoxInline extends BlackBox {
   self: BlackBox =>
 
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
-    annotate(ChiselAnnotation(
-      self, classOf[BlackBoxSourceHelper], s"inline\n$blackBoxName\n$blackBoxInline"))
+    val anno = LazyAnnotation[BlackBox](self, (s) =>
+        BlackBoxInlineAnno(s.toNamed, blackBoxName, blackBoxInline))
+    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }
 }

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -4,13 +4,13 @@ package chisel3.util
 
 import chisel3._
 import chisel3.core.ChiselAnnotation
-import firrtl.transforms.{BlackBoxInline, BlackBoxResource, BlackBoxSourceHelper}
+import firrtl.transforms.{BlackBoxSourceHelper}
 
 trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>
 
   def setResource(blackBoxResource: String): Unit = {
-    annotate(ChiselAnnotation(self, classOf[BlackBoxSourceHelper], BlackBoxResource(blackBoxResource).serialize))
+    annotate(ChiselAnnotation(self, classOf[BlackBoxSourceHelper], s"resource\n$blackBoxResource"))
   }
 }
 
@@ -19,6 +19,6 @@ trait HasBlackBoxInline extends BlackBox {
 
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
     annotate(ChiselAnnotation(
-      self, classOf[BlackBoxSourceHelper], BlackBoxInline(blackBoxName, blackBoxInline).serialize))
+      self, classOf[BlackBoxSourceHelper], s"inline\n$blackBoxName\n$blackBoxInline"))
   }
 }

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -3,17 +3,18 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.experimental.LazyAnnotation
+import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
 import firrtl.transforms.{BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper}
-import firrtl.annotations.RunTransformAnnotation
 
 trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>
 
   def setResource(blackBoxResource: String): Unit = {
-    val anno = LazyAnnotation(() => BlackBoxResourceAnno(self.toNamed, blackBoxResource))
+    val anno = new ChiselAnnotation with RunFirrtlTransform {
+      def toFirrtl = BlackBoxResourceAnno(self.toNamed, blackBoxResource)
+      def transformClass = classOf[BlackBoxSourceHelper]
+    }
     chisel3.experimental.annotate(anno)
-    chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }
 }
 
@@ -21,8 +22,10 @@ trait HasBlackBoxInline extends BlackBox {
   self: BlackBox =>
 
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
-    val anno = LazyAnnotation(() => BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline))
+    val anno = new ChiselAnnotation with RunFirrtlTransform {
+      def toFirrtl = BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline)
+      def transformClass = classOf[BlackBoxSourceHelper]
+    }
     chisel3.experimental.annotate(anno)
-    chisel3.experimental.annotate(RunTransformAnnotation(classOf[BlackBoxSourceHelper]))
   }
 }

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -24,9 +24,7 @@ case class IdentityAnnotation(target: Named, value: String) extends SingleTarget
 }
 object identify {
   def apply(component: InstanceId, value: String): Unit = {
-    val anno = LazyAnnotation[(InstanceId, String)]((component, value),
-      { case (c, v) => IdentityAnnotation(c.toNamed, value) }
-    )
+    val anno = LazyAnnotation(() => IdentityAnnotation(component.toNamed, value))
     annotate(anno)
     annotate(RunTransformAnnotation(classOf[IdentityTransform]))
   }

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{annotate, ChiselAnnotation}
+import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
 import chisel3.internal.InstanceId
 import chisel3.testers.BasicTester
 import firrtl.{CircuitState, LowForm, Transform}
@@ -23,14 +23,15 @@ case class IdentityAnnotation(target: Named, value: String) extends SingleTarget
   def duplicate(n: Named) = this.copy(target = n)
 }
 /** ChiselAnnotation that corresponds to the above FIRRTL annotation */
-case class IdentityChiselAnnotation(target: InstanceId, value: String) extends ChiselAnnotation {
+case class IdentityChiselAnnotation(target: InstanceId, value: String)
+    extends ChiselAnnotation with RunFirrtlTransform {
   def toFirrtl = IdentityAnnotation(target.toNamed, value)
+  def transformClass = classOf[IdentityTransform]
 }
 object identify {
   def apply(component: InstanceId, value: String): Unit = {
     val anno = IdentityChiselAnnotation(component, value)
     annotate(anno)
-    annotate(ChiselAnnotation(component, classOf[IdentityTransform], ""))
   }
 }
 

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -11,8 +11,7 @@ import firrtl.annotations.{
   Annotation,
   SingleTargetAnnotation,
   ModuleName,
-  Named,
-  RunTransformAnnotation
+  Named
 }
 import org.scalatest._
 

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.ChiselAnnotation
 import chisel3.internal.InstanceId
 import chisel3.testers.BasicTester
 import firrtl.{CircuitForm, CircuitState, LowForm, Transform}
-import firrtl.annotations.{Annotation, ModuleName, Named}
+import firrtl.annotations.{Annotation, ModuleName, Named, LegacyAnnotation}
 import org.scalatest._
 
 //scalastyle:off magic.number
@@ -129,7 +129,7 @@ class DiamondTester extends BasicTester {
 
 class AnnotatingDiamondSpec extends FreeSpec with Matchers {
   def findAnno(as: Seq[Annotation], name: String): Option[Annotation] = {
-    as.find { a => a.targetString == name }
+    as.collectFirst { case a: LegacyAnnotation if a.targetString == name => a }
   }
 
   """

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -3,47 +3,48 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.ChiselAnnotation
+import chisel3.experimental.{annotate, LazyAnnotation}
 import chisel3.internal.InstanceId
 import chisel3.testers.BasicTester
-import firrtl.{CircuitForm, CircuitState, LowForm, Transform}
-import firrtl.annotations.{Annotation, ModuleName, Named, LegacyAnnotation}
+import firrtl.{CircuitState, LowForm, Transform}
+import firrtl.annotations.{
+  Annotation,
+  SingleTargetAnnotation,
+  ModuleName,
+  Named,
+  RunTransformAnnotation
+}
 import org.scalatest._
 
-//scalastyle:off magic.number
-/**
-  * This and the Identity transform class are a highly schematic implementation of a
-  * library implementation of   (i.e. code outside of firrtl itself)
+/** This and the IdentityTransform class serve as an example of how to write a Chisel/Firrtl
+  * library
   */
-object IdentityAnnotation {
-  def apply(target: Named, value: String): Annotation = Annotation(target, classOf[IdentityTransform], value)
-
-  def unapply(a: Annotation): Option[(Named, String)] = a match {
-    case Annotation(named, t, value) if t == classOf[IdentityTransform] => Some((named, value))
-    case _ => None
+case class IdentityAnnotation(target: Named, value: String) extends SingleTargetAnnotation[Named] {
+  def duplicate(n: Named) = this.copy(target = n)
+}
+object identify {
+  def apply(component: InstanceId, value: String): Unit = {
+    val anno = LazyAnnotation[(InstanceId, String)]((component, value),
+      { case (c, v) => IdentityAnnotation(c.toNamed, value) }
+    )
+    annotate(anno)
+    annotate(RunTransformAnnotation(classOf[IdentityTransform]))
   }
 }
 
 class IdentityTransform extends Transform {
-  override def inputForm: CircuitForm = LowForm
+  def inputForm = LowForm
+  def outputForm = LowForm
 
-  override def outputForm: CircuitForm = LowForm
-
-  override def execute(state: CircuitState): CircuitState = {
-    getMyAnnotations(state) match {
-      case Nil => state
-      case myAnnotations =>
-        state
+  def execute(state: CircuitState): CircuitState = {
+    val annosx = state.annotations.map {
+      case IdentityAnnotation(t, value) => IdentityAnnotation(t, value + ":seen")
+      case other => other
     }
+    state.copy(annotations = annosx)
   }
 }
 
-trait IdentityAnnotator {
-  self: Module =>
-  def identify(component: InstanceId, value: String): Unit = {
-    annotate(ChiselAnnotation(component, classOf[IdentityTransform], value))
-  }
-}
 /** A diamond circuit Top instantiates A and B and both A and B instantiate C
   * Illustrations of annotations of various components and modules in both
   * relative and absolute cases
@@ -54,7 +55,7 @@ trait IdentityAnnotator {
   * This class has parameterizable widths, it will generate different hardware
   * @param widthC io width
   */
-class ModC(widthC: Int) extends Module with IdentityAnnotator {
+class ModC(widthC: Int) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(widthC.W))
     val out = Output(UInt(widthC.W))
@@ -71,7 +72,7 @@ class ModC(widthC: Int) extends Module with IdentityAnnotator {
   * based on it's parameter
   * @param annoParam  parameter is only used in annotation not in circuit
   */
-class ModA(annoParam: Int) extends Module with IdentityAnnotator {
+class ModA(annoParam: Int) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt())
     val out = Output(UInt())
@@ -86,7 +87,7 @@ class ModA(annoParam: Int) extends Module with IdentityAnnotator {
   identify(io.out, s"ModA.io.out(ignore_param)")
 }
 
-class ModB(widthB: Int) extends Module with IdentityAnnotator{
+class ModB(widthB: Int) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(widthB.W))
     val out = Output(UInt(widthB.W))
@@ -98,7 +99,7 @@ class ModB(widthB: Int) extends Module with IdentityAnnotator{
   identify(io.in, s"modB.io.in annotated from inside modB")
 }
 
-class TopOfDiamond extends Module with IdentityAnnotator {
+class TopOfDiamond extends Module {
   val io = IO(new Bundle {
     val in   = Input(UInt(32.W))
     val out  = Output(UInt(32.W))
@@ -128,9 +129,6 @@ class DiamondTester extends BasicTester {
 }
 
 class AnnotatingDiamondSpec extends FreeSpec with Matchers {
-  def findAnno(as: Seq[Annotation], name: String): Option[Annotation] = {
-    as.collectFirst { case a: LegacyAnnotation if a.targetString == name => a }
-  }
 
   """
     |Diamond is an example of a module that has two sub-modules A and B who both instantiate their
@@ -145,15 +143,15 @@ class AnnotatingDiamondSpec extends FreeSpec with Matchers {
       Driver.execute(Array("--target-dir", "test_run_dir"), () => new TopOfDiamond) match {
         case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
           val annos = circuit.annotations
-          annos.length should be (10)
+          annos.count(_.isInstanceOf[IdentityAnnotation]) should be (10)
 
           annos.count {
-            case Annotation(ModuleName(name, _), _, annoValue) => name == "ModC" && annoValue == "ModC(16)"
+            case IdentityAnnotation(ModuleName("ModC", _), "ModC(16)") => true
             case _ => false
           } should be (1)
 
           annos.count {
-            case Annotation(ModuleName(name, _), _, annoValue) => name == "ModC_1" && annoValue == "ModC(32)"
+            case IdentityAnnotation(ModuleName("ModC_1", _), "ModC(32)") => true
             case _ => false
           } should be (1)
         case _ =>

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -3,14 +3,14 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{annotate, LazyAnnotation}
+import chisel3.experimental.{annotate, ChiselAnnotation}
 import firrtl.FirrtlExecutionSuccess
 import firrtl.transforms.NoDedupAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
 object doNotDedup {
   def apply(module: Module): Unit = {
-    annotate(LazyAnnotation(() => NoDedupAnnotation(module.toNamed)))
+    annotate(new ChiselAnnotation { def toFirrtl = NoDedupAnnotation(module.toNamed) })
   }
 }
 

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -3,16 +3,14 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.ChiselAnnotation
+import chisel3.experimental.{annotate, LazyAnnotation}
 import firrtl.FirrtlExecutionSuccess
-import firrtl.transforms.DedupModules
+import firrtl.transforms.NoDedupAnnotation
 import org.scalatest.{FreeSpec, Matchers}
 
-trait NoDedupAnnotator {
-  self: Module =>
-
-  def doNotDedup(module: Module): Unit = {
-    annotate(ChiselAnnotation(module, classOf[DedupModules], "nodedup!"))
+object doNotDedup {
+  def apply(module: Module): Unit = {
+    annotate(LazyAnnotation[Module](module, (m) => NoDedupAnnotation(m.toNamed)))
   }
 }
 
@@ -24,7 +22,7 @@ class MuchUsedModule extends Module {
   io.out := io.in +% 1.U
 }
 
-class UsesMuchUsedModule(addAnnos: Boolean) extends Module with NoDedupAnnotator{
+class UsesMuchUsedModule(addAnnos: Boolean) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(16.W))
     val out = Output(UInt(16.W))

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FreeSpec, Matchers}
 
 object doNotDedup {
   def apply(module: Module): Unit = {
-    annotate(LazyAnnotation[Module](module, (m) => NoDedupAnnotation(m.toNamed)))
+    annotate(LazyAnnotation(() => NoDedupAnnotation(module.toNamed)))
   }
 }
 

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -49,7 +49,7 @@ class UsesMuchUsedModule(addAnnos: Boolean) extends Module with NoDedupAnnotator
 
 class AnnotationNoDedup extends FreeSpec with Matchers {
   "Firrtl provides transform that reduces identical modules to a single instance" - {
-    "Annotations can be added which will defeat this deduplication for specific modules instances" in {
+    "Annotations can be added which will prevent this deduplication for specific modules instances" in {
       Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new UsesMuchUsedModule(addAnnos = true)) match {
         case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
           val lowFirrtl = firrtlResult.emitted
@@ -62,7 +62,7 @@ class AnnotationNoDedup extends FreeSpec with Matchers {
         case _ =>
       }
     }
-    "Turning off these nnotations dedup all the occurrences" in {
+    "Turning off these annotations dedups all the occurrences" in {
       Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new UsesMuchUsedModule(addAnnos = false)) match {
         case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
           val lowFirrtl = firrtlResult.emitted

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -16,9 +16,10 @@ import firrtl.{
   FirrtlExecutionSuccess,
   FirrtlExecutionFailure
 }
+import firrtl.util.BackendCompilationUtilities
 
 /** Common utility functions for Chisel unit tests. */
-trait ChiselRunners extends Assertions {
+trait ChiselRunners extends Assertions with BackendCompilationUtilities {
   def runTester(t: => BasicTester, additionalVResources: Seq[String] = Seq()): Boolean = {
     TesterDriver.execute(() => t, additionalVResources)
   }
@@ -43,9 +44,10 @@ trait ChiselRunners extends Assertions {
     * @return the Verilog code as a string.
     */
   def compile(t: => RawModule): String = {
+    val testDir = createTestDirectory(this.getClass.getSimpleName)
     val manager = new ExecutionOptionsManager("compile") with HasFirrtlOptions
                                                          with HasChiselExecutionOptions {
-      commonOptions = CommonOptions(targetDirName = "test_run_dir")
+      commonOptions = CommonOptions(targetDirName = testDir.toString)
     }
 
     Driver.execute(manager, () => t) match {

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -45,26 +45,12 @@ class DontTouchSpec extends ChiselFlatSpec {
       verilog should not include (signal)
     }
   }
-}
-class DontTouchSpec2 extends ChiselFlatSpec {
-  val deadSignals = List(
-    "io_c_0",
-    "io_c_1",
-    "dead"
-  )
-  "Dead code" should "NOT be removed if marked dontTouch" in {
+  it should "NOT be removed if marked dontTouch" in {
     val verilog = compile(new HasDeadCode(true))
     for (signal <- deadSignals) {
       verilog should include (signal)
     }
   }
-}
-class DontTouchSpec3 extends ChiselFlatSpec {
-  val deadSignals = List(
-    "io_c_0",
-    "io_c_1",
-    "dead"
-  )
   "Dont touch" should "only work on bound hardware" in {
     a [chisel3.core.Binding.BindingException] should be thrownBy {
       compile(new Module {

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -45,12 +45,26 @@ class DontTouchSpec extends ChiselFlatSpec {
       verilog should not include (signal)
     }
   }
-  it should "NOT be removed if marked dontTouch" in {
+}
+class DontTouchSpec2 extends ChiselFlatSpec {
+  val deadSignals = List(
+    "io_c_0",
+    "io_c_1",
+    "dead"
+  )
+  "Dead code" should "NOT be removed if marked dontTouch" in {
     val verilog = compile(new HasDeadCode(true))
     for (signal <- deadSignals) {
       verilog should include (signal)
     }
   }
+}
+class DontTouchSpec3 extends ChiselFlatSpec {
+  val deadSignals = List(
+    "io_c_0",
+    "io_c_1",
+    "dead"
+  )
   "Dont touch" should "only work on bound hardware" in {
     a [chisel3.core.Binding.BindingException] should be thrownBy {
       compile(new Module {

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -25,7 +25,7 @@ class DriverSpec extends FreeSpec with Matchers {
       val  targetDir = "."
       Driver.execute(Array.empty[String], () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val exts = List("anno", "fir", "v")
+          val exts = List("anno.json", "fir", "v")
           for (ext <- exts) {
             val dummyOutput = new File(targetDir, "DummyModule" + "." + ext)
             dummyOutput.exists() should be(true)
@@ -41,7 +41,7 @@ class DriverSpec extends FreeSpec with Matchers {
       val  targetDir = "local-build"
       Driver.execute(Array("-tn", "dm", "-td", targetDir), () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val exts = List("anno", "fir", "v")
+          val exts = List("anno.json", "fir", "v")
           for (ext <- exts) {
             val dummyOutput = new File(targetDir, "dm" + "." + ext)
             dummyOutput.exists() should be(true)


### PR DESCRIPTION
This makes it much easier to write annotations. As an example, check out identity annotation from the tests:
```scala
// Annotation used in Firrtl
case class IdentityAnnotation(target: Named, value: String) extends SingleTargetAnnotation[Named] {
  def duplicate(n: Named) = this.copy(target = n)
}
object identify {
  // Convenient constructor for this annotation in Chisel code on Chisel InstanceIds
  def apply(component: InstanceId, value: String): Unit = {
    val anno = LazyAnnotation(() => IdentityAnnotation(component.toNamed, value))
    annotate(anno)
    // We have a transform we want to run whenever something is identified
    annotate(RunTransformAnnotation(classOf[IdentityTransform]))
   }
 }
```

* **Related issue**

This is a companion to https://github.com/freechipsproject/firrtl/pull/721

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [x] Other enhancement

* **Impact**
  - [ ] no functional change
  - [ ] API addition (no impact on existing code)
  - [x] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

    * Updates Chisel to new JSON-based Annotation system in Firrtl (see https://github.com/freechipsproject/firrtl/pull/721).
    * Deprecates `ChiselAnnotation` in favor of `LazyAnnotation`.
    * Deprecates `Module.annotate` in favor of `object annotate`
    * Adds `.toNamed` to `InstanceId` so that we can easily generate Firrtl references to Chisel objects. 