### PR TITLE
Fallback null insertion for autoclonetype

### DIFF
--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -161,4 +161,15 @@ class AutoClonetypeSpec extends ChiselFlatSpec {
     } }
   }
 
+  "3.0 null compatibility" should "not need clonetype" in {
+    elaborate { new Module {
+      class InnerClassThing {
+        def createBundle = new Bundle {
+          val a = Output(UInt(8.W))
+        }
+      }
+      val io = IO((new InnerClassThing).createBundle)
+      val a = WireInit(io)
+    } }
+  }
 }

--- a/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
+++ b/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
@@ -102,9 +102,9 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers {
     }
   }
 
-  behavior of "anonymous doubly-nested inner bundle fails with clear error"
-  ( the[ChiselException] thrownBy {
-    elaborate {
+  // Test ignored because the compatibility null-inserting autoclonetype doesn't trip this
+  ignore should "fail on anonymous doubly-nested inner bundle with clear error" in {
+    intercept[ChiselException] { elaborate {
       class Outer(val w: Int) extends Module {
         class Middle(val w: Int) {
           def getIO = new Bundle {
@@ -115,6 +115,6 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers {
         val myWire = Wire((new Middle(w)).getIO)
       }
       new Outer(2)
-    }
-  }).getMessage should include("Unable to determine instance")
+    }}.getMessage should include("Unable to determine instance")
+  }
 }


### PR DESCRIPTION
If autoclonetype is unable to determine an outer class, this attempts to insert a null (and give a deprecation warning), preserving old behavior (in some cases) where the new behavior doesn't work.

This doesn't provide full compatibility with old autoclonetype: this does not attempt null insertion in the general first argument (if it's not an outer class reference). Reasoning is that inserting a null for an explicit argument is probably not the right thing to do, and will likely cause a difficult-to-debug NullPointerException (whereas that would be unlikely for an outer class, which is not always referenced in Bundle subclass code).

@colinschmidt would this have prevented some of your autoclonetype errors when porting code?

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
