### PR TITLE
Better support for autoclonetype of nested Bundles

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -588,7 +588,7 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
             _outerInst = Some(outer)
             outer
           } catch {
-            case _: NoSuchFieldException =>
+            case (_: NoSuchFieldException | _: IllegalAccessException) =>
               // Fallback using guesses based on common patterns
               val allOuterCandidates = Seq(
                   _containingModule.toSeq,

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -552,10 +552,15 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
     case _ => None
   }
 
-  // If this Data is an instance of an inner class, record a *guess* at the outer object.
-  // This is only used for cloneType, and is mutable to allow autoCloneType to try guesses other
-  // than the module that was current when the Bundle was constructed.
-  private var _outerInst: Option[Object] = Builder.currentModule
+  // Memoize the outer instance for autoclonetype, especially where this is context-dependent
+  // (like the outer module or enclosing Bundles).
+  private var _outerInst: Option[Object] = None
+
+  // For autoclonetype, record possible candidates for outer instance.
+  // _outerInst should always take precedence, since it should be propagated from the original
+  // object which has the most accurate context.
+  private val _containingModule: Option[BaseModule] = Builder.currentModule
+  private val _containingBundles: Seq[Bundle] = Builder.updateBundleStack(this)
 
   override def cloneType : this.type = {
     // This attempts to infer constructor and arguments to clone this Bundle subtype without
@@ -570,23 +575,33 @@ class Bundle(implicit compileOptions: CompileOptions) extends Record {
 
     // Check if this is an inner class, and if so, try to get the outer instance
     val clazz = this.getClass
+
     val outerClassInstance = Option(clazz.getEnclosingClass).map { outerClass =>
       def canAssignOuterClass(x: Object) = outerClass.isAssignableFrom(x.getClass)
-      val outerInstance = try {
-        clazz.getDeclaredField("$outer").get(this)  // doesn't work in all cases, namely anonymous inner Bundles
-      } catch {
-        case _: NoSuchFieldException =>
-          // First check if this Bundle is bound and an anonymous inner Bundle of another Bundle
-          this.bindingOpt.collect { case ChildBinding(p) if canAssignOuterClass(p) => p }
-              .orElse(this._outerInst)
-              .getOrElse(reflectError(s"Unable to determine instance of outer class $outerClass"))
+
+      val outerInstance = _outerInst match {
+        case Some(outerInstance) => outerInstance  // use _outerInst if defined
+        case None =>  // determine outer instance if not already recorded
+          val reflectOuter = try {
+            Some(clazz.getDeclaredField("$outer").get(this))  // doesn't work in all cases, namely anonymous inner Bundles
+          } catch {
+            case _: NoSuchFieldException => None
+          }
+          val allOuterCandidates = Seq(
+              reflectOuter.toSeq,
+              _containingModule.toSeq,
+              _containingBundles
+            ).flatten
+          allOuterCandidates.filter(canAssignOuterClass(_)) match {
+            case outer :: Nil =>
+              _outerInst = Some(outer)  // record the guess for future use
+              outer
+            case Nil => reflectError(s"Unable to determine instance of outer class $outerClass," +
+                s" no candidates assignable to outer class types; examined $allOuterCandidates")
+            case candidates => reflectError(s"Unable to determine instance of outer class $outerClass," +
+                s" multiple possible candidates $candidates assignable to outer class type")
+          }
       }
-      if (!canAssignOuterClass(outerInstance)) {
-        reflectError(s"Unable to determine instance of outer class $outerClass," +
-            s" guessed $outerInstance, but is not assignable to outer class $outerClass")
-      }
-      // Record the outer instance for future cloning
-      this._outerInst = Some(outerInstance)
       (outerClass, outerInstance)
     }
 

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -241,6 +241,9 @@ private[chisel3] object Builder {
       dynamicContext.bundleStack.remove(dynamicContext.bundleStack.size - 1)
     }
 
+    // Return the stack state before adding the most recent bundle
+    val lastStack = dynamicContext.bundleStack.map(_._1).toSeq
+
     // Append the current Bundle to the stack, if it's on the stack trace
     val eltClassName = elt.getClass.getName
     val eltStackPos = stackClasses.lastIndexOf(eltClassName)
@@ -249,7 +252,7 @@ private[chisel3] object Builder {
     }
     // Otherwise discard the stack frame, this shouldn't fail noisily
 
-    dynamicContext.bundleStack.map(_._1).toSeq
+    lastStack
   }
 
   def errors: ErrorLog = dynamicContext.errors

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -235,11 +235,10 @@ private[chisel3] object Builder {
         .reverse  // so stack frame numbers are deterministic across calls
 
     // Prune the existing Bundle stack of closed Bundles
-    while (!dynamicContext.bundleStack.isEmpty &&
-        (dynamicContext.bundleStack.last._3 >= stackClasses.size ||
-            (stackClasses(dynamicContext.bundleStack.last._3) != dynamicContext.bundleStack.last._2))) {
-      dynamicContext.bundleStack.remove(dynamicContext.bundleStack.size - 1)
+    val pruneLength = dynamicContext.bundleStack.reverse.prefixLength { case (_, cname, pos) =>
+      pos >= stackClasses.size || stackClasses(pos) != cname
     }
+    dynamicContext.bundleStack.trimEnd(pruneLength)
 
     // Return the stack state before adding the most recent bundle
     val lastStack = dynamicContext.bundleStack.map(_._1).toSeq

--- a/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
+++ b/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
@@ -89,6 +89,19 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers {
     }
   }
 
+  it should "clone a double-nested anonymous Bundle" in {
+    elaborate {
+      class TestModule() extends Module {
+        val io = IO(new Bundle {
+          val inner = Input(new Bundle {
+            val x = UInt(8.W)
+          })
+        })
+      }
+      new TestModule()
+    }
+  }
+
   behavior of "anonymous doubly-nested inner bundle fails with clear error"
   ( the[ChiselException] thrownBy {
     elaborate {
@@ -104,5 +117,4 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers {
       new Outer(2)
     }
   }).getMessage should include("Unable to determine instance")
-
 }


### PR DESCRIPTION
Use a Bundle Stack in Builder to keep track of currently open bundles, and use those as autoclonetype candidates.
On each Bundle's construction, it appends itself onto the stack.
Before each element is added to the stack, previous elements are pruned if their classes are no longer on the stack trace.
This allows Bundles guesses at enclosing Bundles for autoclonetype.

The previous proposal for traversing Bundle elements and marking them with parents doesn't work, because if you have code like
```scala
        val io = IO(new Bundle {
          val inner = Input(new Bundle {
            val x = UInt(8.W)
          })
        })
```
the `Input(new Bundle{...})` is called (and attempts to bind the inner) before the outer finishes construction and before the outer `IO(...)` is called. So a solution to that problem requires that references to outers are recorded before those outers finish construction. A Bundle stack does that, and using the system stack trace is the only way I could think of to prune closed Bundles (Chisel doesn't do anything when Bundles finish construction).

* **Related issue** (if applicable)

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [X] Other enhancement

* **Impact**
  - [x] no functional change (since 3.0)
  - [ ] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [X] implementation

* **Release Notes**
