### PR TITLE
Make Bundle abstract

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -508,7 +508,7 @@ class AutoClonetypeException(message: String) extends ChiselException(message, n
   *   }
   * }}}
   */
-class Bundle(implicit compileOptions: CompileOptions) extends Record {
+abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
   override def className = "Bundle"
 
   /** The collection of [[Data]]

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -69,7 +69,7 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
   it should "successfully compile a complete module" in {
     class Dummy extends Module {
       // The following just checks that we can create objects with nothing more than the Chisel compatibility package.
-      val io = new Bundle
+      val io = new Bundle {}
       val data = UInt(width = 3)
       new ArbiterIO(data, 2) shouldBe a [ArbiterIO[_]]
       new LockingRRArbiter(data, 2, 2, None) shouldBe a [LockingRRArbiter[_]]

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -92,7 +92,7 @@ class BadBoolConversion extends Module {
 }
 
 class NegativeShift(t: => Bits) extends Module {
-  val io = IO(new Bundle)
+  val io = IO(new Bundle {})
   Reg(t) >> -1
 }
 


### PR DESCRIPTION
I'm not sure why it wasn't abstract.

The basic motivation is that autoclonetype doesn't work on instances of Bundle because it can't figure out what to do about the CompileOptions. It **does** however, work on `new Bundle {}` because it's an anonymous subclass with no constructor arguments. I'm really not sure why the UIntOps test didn't fail in https://github.com/freechipsproject/chisel3/pull/754. We could of course special case this and make it work, but I'm honestly not sure why Bundle isn't abstract?

* **Type of change**
  - [ ] Bug report
  - [ ] Feature request
  - [x] Other enhancement

* **Impact**
  - [ ] no functional change
  - [ ] API addition (no impact on existing code)
  - [x] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Make Bundle abstract