### PR TITLE
Revert "Aggregate coverage - discover a working combination of aggreg…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,16 +136,6 @@ lazy val chisel = (project in file(".")).
   // Prevent separate JARs from being generated for coreMacros and chiselFrontend.
   dependsOn(coreMacros % "compile-internal;test-internal").
   dependsOn(chiselFrontend % "compile-internal;test-internal").
-  // Disable aggregation in general, but enable it for specific tasks.
-  // Otherwise we get separate Jar files for each subproject and we
-  //  go to great pains to package all chisel3 core code in a single Jar.
-  // If you get errors indicating coverageReport is undefined, be sure
-  //  you have sbt-scoverage in project/plugins.sbt
-  aggregate(coreMacros, chiselFrontend).
-  settings(
-    aggregate := false,
-    aggregate in coverageReport := true
-  ).
   settings(
     scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
     scalacOptions in Compile in doc ++= Seq(
@@ -155,6 +145,13 @@ lazy val chisel = (project in file(".")).
       "-doc-title", name.value,
       "-doc-root-content", baseDirectory.value+"/root-doc.txt"
     ),
+    // Disable aggregation in general, but enable it for specific tasks.
+    // Otherwise we get separate Jar files for each subproject and we
+    //  go to great pains to package all chisel3 core code in a single Jar.
+    // If you get errors indicating coverageReport is undefined, be sure
+    //  you have sbt-scoverage in project/plugins.sbt
+    aggregate := false,
+    aggregate in coverageReport := true,
     // Include macro classes, resources, and sources main JAR.
     mappings in (Compile, packageBin) ++= (mappings in (coreMacros, Compile, packageBin)).value,
     mappings in (Compile, packageSrc) ++= (mappings in (coreMacros, Compile, packageSrc)).value,


### PR DESCRIPTION
…ate usage to enable coverage of subprojects. (#782)"

This is still broken - it publishes multiple jars.
This reverts commit e08da9127b3465f158145f97ef16eb9fc8d0b5a7.

**Related issue** (if applicable)
 #772 

**Type of change*:  bug report

**Impact**: no functional change

**Development Phase**: implementation
