### PR TITLE
Add companion objects to macro classes

### DIFF
--- a/coreMacros/src/main/scala/chisel3/internal/RangeTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/RangeTransform.scala
@@ -9,6 +9,7 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import scala.reflect.macros.whitebox
 
+object RangeTransform
 class RangeTransform(val c: Context) {
   import c.universe._
   def apply(args: c.Tree*): c.Tree = {

--- a/coreMacros/src/main/scala/chisel3/internal/RangeTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/RangeTransform.scala
@@ -9,6 +9,7 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import scala.reflect.macros.whitebox
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object RangeTransform
 class RangeTransform(val c: Context) {
   import c.universe._

--- a/coreMacros/src/main/scala/chisel3/internal/RuntimeDeprecationTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/RuntimeDeprecationTransform.scala
@@ -7,6 +7,7 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.annotation.compileTimeOnly
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object RuntimeDeprecatedTransform
 class RuntimeDeprecatedTransform(val c: Context) {
   import c.universe._

--- a/coreMacros/src/main/scala/chisel3/internal/RuntimeDeprecationTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/RuntimeDeprecationTransform.scala
@@ -7,7 +7,7 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.annotation.compileTimeOnly
 
-
+object RuntimeDeprecatedTransform
 class RuntimeDeprecatedTransform(val c: Context) {
   import c.universe._
 

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
@@ -17,6 +17,7 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.annotation.compileTimeOnly
 
+object DebugTransforms
 class DebugTransforms(val c: Context) {
   import c.universe._
 
@@ -45,6 +46,7 @@ class DebugTransforms(val c: Context) {
   }
 }
 
+object NamingTransforms
 class NamingTransforms(val c: Context) {
   import c.universe._
   import Flag._

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
@@ -17,6 +17,7 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.annotation.compileTimeOnly
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object DebugTransforms
 class DebugTransforms(val c: Context) {
   import c.universe._
@@ -46,6 +47,7 @@ class DebugTransforms(val c: Context) {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object NamingTransforms
 class NamingTransforms(val c: Context) {
   import c.universe._

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -27,6 +27,7 @@ trait SourceInfoTransformMacro {
   def implicitCompileOptions = q"implicitly[_root_.chisel3.core.CompileOptions]"
 }
 
+object UIntTransform
 class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def bitset(off: c.Tree, dat: c.Tree): c.Tree = {
@@ -35,6 +36,7 @@ class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
 }
 
 // Module instantiation transform
+object InstTransform
 class InstTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](bc: c.Tree): c.Tree = {
@@ -42,6 +44,7 @@ class InstTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+object MemTransform
 class MemTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](size: c.Tree, t: c.Tree): c.Tree = {
@@ -49,6 +52,7 @@ class MemTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+object MuxTransform
 class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](cond: c.Tree, con: c.Tree, alt: c.Tree): c.Tree = {
@@ -57,6 +61,7 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+object VecTransform
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply_elts(elts: c.Tree): c.Tree = {
@@ -93,6 +98,7 @@ abstract class AutoSourceTransform extends SourceInfoTransformMacro {
   }
 }
 
+object SourceInfoTransform
 class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   import c.universe._
 
@@ -129,6 +135,7 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   }
 }
 
+object CompileOptionsTransform
 class CompileOptionsTransform(val c: Context) extends AutoSourceTransform {
   import c.universe._
 
@@ -145,8 +152,9 @@ class CompileOptionsTransform(val c: Context) extends AutoSourceTransform {
   }
 }
 
-/** Special whitebox version of the blackbox SourceInfoTransform, used when fun things need to happen to satisfy the
-  * type system while preventing the use of macro overrides.
+object SourceInfoWhiteboxTransform
+/** Special whitebox version of the blackbox SourceInfoTransform, used when fun things need to
+  * happen to satisfy the type system while preventing the use of macro overrides.
   */
 class SourceInfoWhiteboxTransform(val c: whitebox.Context) extends AutoSourceTransform {
   import c.universe._

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -27,6 +27,7 @@ trait SourceInfoTransformMacro {
   def implicitCompileOptions = q"implicitly[_root_.chisel3.core.CompileOptions]"
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object UIntTransform
 class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
@@ -35,8 +36,9 @@ class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
-// Module instantiation transform
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object InstTransform
+// Module instantiation transform
 class InstTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](bc: c.Tree): c.Tree = {
@@ -44,6 +46,7 @@ class InstTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object MemTransform
 class MemTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
@@ -52,6 +55,7 @@ class MemTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object MuxTransform
 class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
@@ -61,6 +65,7 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object VecTransform
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
@@ -98,6 +103,7 @@ abstract class AutoSourceTransform extends SourceInfoTransformMacro {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object SourceInfoTransform
 class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   import c.universe._
@@ -135,6 +141,7 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object CompileOptionsTransform
 class CompileOptionsTransform(val c: Context) extends AutoSourceTransform {
   import c.universe._
@@ -152,6 +159,7 @@ class CompileOptionsTransform(val c: Context) extends AutoSourceTransform {
   }
 }
 
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object SourceInfoWhiteboxTransform
 /** Special whitebox version of the blackbox SourceInfoTransform, used when fun things need to
   * happen to satisfy the type system while preventing the use of macro overrides.


### PR DESCRIPTION
Workaround for unconditional invalidation of macro classes in
incremental recompilation

* **Related issue** 

It's unclear if this is a bug in sbt incremental recompilation or an issue with our use of macros. In either case, this fixes unconditional recompilation of all scala files for projects that use chisel3 in multiproject builds (eg. rocket-chip).

sbt issue describing the problem this is working around: https://github.com/sbt/sbt/issues/3966

* **Type of change**
  - [x] Bug(?) fix/workaround
  - [ ] Feature request
  - [ ] Other enhancement

* **Impact**
  - [x] no functional change
  - [ ] API addition (no impact on existing code)
  - [ ] API modification

* **Development Phase**
  - [ ] proposal
  - [x] implementation

* **Release Notes**

Workaround for unconditional invalidation of macro classes in incremental recompilation
