### PR TITLE
Stricter updateBundleStack

### DIFF
--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -56,6 +56,12 @@ object CompanionObjectWithBundle {
   }
 }
 
+class NestedAnonymousBundle extends Bundle {
+  val a = Output(new Bundle {
+    val a = UInt(8.W)
+  })
+}
+
 // A Bundle with an argument that is also a field.
 // Not necessarily good style (and not necessarily recommended), but allowed to preserve compatibility.
 class BundleWithArgumentField(val x: Data, val y: Data) extends Bundle
@@ -146,4 +152,13 @@ class AutoClonetypeSpec extends ChiselFlatSpec {
       io.data := 1.U
     } }
   }
+
+  "Nested directioned anonymous Bundles" should "not need clonetype" in {
+    elaborate { new Module {
+      val io = IO(new NestedAnonymousBundle)
+      val a = WireInit(io)
+      io.a.a := 1.U
+    } }
+  }
+
 }


### PR DESCRIPTION
Makes Builder.updateBundleStack a bit stricter in deciding how many stack frames to discard by additionally matching against method names and deleting stack frames at or above the frame currently being inserted.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #792 

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
