### PR TITLE
Autoclonetype will clone args that are of type data

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -703,10 +703,10 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
     }
 
     // Clone unbound parameters in case they are being used as bundle fields.
-    val ctorParamsVals = ctorParamsNameVals.map{ case (paramName, paramVal) => paramVal match {
-      case paramVal: Data => paramVal.cloneTypeFull
-      case paramVal => paramVal
-    } }
+    val ctorParamsVals = ctorParamsNameVals.map {
+      case (_, paramVal: Data) => paramVal.cloneTypeFull
+      case (_, paramVal) => paramVal
+    }
 
     // Invoke ctor
     val classMirror = outerClassInstance match {

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -702,7 +702,11 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
           " Use chisel types instead: use the value before it is turned to a hardware type (with Wire(...), Reg(...), etc) or use chiselTypeOf(...) to extract the chisel type.")
     }
 
-    val ctorParamsVals = ctorParamsNameVals.map{ case (_, paramVal) => paramVal }
+    // Clone unbound parameters in case they are being used as bundle fields.
+    val ctorParamsVals = ctorParamsNameVals.map{ case (paramName, paramVal) => paramVal match {
+      case paramVal: Data => paramVal.cloneTypeFull
+      case paramVal => paramVal
+    } }
 
     // Invoke ctor
     val classMirror = outerClassInstance match {

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -15,8 +15,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
   * @param n number of inputs
   */
 class ArbiterIO[T <: Data](private val gen: T, val n: Int) extends Bundle {
-  // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
-  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+  // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   val in  = Flipped(Vec(n, Decoupled(gen)))
   val out = Decoupled(gen)

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -14,11 +14,13 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
   * @param gen data type
   * @param n number of inputs
   */
-class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
+class ArbiterIO[T <: Data](private val gen: T, val n: Int) extends Bundle {
+  // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
+  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+
   val in  = Flipped(Vec(n, Decoupled(gen)))
   val out = Decoupled(gen)
   val chosen = Output(UInt(log2Ceil(n).W))
-  override def cloneType: this.type = new ArbiterIO(gen, n).asInstanceOf[this.type]
 }
 
 /** Arbiter Control determining which producer has access

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -18,6 +18,7 @@ class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
   val in  = Flipped(Vec(n, Decoupled(gen)))
   val out = Decoupled(gen)
   val chosen = Output(UInt(log2Ceil(n).W))
+  override def cloneType: this.type = new ArbiterIO(gen, n).asInstanceOf[this.type]
 }
 
 /** Arbiter Control determining which producer has access

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -18,8 +18,7 @@ import chisel3.internal.naming._  // can't use chisel3_ version because of compi
   * @param gen the type of data to be wrapped in Ready/Valid
   */
 abstract class ReadyValidIO[+T <: Data](private val gen: T) extends Bundle
-{ // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
-  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+{ // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   // Compatibility hack for rocket-chip
   private val genType = (DataMirror.internal.isSynthesizable(gen), chisel3.internal.Builder.currentModule) match {
@@ -150,8 +149,7 @@ object DeqIO {
   * @param entries The max number of entries in the queue.
   */
 class QueueIO[T <: Data](private val gen: T, val entries: Int) extends Bundle
-{ // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
-  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+{ // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   /* These may look inverted, because the names (enq/deq) are from the perspective of the client,
    *  but internally, the queue implementation itself sits on the other side

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -17,9 +17,8 @@ import chisel3.internal.naming._  // can't use chisel3_ version because of compi
   * The actual semantics of ready/valid are enforced via the use of concrete subclasses.
   * @param gen the type of data to be wrapped in Ready/Valid
   */
-abstract class ReadyValidIO[+T <: Data](private val gen: T) extends Bundle
-{ // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
-
+abstract class ReadyValidIO[+T <: Data](gen: T) extends Bundle
+{
   // Compatibility hack for rocket-chip
   private val genType = (DataMirror.internal.isSynthesizable(gen), chisel3.internal.Builder.currentModule) match {
     case (true, Some(module: chisel3.core.ImplicitModule))
@@ -80,6 +79,7 @@ object ReadyValidIO {
   */
 class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
 {
+  override def cloneType: this.type = new DecoupledIO(gen).asInstanceOf[this.type]
 }
 
 /** This factory adds a decoupled handshaking protocol to a data bundle. */
@@ -110,6 +110,9 @@ object Decoupled
   * @param gen the type of data to be wrapped in IrrevocableIO
   */
 class IrrevocableIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
+{
+  override def cloneType: this.type = new IrrevocableIO(gen).asInstanceOf[this.type]
+}
 
 /** Factory adds an irrevocable handshaking protocol to a data bundle. */
 object Irrevocable

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -11,12 +11,12 @@ import chisel3.experimental.DataMirror
 import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 
 /** An Bundle containing data and a signal determining if it is valid */
-class Valid[+T <: Data](private val gen: T) extends Bundle
-{ // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
-
+class Valid[+T <: Data](gen: T) extends Bundle
+{
   val valid = Output(Bool())
   val bits  = Output(gen)
   def fire(dummy: Int = 0): Bool = valid
+  override def cloneType: this.type = Valid(gen).asInstanceOf[this.type]
 }
 
 /** Adds a valid protocol to any interface */

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -12,8 +12,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
 
 /** An Bundle containing data and a signal determining if it is valid */
 class Valid[+T <: Data](private val gen: T) extends Bundle
-{ // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
-  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+{ // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   val valid = Output(Bool())
   val bits  = Output(gen)

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -11,12 +11,13 @@ import chisel3.experimental.DataMirror
 import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 
 /** An Bundle containing data and a signal determining if it is valid */
-class Valid[+T <: Data](gen: T) extends Bundle
-{
+class Valid[+T <: Data](private val gen: T) extends Bundle
+{ // gen is a val to allow autoclonetype to work, but private to not be detected as a Bundle field.
+  // No, it's not the most intuitive or clean API. We'll revisit it for 3.1.1 or 3.2.
+
   val valid = Output(Bool())
   val bits  = Output(gen)
   def fire(dummy: Int = 0): Bool = valid
-  override def cloneType: this.type = Valid(gen).asInstanceOf[this.type]
 }
 
 /** Adds a valid protocol to any interface */

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -47,6 +47,10 @@ class ModuleWithInner extends Module {
   require(myWire.i == 14)
 }
 
+// A Bundle with an argument that is also a field.
+// Not necessarily good style (and not necessarily recommended), but allowed to preserve compatibility.
+class BundleWithArgumentField(val x: Data, val y: Data) extends Bundle {
+}
 
 class AutoClonetypeSpec extends ChiselFlatSpec {
   "Bundles with Scala args" should "not need clonetype" in {
@@ -111,5 +115,13 @@ class AutoClonetypeSpec extends ChiselFlatSpec {
 
   "Inner bundles with Scala args" should "not need clonetype" in {
     elaborate { new ModuleWithInner }
+  }
+
+  "Bundles with arguments as fields" should "not need clonetype" in {
+    elaborate { new Module {
+      val io = IO(Output(new BundleWithArgumentField(UInt(8.W), UInt(8.W))))
+      io.x := 1.U
+      io.y := 1.U
+    } }
   }
 }

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -49,8 +49,7 @@ class ModuleWithInner extends Module {
 
 // A Bundle with an argument that is also a field.
 // Not necessarily good style (and not necessarily recommended), but allowed to preserve compatibility.
-class BundleWithArgumentField(val x: Data, val y: Data) extends Bundle {
-}
+class BundleWithArgumentField(val x: Data, val y: Data) extends Bundle
 
 class AutoClonetypeSpec extends ChiselFlatSpec {
   "Bundles with Scala args" should "not need clonetype" in {


### PR DESCRIPTION
* **Related issue** (if applicable)
Short-term (until 3.1.1/3.2) patch for #765 to work better with autoclonetype

This does not attempt to give an informative error message for `MixedDirectionAggregateException `, because the exception will not be raised in all cases (for example, if the Bundle contents were not directioned), it will require significant heuristic code to catch what seems to be a very uncommon edge case, sufficient debugging information is already printed, and an API addition for 3.1.1/3.2 should remove ambiguity.

Also makes ArbiterIO cloneable through a cloneType implementation.

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [X] Other enhancement

* **Impact**
  - [ ] no functional change
  - [X] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [X] implementation

* **Release Notes**
Autoclonetype will work with Bundle that have fields defined in their constructors.
I personally don't think that's good style. as it raises the learning curve needed, but apparently it has users.
See #765 for proposals for 3.1.1/3.2, where we may add an explicit (but optional) Field(...) construct to Bundle.