### PR TITLE
Add treadle as an additional backend to new testers2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,9 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 }
 
 val defaultVersions = Map(
-  "firrtl" -> "1.1-SNAPSHOT",
-  "firrtl-interpreter" -> "1.2-SNAPSHOT"
+  "firrtl" -> "1.2-SNAPSHOT",
+  "firrtl-interpreter" -> "1.2-SNAPSHOT",
+  "treadle" -> "1.1-SNAPSHOT"
 )
 
 lazy val commonSettings = Seq (

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -2,7 +2,8 @@
 
 package chisel3
 
-import firrtl.{ExecutionOptionsManager, ComposableOptions}
+import chisel3.tester.{ScalaSimulator, TreadleSimulator}
+import firrtl.{ComposableOptions, ExecutionOptionsManager}
 
 //TODO: provide support for running firrtl as separate process, could alternatively be controlled by external driver
 //TODO: provide option for not saving chirrtl file, instead calling firrtl with in memory chirrtl
@@ -13,9 +14,10 @@ import firrtl.{ExecutionOptionsManager, ComposableOptions}
   * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
   */
 case class ChiselExecutionOptions(
-                                   runFirrtlCompiler: Boolean = true
-                                   // var runFirrtlAsProcess: Boolean = false
-                                 ) extends ComposableOptions
+  runFirrtlCompiler : Boolean = true,
+  scalaSimulator    : ScalaSimulator = TreadleSimulator
+  // var runFirrtlAsProcess: Boolean = false
+) extends ComposableOptions
 
 trait HasChiselExecutionOptions {
   self: ExecutionOptionsManager =>
@@ -30,5 +32,12 @@ trait HasChiselExecutionOptions {
       chiselOptions = chiselOptions.copy(runFirrtlCompiler = false)
     }
     .text("Stop after chisel emits chirrtl file")
+
+  parser.opt[String]("scala-backend")
+    .abbr("chsb")
+    .foreach { x =>
+      chiselOptions = chiselOptions.copy(scalaSimulator = ScalaSimulator(x))
+    }
+    .text(s"Choose scala simulation engine, either interpreter or interpreter")
 }
 

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -14,9 +14,8 @@ import firrtl.{ComposableOptions, ExecutionOptionsManager}
   * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
   */
 case class ChiselExecutionOptions(
-  runFirrtlCompiler : Boolean = true,
+  runFirrtlCompiler : Boolean        = true,
   scalaSimulator    : ScalaSimulator = TreadleSimulator
-  // var runFirrtlAsProcess: Boolean = false
 ) extends ComposableOptions
 
 trait HasChiselExecutionOptions {
@@ -32,12 +31,5 @@ trait HasChiselExecutionOptions {
       chiselOptions = chiselOptions.copy(runFirrtlCompiler = false)
     }
     .text("Stop after chisel emits chirrtl file")
-
-  parser.opt[String]("scala-backend")
-    .abbr("chsb")
-    .foreach { x =>
-      chiselOptions = chiselOptions.copy(scalaSimulator = ScalaSimulator(x))
-    }
-    .text(s"Choose scala simulation engine, either interpreter or interpreter")
 }
 

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -91,14 +91,7 @@ trait TestEnvInterface {
   def checkpoint()
 }
 
-trait ScalaSimulator
-
-object ScalaSimulator {
-  def apply(name: String): ScalaSimulator = name match {
-    case "interpreter" => FirrtlInterpreterSimulator
-    case "treadle"     => TreadleSimulator
-  }
-}
+sealed trait ScalaSimulator
 
 object FirrtlInterpreterSimulator extends ScalaSimulator
 object TreadleSimulator extends ScalaSimulator

--- a/src/main/scala/chisel3/tester/BackendInterface.scala
+++ b/src/main/scala/chisel3/tester/BackendInterface.scala
@@ -90,3 +90,15 @@ trait TestEnvInterface {
     */
   def checkpoint()
 }
+
+trait ScalaSimulator
+
+object ScalaSimulator {
+  def apply(name: String): ScalaSimulator = name match {
+    case "interpreter" => FirrtlInterpreterSimulator
+    case "treadle"     => TreadleSimulator
+  }
+}
+
+object FirrtlInterpreterSimulator extends ScalaSimulator
+object TreadleSimulator extends ScalaSimulator

--- a/src/main/scala/chisel3/tester/Testers2.scala
+++ b/src/main/scala/chisel3/tester/Testers2.scala
@@ -21,12 +21,20 @@ object Context {
 
   // TODO: better integration points for default tester selection
   def createDefaultTester[T <: Module](dutGen: => T): BackendInstance[T] = {
-    Firrterpreter.start(dutGen)
+//    Firrterpreter.start(dutGen)
+    TreadleExecutive.start(dutGen)
   }
 
   // TODO: add TesterOptions (from chisel-testers) and use that to control default tester selection.
-  def createDefaultTester[T <: Module](dutGen: => T, options: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions with HasInterpreterSuite): BackendInstance[T] = {
-    Firrterpreter.start(dutGen, Some(options))
+  def createDefaultTester[T <: Module](
+    dutGen: => T,
+    options: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions with HasInterpreterSuite
+  ): BackendInstance[T] = {
+
+    options.chiselOptions.scalaSimulator match {
+      case FirrtlInterpreterSimulator => Firrterpreter.start(dutGen, Some(options))
+      case TreadleSimulator           => TreadleExecutive.start(dutGen)
+    }
   }
 
   def apply(): Instance = context.value.get

--- a/src/main/scala/chisel3/tester/Testers2.scala
+++ b/src/main/scala/chisel3/tester/Testers2.scala
@@ -21,7 +21,6 @@ object Context {
 
   // TODO: better integration points for default tester selection
   def createDefaultTester[T <: Module](dutGen: => T): BackendInstance[T] = {
-//    Firrterpreter.start(dutGen)
     TreadleExecutive.start(dutGen)
   }
 

--- a/src/main/scala/chisel3/tester/TreadleBackend.scala
+++ b/src/main/scala/chisel3/tester/TreadleBackend.scala
@@ -1,0 +1,212 @@
+// See LICENSE for license details.
+
+package chisel3.tester
+
+import chisel3._
+import java.util.concurrent.{Semaphore, SynchronousQueue, TimeUnit}
+
+import scala.collection.mutable
+import firrtl_interpreter._
+import treadle.{HasTreadleSuite, TreadleTester}
+
+class TreadleBackend[T <: Module](dut: T, tester: TreadleTester)
+    extends BackendInstance[T] with ThreadedBackend {
+  def getModule() = dut
+
+  /** Returns a Seq of (data reference, fully qualified element names) for the input.
+    * name is the name of data
+    */
+  protected def getDataNames(name: String, data: Data): Seq[(Data, String)] = Seq(data -> name) ++ (data match {
+    case e: Element => Seq()
+    case b: Record => b.elements.toSeq flatMap {case (n, e) => getDataNames(s"${name}_$n", e)}
+    case v: Vec[_] => v.zipWithIndex flatMap {case (e, i) => getDataNames(s"${name}_$i", e)}
+  })
+
+  // TODO: the naming facility should be part of infrastructure not backend
+  protected val portNames = (getDataNames("io", dut.io) ++ getDataNames("reset", dut.reset)).toMap
+  protected def resolveName(signal: Data) =
+    portNames.getOrElse(signal, signal.toString())
+
+  protected val threadingChecker = new ThreadingChecker()
+
+  override def pokeBits(signal: Bits, value: BigInt, priority: Int): Unit = {
+    if (threadingChecker.doPoke(signal, priority, new Throwable)) {
+      tester.poke(portNames(signal), value)
+    }
+  }
+
+  override def peekBits(signal: Bits, stale: Boolean): BigInt = {
+    require(!stale, "Stale peek not yet implemented")
+
+    threadingChecker.doPeek(signal, new Throwable)
+    tester.peek(portNames(signal))
+  }
+
+  override def expectBits(signal: Bits, value: BigInt, stale: Boolean): Unit = {
+    require(!stale, "Stale peek not yet implemented")
+
+    Context().env.testerExpect(value, peekBits(signal, stale), resolveName(signal), None)
+  }
+
+  protected val clockCounter = mutable.HashMap[Clock, Int]()
+  protected def getClockCycle(clk: Clock): Int = {
+    clockCounter.getOrElse(clk, 0)
+  }
+
+  protected val lastClockValue = mutable.HashMap[Clock, Boolean]()
+
+  protected def scheduler() {
+    var testDone: Boolean = false  // set at the end of the clock cycle that the main thread dies on
+
+    while (activeThreads.isEmpty && !testDone) {
+      threadingChecker.finishTimestep()
+      Context().env.checkpoint()
+      tester.step(1)
+      clockCounter.put(dut.clock, getClockCycle(dut.clock) + 1)
+
+      if (mainTesterThread.get.done) {
+        testDone = true
+      }
+
+      threadingChecker.newTimestep(dut.clock)
+
+      // Unblock threads waiting on main clock
+      activeThreads ++= blockedThreads.getOrElse(dut.clock, Seq())
+      blockedThreads.remove(dut.clock)
+
+      // Unblock threads waiting on dependent clocks
+      // TODO: purge unused clocks instead of still continuing to track them
+      val waitingClocks = blockedThreads.keySet ++ lastClockValue.keySet - dut.clock
+      for (waitingClock <- waitingClocks) {
+        val currentClockVal = tester.peek(portNames(waitingClock)).toInt match {
+          case 0 => false
+          case 1 => true
+        }
+        if (lastClockValue.getOrElseUpdate(waitingClock, currentClockVal) != currentClockVal) {
+          lastClockValue.put(waitingClock, currentClockVal)
+          if (currentClockVal == true) {
+            activeThreads ++= blockedThreads.getOrElse(waitingClock, Seq())
+            blockedThreads.remove(waitingClock)
+            threadingChecker.newTimestep(waitingClock)
+
+            clockCounter.put(waitingClock, getClockCycle(waitingClock) + 1)
+          }
+        }
+      }
+    }
+
+    if (!testDone) {  // if test isn't over, run next thread
+      val nextThread = activeThreads.head
+      currentThread = Some(nextThread)
+      activeThreads.trimStart(1)
+      nextThread.waiting.release()
+    } else {  // if test is done, return to the main scalatest thread
+      scalatestWaiting.release()
+    }
+
+  }
+
+  override def step(signal: Clock, cycles: Int): Unit = {
+    // TODO: clock-dependence
+    // TODO: maybe a fast condition for when threading is not in use?
+    for (_ <- 0 until cycles) {
+      val thisThread = currentThread.get
+      threadingChecker.finishThread(thisThread, signal)
+      // TODO this also needs to be called on thread death
+
+      blockedThreads.put(signal, blockedThreads.getOrElseUpdate(signal, Seq()) :+ thisThread)
+      scheduler()
+      thisThread.waiting.acquire()
+    }
+  }
+
+  protected var scalatestThread: Option[Thread] = None
+  protected var mainTesterThread: Option[TesterThread] = None
+  protected val scalatestWaiting = new Semaphore(0)
+  protected val interruptedException = new SynchronousQueue[Throwable]()
+
+  protected def onException(e: Throwable) {
+    scalatestThread.get.interrupt()
+    interruptedException.offer(e, 10, TimeUnit.SECONDS)
+  }
+
+  override def run(testFn: T => Unit): Unit = {
+    tester.poke("reset", 1)
+    tester.step(1)
+    tester.poke("reset", 0)
+
+    val mainThread = fork(
+      testFn(dut)
+    )
+
+    require(activeThreads.length == 1)  // only thread should be main
+    activeThreads.trimStart(1)
+    currentThread = Some(mainThread)
+    scalatestThread = Some(Thread.currentThread())
+    mainTesterThread = Some(mainThread)
+
+    mainThread.waiting.release()
+    try {
+      scalatestWaiting.acquire()
+    } catch {
+      case e: InterruptedException =>
+        throw interruptedException.poll(10, TimeUnit.SECONDS)
+    }
+
+    mainTesterThread = None
+    scalatestThread = None
+    currentThread = None
+
+    for (thread <- allThreads.clone()) {
+      // Kill the threads using an InterruptedException
+      if (thread.thread.isAlive) {
+        thread.thread.interrupt()
+      }
+    }
+  }
+}
+
+object TreadleExecutive {
+  import chisel3.internal.firrtl.Circuit
+  import chisel3.experimental.BaseModule
+
+  import firrtl._
+
+  def getTopModule(circuit: Circuit): BaseModule = {
+    (circuit.components find (_.name == circuit.name)).get.id
+  }
+
+  def start[T <: Module](
+    dutGen: => T,
+    options: Option[ExecutionOptionsManager
+            with HasChiselExecutionOptions
+            with HasFirrtlOptions
+            with HasInterpreterSuite
+            with HasTreadleSuite] = None): BackendInstance[T] = {
+    val optionsManager = options match  {
+      case Some(o: ExecutionOptionsManager) => o
+
+      case None =>
+        new ExecutionOptionsManager("chisel3")
+          with HasChiselExecutionOptions with HasFirrtlOptions with HasInterpreterSuite with HasTreadleSuite {
+          commonOptions = CommonOptions(targetDirName = "test_run_dir")
+        }
+    }
+    // the backend must be firrtl if we are here, therefore we want the firrtl compiler
+    optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
+
+    chisel3.Driver.execute(optionsManager, () => dutGen) match {
+      case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>
+        firrtlExecutionResult match {
+          case FirrtlExecutionSuccess(_, compiledFirrtl) =>
+            val dut = getTopModule(circuit).asInstanceOf[T]
+            val interpretiveTester = new TreadleTester(compiledFirrtl, optionsManager)
+            new TreadleBackend(dut, interpretiveTester)
+          case FirrtlExecutionFailure(message) =>
+            throw new Exception(s"FirrtlBackend: failed firrtl compile message: $message")
+        }
+      case _ =>
+        throw new Exception("Problem with compilation")
+    }
+  }
+}


### PR DESCRIPTION
**Enhancement**:
Add treadle backend intergration

**No functional change**: 
default backend is now treadle, can be optionally changed.
Functionality of backend should be the same

**Initial implementation**: proposal |  implementation

**Release Notes**
Treadle scala simulator is a faster more modern implementation of the firrtl-interpreter
