### PR TITLE
Annotations are Options, Immutable Option Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test_run_dir
 *~
 \#*\#
 .\#*
+utils

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val chiselSettings = Seq (
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "com.github.scopt" %% "scopt" % "3.6.0"
+    "com.github.scopt" %% "scopt" % "3.7.0"
   ),
 
   // Tests from other projects may still run concurrently.

--- a/build.sbt
+++ b/build.sbt
@@ -161,3 +161,7 @@ lazy val chisel = (project in file(".")).
     // published artifact) also see the stuff in coreMacros and chiselFrontend.
     exportJars := true
   )
+
+assemblyJarName in assembly := "chisel3.jar"
+test in assembly := {} // skip tests when building fat jar
+assemblyOutputPath in assembly := file("./utils/bin/chisel3.jar")

--- a/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
@@ -87,4 +87,3 @@ object dontTouch { // scalastyle:ignore object.name
     data
   }
 }
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -3,36 +3,63 @@
 package chisel3
 
 import firrtl.ExecutionOptionsManager
-import firrtl.annotations.NoTargetAnnotation
+import firrtl.annotations.{
+  Annotation,
+  NoTargetAnnotation }
 
-sealed trait ChiselOption
+/** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
+  * an option consummable by [[HasChiselExecutionOptions]]
+  *
+  * This must be mixed into a subclass of [[annotaiton.Annotation]]
+  */
+sealed trait ChiselOption { self: Annotation => }
+
+/** Disables FIRRTL compiler execution
+  *  - deasserts [[ChiselExecutionOptions.runFirrtlCompiler]]
+  *  - equivalent to command line option `-chnrf/--no-run-firrtl`
+  */
 case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption
+
+/** Disable saving CHIRRTL to an intermediate file
+  *  - deasserts [[ChiselExecutionOptions.saveChirrtl]]
+  *  - equivalent to command line option `--dont-save-chirrtl`
+  */
 case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption
+
+/** Disable saving CHIRRTL-time annotaitons to an intermediate file
+  *  - deasserts [[ChiselExecutionOptions.saveAnnotations]]
+  *  - equivalent to command line option `--dont-save-annotations`
+  */
 case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption
 
-//TODO: provide support for running firrtl as separate process, could alternatively be controlled by external driver
-/**
-  * Options that are specific to chisel.
+// TODO: provide support for running firrtl as separate process, could
+//       alternatively be controlled by external driver
+/** Options that control the execution of the Chisel compiler
   *
-  * @param runFirrtlCompiler when true just run chisel, when false run chisel then compile its output with firrtl
+  * @param runFirrtlCompiler run the FIRRTL compiler if true
+  * @param saveChirrtl save CHIRRTL output to a file if true
+  * @param saveAnnotations save CHIRRTL-time annotations to a file if true
   * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
   */
 case class ChiselExecutionOptions (
   runFirrtlCompiler: Boolean = true,
-  saveChirrtl: Boolean = true,
-  saveAnnotations: Boolean = true
+  saveChirrtl: Boolean       = true,
+  saveAnnotations: Boolean   = true
 )
 
 trait HasChiselExecutionOptions {
   self: ExecutionOptionsManager =>
 
+  /** A [[ChiselExecutionOptions]] object generated from processing all
+    * Chisel command line options
+    */
   lazy val chiselOptions: ChiselExecutionOptions = options
     .collect{ case opt: ChiselOption => opt }
-    .foldLeft(ChiselExecutionOptions())( (old, x) =>
+    .foldLeft(ChiselExecutionOptions())( (c, x) =>
       x match {
-        case NoRunFirrtlAnnotation => old.copy(runFirrtlCompiler = false)
-        case DontSaveChirrtlAnnotation => old.copy(saveChirrtl = false)
-        case DontSaveAnnotationsAnnotation => old.copy(saveAnnotations = false)
+        case NoRunFirrtlAnnotation         => c.copy(runFirrtlCompiler = false)
+        case DontSaveChirrtlAnnotation     => c.copy(saveChirrtl = false)
+        case DontSaveAnnotationsAnnotation => c.copy(saveAnnotations = false)
       } )
 
   parser.note("Chisel Options")

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -22,7 +22,7 @@ case class ChiselExecutionOptions (
 
 object ChiselViewer {
   implicit object ChiselOptionsView extends OptionsView[ChiselExecutionOptions] {
-    def view(implicit options: AnnotationSeq): Option[ChiselExecutionOptions] = Some(
+    def view(options: AnnotationSeq): Option[ChiselExecutionOptions] = Some(
       options
         .collect{ case opt: ChiselOption => opt }
         .foldLeft(ChiselExecutionOptions())( (c, x) =>
@@ -38,17 +38,10 @@ trait HasChiselExecutionOptions { this: ExecutionOptionsManager =>
   import firrtl.options.Viewer._
   import chisel3.ChiselViewer._
 
-  /** A [[ChiselExecutionOptions]] object generated from processing all
-    * Chisel command line options
-    */
-  @deprecated("Use view[ChiselExecutionOptions]", "3.2.0")
-  lazy val chiselOptions: ChiselExecutionOptions = view[ChiselExecutionOptions].getOrElse{
-    throw new Exception("Unable to parse Chisel command line options/annotations") }
-
   parser.note("Chisel Options")
 
   Seq( NoRunFirrtlAnnotation,
        DontSaveChirrtlAnnotation,
        DontSaveAnnotationsAnnotation )
-    .map(_.addOptions)
+    .map(_.addOptions(parser))
 }

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -2,33 +2,51 @@
 
 package chisel3
 
-import firrtl.{ExecutionOptionsManager, ComposableOptions}
+import firrtl.ExecutionOptionsManager
+import firrtl.annotations.NoTargetAnnotation
+
+sealed trait ChiselOption
+case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption
+case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption
+case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption
 
 //TODO: provide support for running firrtl as separate process, could alternatively be controlled by external driver
-//TODO: provide option for not saving chirrtl file, instead calling firrtl with in memory chirrtl
 /**
   * Options that are specific to chisel.
   *
   * @param runFirrtlCompiler when true just run chisel, when false run chisel then compile its output with firrtl
   * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
   */
-case class ChiselExecutionOptions(
-                                   runFirrtlCompiler: Boolean = true
-                                   // var runFirrtlAsProcess: Boolean = false
-                                 ) extends ComposableOptions
+case class ChiselExecutionOptions (
+  runFirrtlCompiler: Boolean = true,
+  saveChirrtl: Boolean = true,
+  saveAnnotations: Boolean = true
+)
 
 trait HasChiselExecutionOptions {
   self: ExecutionOptionsManager =>
 
-  var chiselOptions = ChiselExecutionOptions()
+  lazy val chiselOptions: ChiselExecutionOptions = options
+    .collect{ case opt: ChiselOption => opt }
+    .foldLeft(ChiselExecutionOptions())( (old, x) =>
+      x match {
+        case NoRunFirrtlAnnotation => old.copy(runFirrtlCompiler = false)
+        case DontSaveChirrtlAnnotation => old.copy(saveChirrtl = false)
+        case DontSaveAnnotationsAnnotation => old.copy(saveAnnotations = false)
+      } )
 
-  parser.note("chisel3 options")
+  parser.note("Chisel Options")
 
   parser.opt[Unit]("no-run-firrtl")
     .abbr("chnrf")
-    .foreach { _ =>
-      chiselOptions = chiselOptions.copy(runFirrtlCompiler = false)
-    }
+    .action( (x, c) => c :+ NoRunFirrtlAnnotation )
     .text("Stop after chisel emits chirrtl file")
-}
 
+  parser.opt[Unit]("dont-save-chirrtl")
+    .action( (x, c) => c :+ DontSaveChirrtlAnnotation )
+    .text("Do not save CHIRRTL output")
+
+  parser.opt[Unit]("dont-save-annotations")
+    .action( (x, c) => c :+ DontSaveAnnotationsAnnotation )
+    .text("Do not save Chisel Annotations")
+}

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -2,16 +2,9 @@
 
 package chisel3
 
-import firrtl.{
-  AnnotationSeq,
-  FirrtlViewer }
-import firrtl.options.{
-  ExecutionOptionsManager,
-  OptionsView,
-  Viewer }
-import firrtl.annotations.{
-  Annotation,
-  NoTargetAnnotation }
+import firrtl.{AnnotationSeq, FirrtlViewer}
+import firrtl.options.{ExecutionOptionsManager, OptionsView, Viewer}
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
 
 /** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
   * an option consummable by [[HasChiselExecutionOptions]]

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -2,34 +2,8 @@
 
 package chisel3
 
-import firrtl.{AnnotationSeq, FirrtlViewer}
+import firrtl.AnnotationSeq
 import firrtl.options.{ExecutionOptionsManager, OptionsView, Viewer}
-import firrtl.annotations.{Annotation, NoTargetAnnotation}
-
-/** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
-  * an option consummable by [[HasChiselExecutionOptions]]
-  *
-  * This must be mixed into a subclass of [[annotaiton.Annotation]]
-  */
-sealed trait ChiselOption { this: Annotation => }
-
-/** Disables FIRRTL compiler execution
-  *  - deasserts [[ChiselExecutionOptions.runFirrtlCompiler]]
-  *  - equivalent to command line option `-chnrf/--no-run-firrtl`
-  */
-case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption
-
-/** Disable saving CHIRRTL to an intermediate file
-  *  - deasserts [[ChiselExecutionOptions.saveChirrtl]]
-  *  - equivalent to command line option `--dont-save-chirrtl`
-  */
-case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption
-
-/** Disable saving CHIRRTL-time annotaitons to an intermediate file
-  *  - deasserts [[ChiselExecutionOptions.saveAnnotations]]
-  *  - equivalent to command line option `--dont-save-annotations`
-  */
-case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption
 
 // TODO: provide support for running firrtl as separate process, could
 //       alternatively be controlled by external driver
@@ -73,16 +47,8 @@ trait HasChiselExecutionOptions { this: ExecutionOptionsManager =>
 
   parser.note("Chisel Options")
 
-  parser.opt[Unit]("no-run-firrtl")
-    .abbr("chnrf")
-    .action( (x, c) => c :+ NoRunFirrtlAnnotation )
-    .text("Stop after chisel emits chirrtl file")
-
-  parser.opt[Unit]("dont-save-chirrtl")
-    .action( (x, c) => c :+ DontSaveChirrtlAnnotation )
-    .text("Do not save CHIRRTL output")
-
-  parser.opt[Unit]("dont-save-annotations")
-    .action( (x, c) => c :+ DontSaveAnnotationsAnnotation )
-    .text("Do not save Chisel Annotations")
+  Seq( NoRunFirrtlAnnotation,
+       DontSaveChirrtlAnnotation,
+       DontSaveAnnotationsAnnotation )
+    .map(_.addOptions)
 }

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -3,7 +3,11 @@
 package chisel3
 
 import firrtl.AnnotationSeq
+import firrtl.annotations.Annotation
 import firrtl.options.{ExecutionOptionsManager, OptionsView, Viewer}
+import chisel3.internal.firrtl.Circuit
+
+class ChiselOptionsException(msg: String) extends ChiselException(msg, null)
 
 // TODO: provide support for running firrtl as separate process, could
 //       alternatively be controlled by external driver
@@ -12,36 +16,59 @@ import firrtl.options.{ExecutionOptionsManager, OptionsView, Viewer}
   * @param runFirrtlCompiler run the FIRRTL compiler if true
   * @param saveChirrtl save CHIRRTL output to a file if true
   * @param saveAnnotations save CHIRRTL-time annotations to a file if true
-  * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
+  * @param chiselCircuit a Chisel circuit
   */
 case class ChiselExecutionOptions (
-  runFirrtlCompiler: Boolean = true,
-  saveChirrtl: Boolean       = true,
-  saveAnnotations: Boolean   = true
+  runFirrtlCompiler: Boolean     = true,
+  saveChirrtl: Boolean           = true,
+  saveAnnotations: Boolean       = true,
+  chiselCircuit: Option[Circuit] = None
 )
 
 object ChiselViewer {
   implicit object ChiselOptionsView extends OptionsView[ChiselExecutionOptions] {
-    def view(options: AnnotationSeq): Option[ChiselExecutionOptions] = Some(
-      options
-        .collect{ case opt: ChiselOption => opt }
-        .foldLeft(ChiselExecutionOptions())( (c, x) =>
-          x match {
-            case NoRunFirrtlAnnotation         => c.copy(runFirrtlCompiler = false)
-            case DontSaveChirrtlAnnotation     => c.copy(saveChirrtl = false)
-            case DontSaveAnnotationsAnnotation => c.copy(saveAnnotations = false)
-          } ) )
+    def checkAnnotations(annos: AnnotationSeq): AnnotationSeq = {
+      val c = collection.mutable.ListBuffer[Annotation]()
+      annos.foreach{
+        case a: ChiselCircuitAnnotation => c += a
+        case _                          =>
+      }
+      if (c.isEmpty) {
+        throw new ChiselOptionsException("No Chisel circuit specified via ChiselCircuitAnnotation or --dut") }
+      if (c.size > 1) {
+        throw new ChiselOptionsException(
+          "Only one Chisel circuit can be specified but found multiple ChiselCircuitAnnotation or --dut arguments") }
+      annos
+    }
+
+    def view(options: AnnotationSeq): Option[ChiselExecutionOptions] = {
+      val annotationTransforms = Seq(checkAnnotations(_))
+
+      val preprocessedAnnotations = annotationTransforms.foldLeft(options)( (old, tx) => tx(old) )
+
+      val (chiselAnnos, nonChiselAnnos) = preprocessedAnnotations.partition {
+        case opt: ChiselOption => true
+        case _                 => false }
+
+      val x = chiselAnnos
+        .foldLeft(ChiselExecutionOptions())(
+          (c, x) => x match {
+            case NoRunFirrtlAnnotation           => c.copy(runFirrtlCompiler = false)
+            case DontSaveChirrtlAnnotation       => c.copy(saveChirrtl       = false)
+            case DontSaveAnnotationsAnnotation   => c.copy(saveAnnotations   = false)
+            case a: ChiselCircuitAnnotation      => c.copy(chiselCircuit     = Some(a.circuit)) })
+      Some(x)
+    }
   }
 }
 
 trait HasChiselExecutionOptions { this: ExecutionOptionsManager =>
-  import firrtl.options.Viewer._
-  import chisel3.ChiselViewer._
-
   parser.note("Chisel Options")
 
+  // [todo] This could be handled with reflection via knownDirectSubclasses
   Seq( NoRunFirrtlAnnotation,
        DontSaveChirrtlAnnotation,
-       DontSaveAnnotationsAnnotation )
+       DontSaveAnnotationsAnnotation,
+       ChiselCircuitAnnotation() )
     .map(_.addOptions(parser))
 }

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -3,11 +3,12 @@
 package chisel3
 
 import firrtl.{
+  AnnotationSeq,
+  FirrtlViewer }
+import firrtl.options.{
   ExecutionOptionsManager,
   OptionsView,
-  AnnotationSeq,
-  Viewer,
-  FirrtlViewer }
+  Viewer }
 import firrtl.annotations.{
   Annotation,
   NoTargetAnnotation }
@@ -67,7 +68,7 @@ object ChiselViewer {
 }
 
 trait HasChiselExecutionOptions { this: ExecutionOptionsManager =>
-  import firrtl.Viewer._
+  import firrtl.options.Viewer._
   import chisel3.ChiselViewer._
 
   /** A [[ChiselExecutionOptions]] object generated from processing all

--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -11,7 +11,7 @@ import firrtl.annotations.{Annotation, NoTargetAnnotation}
   *
   * This must be mixed into a subclass of [[annotaiton.Annotation]]
   */
-sealed trait ChiselOption { self: Annotation => }
+sealed trait ChiselOption { this: Annotation => }
 
 /** Disables FIRRTL compiler execution
   *  - deasserts [[ChiselExecutionOptions.runFirrtlCompiler]]

--- a/src/main/scala/chisel3/ChiselOptions.scala
+++ b/src/main/scala/chisel3/ChiselOptions.scala
@@ -2,8 +2,8 @@
 
 package chisel3
 
-import firrtl.{AnnotationSeq, FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.annotations.{NoTargetAnnotation, SingleTargetAnnotation, CircuitName}
+import firrtl.{AnnotationSeq, FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation, Transform}
+import firrtl.annotations.{NoTargetAnnotation, SingleTargetAnnotation, CircuitName, Unserializable, DeletedAnnotation}
 import firrtl.options.HasScoptOptions
 import chisel3.experimental.{RawModule, RunFirrtlTransform}
 import chisel3.internal.firrtl.{Converter, Circuit}
@@ -52,13 +52,12 @@ case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with Chisel
 
 /** Holds a Chisel circuit
   *
-  * @param target a circuit name
-  * @param circuit the Chisel Circuit
+  * @param circuit a Chisel Circuit
   * @note this is not JSON serializable and will be unpacked into a
   * [[firrtl.FirrtlCircuitAnnotation]] and
   * [[firrtl.RunFirrtlTransformAnnotation]] by Chisel's Driver
   */
-case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption {
+case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption with Unserializable {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("dut")
     .action{ (x, c) => ChiselCircuitAnnotation(() => Class.forName(x).newInstance().asInstanceOf[RawModule]) +: c }
     .validate( x => try {
@@ -69,6 +68,25 @@ case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation 
                   throw new ChiselException(s"Class $x not found (did you misspell it?", null) })
     .unbounded()
     .text("Chisel design under test to load (must be of type <: RawModule)")
+
+  /** Convert this Chisel circuit to a FIRRTL circuit
+    * @return an [[AnnotationSeq]] containing a [[firrtl.FirrtlCircuitAnnotation]]
+    */
+  def convert: AnnotationSeq = {
+    val transforms = circuit.annotations
+      .collect { case anno: RunFirrtlTransform => anno.transformClass }
+      .distinct
+      .filterNot(_ == classOf[Transform])
+      .map{ RunFirrtlTransformAnnotation(_) }
+    Seq(DeletedAnnotation(this.getClass.getName, this)) ++
+      circuit.annotations.map(_.toFirrtl) ++ transforms :+ FirrtlCircuitAnnotation(Converter.convert(circuit))
+  }
+
+  /** Prepare this [[Annotation]] for JSON serialization
+    * @note this simply runs [[convert]]
+    * @return an [[AnnotationSeq]] without any [[firrtl.Unserializable]] annotations
+    */
+  def toJsonSerializable: AnnotationSeq = convert
 }
 
 object ChiselCircuitAnnotation {
@@ -79,4 +97,32 @@ object ChiselCircuitAnnotation {
   def apply(dut: () => RawModule): ChiselCircuitAnnotation = ChiselCircuitAnnotation(Driver.elaborate(dut))
 
   private [chisel3] def apply(): ChiselCircuitAnnotation = ChiselCircuitAnnotation(Circuit("null", Seq.empty))
+}
+
+/** Holds a function that, when elaborated, produces a [[Circuti]]
+  *
+  * @param dut a function that generates a [[RawModule]]
+  * @note This [[Annotation]] is [[Unserializable]]. It will be converted to a [[ChiselCircuitAnnotation]] if serialized
+  * to JSON.
+  */
+case class ChiselDutGeneratorAnnotation(dut: () => RawModule) extends NoTargetAnnotation with Unserializable {
+  /** Elaborate this dut into a Chisel circuit
+    * @return an [[AnnotationSeq]] containing an [[ChiselCircuitAnnotation]]
+    * @note This [[Annotation]] will be preserved as a [[DeletedAnnotation]]
+    */
+  def elaborate: AnnotationSeq = DeletedAnnotation(this.getClass.getName, this) +: Seq(ChiselCircuitAnnotation(dut))
+
+  /** Convert this dut to a FIRRTL circuit
+    * @return an [[AnnotationSeq]] containing a [[firrtl.FirrtlCircuitAnnotation]]
+    */
+  def convert: AnnotationSeq = elaborate.flatMap {
+    case a: ChiselCircuitAnnotation => a.convert
+    case a                          => Seq(a)
+  }
+
+  /** Prepare this [[Annotation]] for JSON serialization
+    * @note this simply runs [[convert]]
+    * @return an [[AnnotationSeq]] without any [[firrtl.Unserializable]] annotations
+    */
+  def toJsonSerializable: AnnotationSeq = convert
 }

--- a/src/main/scala/chisel3/ChiselOptions.scala
+++ b/src/main/scala/chisel3/ChiselOptions.scala
@@ -1,0 +1,45 @@
+// See LICENSE for license details.
+
+package chisel3
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.{NoTargetAnnotation, HasScoptOptions}
+import scopt.OptionParser
+
+/** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
+  * an option consummable by [[HasChiselExecutionOptions]]
+  *
+  * This must be mixed into a subclass of [[annotaiton.Annotation]]
+  */
+sealed trait ChiselOption extends HasScoptOptions
+
+/** Disables FIRRTL compiler execution
+  *  - deasserts [[ChiselExecutionOptions.runFirrtlCompiler]]
+  *  - equivalent to command line option `-chnrf/--no-run-firrtl`
+  */
+case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
+  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("no-run-firrtl")
+    .abbr("chnrf")
+    .action( (x, c) => c :+ NoRunFirrtlAnnotation )
+    .text("Stop after chisel emits chirrtl file")
+}
+
+/** Disable saving CHIRRTL to an intermediate file
+  *  - deasserts [[ChiselExecutionOptions.saveChirrtl]]
+  *  - equivalent to command line option `--dont-save-chirrtl`
+  */
+case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
+  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-chirrtl")
+    .action( (x, c) => c :+ DontSaveChirrtlAnnotation )
+    .text("Do not save CHIRRTL output")
+}
+
+/** Disable saving CHIRRTL-time annotaitons to an intermediate file
+  *  - deasserts [[ChiselExecutionOptions.saveAnnotations]]
+  *  - equivalent to command line option `--dont-save-annotations`
+  */
+case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption {
+  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-annotations")
+    .action( (x, c) => c :+ DontSaveAnnotationsAnnotation )
+    .text("Do not save Chisel Annotations")
+}

--- a/src/main/scala/chisel3/ChiselOptions.scala
+++ b/src/main/scala/chisel3/ChiselOptions.scala
@@ -3,7 +3,8 @@
 package chisel3
 
 import firrtl.AnnotationSeq
-import firrtl.annotations.{NoTargetAnnotation, HasScoptOptions}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.HasScoptOptions
 import scopt.OptionParser
 
 /** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
@@ -18,7 +19,7 @@ sealed trait ChiselOption extends HasScoptOptions
   *  - equivalent to command line option `-chnrf/--no-run-firrtl`
   */
 case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
-  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("no-run-firrtl")
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("no-run-firrtl")
     .abbr("chnrf")
     .action( (x, c) => c :+ NoRunFirrtlAnnotation )
     .text("Stop after chisel emits chirrtl file")
@@ -29,7 +30,7 @@ case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
   *  - equivalent to command line option `--dont-save-chirrtl`
   */
 case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
-  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-chirrtl")
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-chirrtl")
     .action( (x, c) => c :+ DontSaveChirrtlAnnotation )
     .text("Do not save CHIRRTL output")
 }
@@ -39,7 +40,7 @@ case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOpti
   *  - equivalent to command line option `--dont-save-annotations`
   */
 case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption {
-  def addOptions(implicit p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-annotations")
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-annotations")
     .action( (x, c) => c :+ DontSaveAnnotationsAnnotation )
     .text("Do not save Chisel Annotations")
 }

--- a/src/main/scala/chisel3/ChiselOptions.scala
+++ b/src/main/scala/chisel3/ChiselOptions.scala
@@ -2,9 +2,11 @@
 
 package chisel3
 
-import firrtl.AnnotationSeq
-import firrtl.annotations.NoTargetAnnotation
+import firrtl.{AnnotationSeq, FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
+import firrtl.annotations.{NoTargetAnnotation, SingleTargetAnnotation, CircuitName}
 import firrtl.options.HasScoptOptions
+import chisel3.experimental.{RawModule, RunFirrtlTransform}
+import chisel3.internal.firrtl.{Converter, Circuit}
 import scopt.OptionParser
 
 /** Indicates that a subclass is an [[firrtl.annotation.Annotation]] with
@@ -22,6 +24,7 @@ case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("no-run-firrtl")
     .abbr("chnrf")
     .action( (x, c) => c :+ NoRunFirrtlAnnotation )
+    .unbounded()
     .text("Stop after chisel emits chirrtl file")
 }
 
@@ -32,6 +35,7 @@ case object NoRunFirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
 case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOption {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-chirrtl")
     .action( (x, c) => c :+ DontSaveChirrtlAnnotation )
+    .unbounded()
     .text("Do not save CHIRRTL output")
 }
 
@@ -42,5 +46,37 @@ case object DontSaveChirrtlAnnotation extends NoTargetAnnotation with ChiselOpti
 case object DontSaveAnnotationsAnnotation extends NoTargetAnnotation with ChiselOption {
   def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[Unit]("dont-save-annotations")
     .action( (x, c) => c :+ DontSaveAnnotationsAnnotation )
+    .unbounded()
     .text("Do not save Chisel Annotations")
+}
+
+/** Holds a Chisel circuit
+  *
+  * @param target a circuit name
+  * @param circuit the Chisel Circuit
+  * @note this is not JSON serializable and will be unpacked into a
+  * [[firrtl.FirrtlCircuitAnnotation]] and
+  * [[firrtl.RunFirrtlTransformAnnotation]] by Chisel's Driver
+  */
+case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption {
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p.opt[String]("dut")
+    .action{ (x, c) => ChiselCircuitAnnotation(() => Class.forName(x).newInstance().asInstanceOf[RawModule]) +: c }
+    .validate( x => try {
+                Class.forName(x)
+                p.success
+              } catch {
+                case e: ClassNotFoundException =>
+                  throw new ChiselException(s"Class $x not found (did you misspell it?", null) })
+    .unbounded()
+    .text("Chisel design under test to load (must be of type <: RawModule)")
+}
+
+object ChiselCircuitAnnotation {
+  /** Elaborate a Chisel circuit from a lambda and create a circuit annotation
+    *
+    * @param dut a function that creates a Chisel circuit
+    */
+  def apply(dut: () => RawModule): ChiselCircuitAnnotation = ChiselCircuitAnnotation(Driver.elaborate(dut))
+
+  private [chisel3] def apply(): ChiselCircuitAnnotation = ChiselCircuitAnnotation(Circuit("null", Seq.empty))
 }

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -5,21 +5,17 @@ package chisel3
 import chisel3.internal.firrtl.Emitter
 import chisel3.experimental.{RawModule, RunFirrtlTransform, ChiselAnnotation}
 
-import java.io._
-import net.jcazevedo.moultingyaml._
-
 import internal.firrtl._
-import firrtl._
-import firrtl.annotations.{Annotation, JsonProtocol}
+import firrtl.{ExecutionOptionsManager, HasFirrtlOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure,
+  FirrtlExecutionResult, Transform}
+import firrtl.annotations.JsonProtocol
 import firrtl.util.{ BackendCompilationUtilities => FirrtlBackendCompilationUtilities }
 
-import _root_.firrtl.annotations.AnnotationYamlProtocol._
+import java.io._
 
 /**
-  * The Driver provides methods to invoke the chisel3 compiler and the firrtl compiler.
-  * By default firrtl is automatically run after chisel.  an [[ExecutionOptionsManager]]
-  * is needed to manage options.  It can parser command line arguments or coordinate
-  * multiple chisel toolchain tools options.
+  * The Driver provides methods to invoke the chisel3 compiler and the FIRRTL compiler.
+  * By default FIRRTL is automatically run after chisel. Command line options
   *
   * @example
   *          {{{
@@ -104,7 +100,7 @@ object Driver extends BackendCompilationUtilities {
     */
   def emitVerilog[T <: RawModule](gen: => T): String = {
     execute(Array[String](), { () => gen }) match {
-      case ChiselExecutionSuccess(_, _, Some(firrtl.FirrtlExecutionSuccess(_, verilog))) => verilog
+      case ChiselExecutionSuccess(_, _, Some(FirrtlExecutionSuccess(_, verilog))) => verilog
       case _ => sys.error("Cannot get Verilog!")
     }
   }

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -12,31 +12,11 @@ import firrtl.annotations.JsonProtocol
 import firrtl.util.{ BackendCompilationUtilities => FirrtlBackendCompilationUtilities }
 
 import java.io._
-
-/**
-  * The Driver provides methods to invoke the chisel3 compiler and the FIRRTL compiler.
-  * By default FIRRTL is automatically run after chisel. Command line options
-  *
-  * @example
-  *          {{{
-  *          val optionsManager = new ExecutionOptionsManager("chisel3")
-  *              with HasFirrtlOptions
-  *              with HasChiselExecutionOptions {
-  *            commonOptions = CommonOption(targetDirName = "my_target_dir")
-  *            chiselOptions = ChiselExecutionOptions(runFirrtlCompiler = false)
-  *          }
-  *          chisel3.Driver.execute(optionsManager, () => new Dut)
-  *          }}}
-  * or via command line arguments
-  * @example {{{
-  *          args = "--no-run-firrtl --target-dir my-target-dir".split(" +")
-  *          chisel3.execute(args, () => new DUT)
-  *          }}}
-  */
 import BuildInfo._
 
 trait BackendCompilationUtilities extends FirrtlBackendCompilationUtilities {
-  /** Compile Chirrtl to Verilog by invoking Firrtl inside the same JVM
+  /**
+    * Compile Chirrtl to Verilog by invoking Firrtl inside the same JVM
     *
     * @param prefix basename of the file
     * @param dir    directory where file lives
@@ -62,27 +42,41 @@ trait BackendCompilationUtilities extends FirrtlBackendCompilationUtilities {
 trait ChiselExecutionResult
 
 /**
+  * Getting one of these indicates a successful Chisel run
   *
   * @param circuitOption  Optional circuit, has information like circuit name
   * @param emitted            The emitted Chirrrl text
   * @param firrtlResultOption Optional Firrtl result, @see ucb-bar/firrtl for details
   */
 case class ChiselExecutionSuccess(
-                                  circuitOption: Option[Circuit],
-                                  emitted: String,
-                                  firrtlResultOption: Option[FirrtlExecutionResult]
-                                  ) extends ChiselExecutionResult
+  circuitOption: Option[Circuit],
+  emitted: String,
+  firrtlResultOption: Option[FirrtlExecutionResult]) extends ChiselExecutionResult
 
 /**
   * Getting one of these indicates failure of some sort
- *
+  *
   * @param message  a clue perhaps will be provided in the here
   */
 case class ChiselExecutionFailure(message: String) extends ChiselExecutionResult
 
+/**
+  * The Driver provides methods to invoke the Chisel3 compiler and the
+  * FIRRTL compiler. By default FIRRTL is automatically run after chisel.
+  *
+  * @example
+  * {{{
+  * val args = Array(
+  *   "--top-name", "MyTopModule",     // The name of the top module
+  *   "--target-dir", "my_target_dir", // The work directory
+  *   "--compiler", "low" )            // The FIRRTL compiler to use
+  * Driver.execute(args, () => new MyTopModule)
+  * }}}
+  */
 object Driver extends BackendCompilationUtilities {
 
-  /** Elaborates the Module specified in the gen function into a Circuit
+  /**
+    * Elaborates the Module specified in the gen function into a Circuit
     *
     *  @param gen a function that creates a Module hierarchy
     *  @return the resulting Chisel IR in the form of a Circuit (TODO: Should be FIRRTL IR)
@@ -93,7 +87,8 @@ object Driver extends BackendCompilationUtilities {
 
   def emit[T <: RawModule](ir: Circuit): String = Emitter.emit(ir)
 
-  /** Elaborates the Module specified in the gen function into Verilog
+  /**
+    * Elaborates the Module specified in the gen function into Verilog
     *
     *  @param gen a function that creates a Module hierarchy
     *  @return the resulting String containing the design in Verilog
@@ -105,7 +100,8 @@ object Driver extends BackendCompilationUtilities {
     }
   }
 
-  /** Emit the CHIRRTL of a circuit
+  /**
+    * Emit the CHIRRTL of a circuit
     *
     * @param ir The circuit to emit
     * @param optName An optional filename (will use s"${ir.name}.fir" otherwise)
@@ -118,7 +114,8 @@ object Driver extends BackendCompilationUtilities {
     f
   }
 
-  /** Emit the annotations of a circuit
+  /**
+    * Emit the annotations of a circuit
     *
     * @param ir The circuit containing annotations to be emitted
     * @param optName An optional filename (will use s"${ir.name}.json" otherwise)
@@ -142,7 +139,8 @@ object Driver extends BackendCompilationUtilities {
 
   def targetDir(): String = { target_dir getOrElse new File(".").getCanonicalPath }
 
-  /** Determine custom transforms FIRRTL Driver command line arguments,
+  /**
+    * Determine custom transforms FIRRTL Driver command line arguments,
     * e.g., "--custom-transforms ..."
     *
     * @param ir A circuit that may contain annotations
@@ -156,7 +154,8 @@ object Driver extends BackendCompilationUtilities {
       case a: Seq[String] if a.nonEmpty => Array("--custom-transforms") ++ a
       case _ => Array("") }
 
-  /** Run the chisel3 compiler and possibly the firrtl compiler with options specified.
+  /**
+    * Run the chisel3 compiler and possibly the firrtl compiler with options specified.
     *
     * @param optionsManager The options specified
     * @param dut            The device under test
@@ -190,7 +189,8 @@ object Driver extends BackendCompilationUtilities {
     ChiselExecutionSuccess(Some(circuit), firrtlString, firrtlExecutionResult)
   }
 
-  /** Run the chisel3 compiler and possibly the firrtl compiler with options specified via an array of Strings
+  /**
+    * Run the chisel3 compiler and possibly the firrtl compiler with options specified via an array of Strings
     *
     * @param args   The options specified, command line style
     * @param dut    The device under test

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -6,7 +6,7 @@ import chisel3.internal.firrtl.Emitter
 import chisel3.experimental.{RawModule, RunFirrtlTransform, ChiselAnnotation}
 
 import internal.firrtl._
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure,
+import firrtl.{ExecutionOptionsManager, HasFirrtlExecutionOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure,
   FirrtlExecutionResult, Transform}
 import firrtl.annotations.JsonProtocol
 import firrtl.util.{ BackendCompilationUtilities => FirrtlBackendCompilationUtilities }
@@ -27,7 +27,7 @@ trait BackendCompilationUtilities extends FirrtlBackendCompilationUtilities {
       "chisel3",
       Array("--top-name", prefix,
             "--target-dir", dir.getAbsolutePath,
-            "--compiler", "verilog")) with HasChiselExecutionOptions with HasFirrtlOptions
+            "--compiler", "verilog")) with HasChiselExecutionOptions with HasFirrtlExecutionOptions
 
     firrtl.Driver.execute(optionsManager) match {
       case _: FirrtlExecutionSuccess => true
@@ -162,7 +162,7 @@ object Driver extends BackendCompilationUtilities {
     * @return               An execution result with useful stuff, or failure with message
     */
   @deprecated("use Driver.execute(args: Array[String], dut: () => RawModule)", "3.2.0")
-  def execute(optionsManager: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions,
+  def execute(optionsManager: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlExecutionOptions,
               dut: () => RawModule): ChiselExecutionResult = {
     val circuit = elaborate(dut)
     val firrtlString = Emitter.emit(circuit)
@@ -171,7 +171,7 @@ object Driver extends BackendCompilationUtilities {
     val optionsManagerX = new ExecutionOptionsManager(
       optionsManager.applicationName,
       Array("--firrtl-source", firrtlString) ++ customTransformsArg(circuit),
-      optionsManager.firrtlOptions.annotations) with HasFirrtlOptions with HasChiselExecutionOptions
+      optionsManager.firrtlOptions.annotations) with HasFirrtlExecutionOptions with HasChiselExecutionOptions
 
     val (chiselOptions, firrtlOptions) = (optionsManagerX.chiselOptions, optionsManagerX.firrtlOptions)
 
@@ -204,7 +204,7 @@ object Driver extends BackendCompilationUtilities {
     val argsx = args ++ Array("--firrtl-source", firrtlString) ++ customTransformsArg(circuit)
 
     val optionsManager = new ExecutionOptionsManager("chisel3", argsx, firrtlAnnos)
-        with HasChiselExecutionOptions with HasFirrtlOptions
+        with HasChiselExecutionOptions with HasFirrtlExecutionOptions
 
     val (chiselOptions, firrtlOptions) = (optionsManager.chiselOptions, optionsManager.firrtlOptions)
 

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -6,11 +6,12 @@ import chisel3.internal.firrtl.Emitter
 import chisel3.experimental.{RawModule, RunFirrtlTransform, ChiselAnnotation}
 
 import internal.firrtl._
-import firrtl.{ExecutionOptionsManager, HasFirrtlExecutionOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure,
-  FirrtlExecutionResult, Transform, FirrtlExecutionOptions}
+import firrtl.{ HasFirrtlExecutionOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure, FirrtlExecutionResult,
+  Transform, FirrtlExecutionOptions }
+import firrtl.options.ExecutionOptionsManager
 import firrtl.annotations.JsonProtocol
 import firrtl.util.{ BackendCompilationUtilities => FirrtlBackendCompilationUtilities }
-import firrtl.Viewer._
+import firrtl.options.Viewer._
 import firrtl.FirrtlViewer._
 import chisel3.ChiselViewer._
 

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -145,6 +145,7 @@ class AnnotatingDiamondSpec extends FreeSpec with Matchers {
       Driver.execute(Array("--target-dir", "test_run_dir"), () => new TopOfDiamond) match {
         case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
           val annos = circuit.annotations.map(_.toFirrtl)
+
           annos.count(_.isInstanceOf[IdentityAnnotation]) should be (10)
 
           annos.count {
@@ -156,7 +157,8 @@ class AnnotatingDiamondSpec extends FreeSpec with Matchers {
             case IdentityAnnotation(ModuleName("ModC_1", _), "ModC(32)") => true
             case _ => false
           } should be (1)
-        case _ =>
+        case failure =>
+          println(failure)
           assert(false)
       }
     }

--- a/src/test/scala/chiselTests/BlackBoxImpl.scala
+++ b/src/test/scala/chiselTests/BlackBoxImpl.scala
@@ -79,7 +79,7 @@ class BlackBoxImplSpec extends FreeSpec with Matchers {
       }
     }
     "Implementations can be contained in resource files" in {
-      Driver.execute(Array("-X", "low", "--target-dir", targetDir), () => new UsesBlackBoxMinusViaResource) match {
+      Driver.execute(Array("-X", "verilog", "--target-dir", targetDir), () => new UsesBlackBoxMinusViaResource) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
           val verilogOutput = new File(targetDir, "BlackBoxTest.v")
           verilogOutput.exists() should be (true)

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -7,11 +7,8 @@ import java.io.File
 import chisel3._
 import chisel3.util.Counter
 import chisel3.testers.BasicTester
-import chisel3.experimental.{MultiIOModule, RawModule, BaseModule}
+import chisel3.experimental.{MultiIOModule, BaseModule}
 import chisel3.util.experimental.BoringUtils
-import firrtl.{CommonOptions, ExecutionOptionsManager, HasFirrtlOptions, FirrtlExecutionOptions, FirrtlExecutionSuccess,
-  FirrtlExecutionFailure}
-import firrtl.passes.wiring.WiringTransform
 
 abstract class ShouldntAssertTester(cyclesToWait: BigInt = 4) extends BasicTester {
   val dut: BaseModule

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -9,8 +9,7 @@ import org.scalacheck._
 import chisel3._
 import chisel3.experimental.RawModule
 import chisel3.testers._
-import firrtl.{HasFirrtlExecutionOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure}
-import firrtl.options.ExecutionOptionsManager
+import firrtl.{FirrtlExecutionSuccess, FirrtlExecutionFailure}
 import firrtl.util.BackendCompilationUtilities
 
 /** Common utility functions for Chisel unit tests. */

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -9,12 +9,8 @@ import org.scalacheck._
 import chisel3._
 import chisel3.experimental.RawModule
 import chisel3.testers._
-import firrtl.{
-  ExecutionOptionsManager,
-  HasFirrtlExecutionOptions,
-  FirrtlExecutionSuccess,
-  FirrtlExecutionFailure
-}
+import firrtl.{HasFirrtlExecutionOptions, FirrtlExecutionSuccess, FirrtlExecutionFailure}
+import firrtl.options.ExecutionOptionsManager
 import firrtl.util.BackendCompilationUtilities
 
 /** Common utility functions for Chisel unit tests. */

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -11,7 +11,7 @@ import chisel3.experimental.RawModule
 import chisel3.testers._
 import firrtl.{
   ExecutionOptionsManager,
-  HasFirrtlOptions,
+  HasFirrtlExecutionOptions,
   FirrtlExecutionSuccess,
   FirrtlExecutionFailure
 }

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -10,7 +10,6 @@ import chisel3._
 import chisel3.experimental.RawModule
 import chisel3.testers._
 import firrtl.{
-  CommonOptions,
   ExecutionOptionsManager,
   HasFirrtlOptions,
   FirrtlExecutionSuccess,
@@ -45,12 +44,9 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
     */
   def compile(t: => RawModule): String = {
     val testDir = createTestDirectory(this.getClass.getSimpleName)
-    val manager = new ExecutionOptionsManager("compile") with HasFirrtlOptions
-                                                         with HasChiselExecutionOptions {
-      commonOptions = CommonOptions(targetDirName = testDir.toString)
-    }
+    val args = Array("--target-dir", testDir.toString)
 
-    Driver.execute(manager, () => t) match {
+    Driver.execute(args, () => t) match {
       case ChiselExecutionSuccess(_, _, Some(firrtlExecRes)) =>
         firrtlExecRes match {
           case FirrtlExecutionSuccess(_, verilog) => verilog

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -5,7 +5,8 @@ package chiselTests
 import java.io.File
 
 import chisel3._
-import firrtl.{FirrtlExecutionSuccess, ExecutionOptionsManager, HasFirrtlExecutionOptions}
+import firrtl.{FirrtlExecutionSuccess, HasFirrtlExecutionOptions}
+import firrtl.options.ExecutionOptionsManager
 import org.scalacheck.Test.Failed
 import org.scalatest.{FreeSpec, Matchers, Succeeded}
 

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import java.io.File
 
 import chisel3._
-import firrtl.{FirrtlExecutionSuccess, ExecutionOptionsManager, HasFirrtlOptions}
+import firrtl.{FirrtlExecutionSuccess, ExecutionOptionsManager, HasFirrtlExecutionOptions}
 import org.scalacheck.Test.Failed
 import org.scalatest.{FreeSpec, Matchers, Succeeded}
 
@@ -112,7 +112,7 @@ class DriverSpec extends FreeSpec with Matchers {
       val optionsManager = new ExecutionOptionsManager (
         "test",
         Array( "-tn", name,
-               "-td", targetDir ) ) with HasFirrtlOptions with HasChiselExecutionOptions
+               "-td", targetDir ) ) with HasFirrtlExecutionOptions with HasChiselExecutionOptions
       Driver.execute(optionsManager, () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
           filesShouldExist(List("anno.json", "fir", "v"))

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import java.io.File
 
 import chisel3._
-import firrtl.FirrtlExecutionSuccess
+import firrtl.{FirrtlExecutionSuccess, ExecutionOptionsManager, HasFirrtlOptions}
 import org.scalacheck.Test.Failed
 import org.scalatest.{FreeSpec, Matchers, Succeeded}
 
@@ -18,41 +18,111 @@ class DummyModule extends Module {
 }
 
 class DriverSpec extends FreeSpec with Matchers {
+
+  val name = "DummyModule"
+  def filesShouldExist(exts: Seq[String])(implicit dir: String): Unit = exts
+    .foreach{ ext =>
+      val dummyOutput = new File(dir, name + "." + ext)
+      dummyOutput.exists() should be (true)
+      dummyOutput.delete() }
+  def filesShouldNotExist(exts: Seq[String])(implicit dir: String): Unit = exts
+    .foreach{ ext =>
+      val dummyOutput = new File(dir, name + "." + ext)
+      dummyOutput.exists should be (false) }
+
   "Driver's execute methods are used to run chisel and firrtl" - {
-    "options can be picked up from comand line with no args" in {
+    "options can be picked up from the command line with no args" in {
       // NOTE: Since we don't provide any arguments (notably, "--target-dir"),
       //  the generated files will be created in the current directory.
-      val  targetDir = "."
+      implicit val targetDir = "."
       Driver.execute(Array.empty[String], () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val exts = List("anno.json", "fir", "v")
-          for (ext <- exts) {
-            val dummyOutput = new File(targetDir, "DummyModule" + "." + ext)
-            dummyOutput.exists() should be(true)
-            dummyOutput.delete()
-          }
+          filesShouldExist(List("anno.json", "fir", "v"))
           Succeeded
         case _ =>
           Failed
       }
     }
 
-    "options can be picked up from comand line setting top name" in {
-      val  targetDir = "local-build"
-      Driver.execute(Array("-tn", "dm", "-td", targetDir), () => new DummyModule) match {
+    "options can be picked up from the command line setting top name" in {
+      implicit val targetDir = "test_run_dir"
+      Driver.execute(Array(
+                       "-tn", name,
+                       "-td", targetDir,
+                       "--compiler", "low"), () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val exts = List("anno.json", "fir", "v")
-          for (ext <- exts) {
-            val dummyOutput = new File(targetDir, "dm" + "." + ext)
-            dummyOutput.exists() should be(true)
-            dummyOutput.delete()
-          }
+          filesShouldExist(List("anno.json", "fir", "lo.fir"))
+          filesShouldNotExist(List("v", "hi.fir", "mid.fir"))
           Succeeded
         case _ =>
           Failed
       }
-
     }
+
+    "--dont-save-chirrtl should disable CHIRRTL emission" in {
+      implicit val targetDir = "test_run_dir"
+      val args = Array(
+        "--dont-save-chirrtl",
+        "--compiler", "middle",
+        "--target-dir", targetDir)
+      Driver.execute(args, () => new DummyModule) match {
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          filesShouldExist(List("anno.json", "mid.fir"))
+          filesShouldNotExist(List("v", "hi.fir", "lo.fir"))
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+
+    "--dont-save-annotations should disable annotation emission" in {
+      implicit val targetDir = "test_run_dir"
+      val args = Array(
+        "--dont-save-annotations",
+        "--compiler", "high",
+        "--target-dir", targetDir)
+      Driver.execute(args, () => new DummyModule) match {
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          filesShouldExist(List("hi.fir"))
+          filesShouldNotExist(List("v", "lo.fir", "mid.fir", "anno.json"))
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+
+    "--no-run-firrtl should emit CHIRRTL and not FIRRTL or Verilog" in {
+      implicit val targetDir = "test_run_dir"
+      val args = Array(
+        "--no-run-firrtl",
+        "--compiler", "verilog",
+        "--target-dir", targetDir)
+      Driver.execute(args, () => new DummyModule) match {
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          filesShouldExist(List("anno.json", "fir"))
+          filesShouldNotExist(List("v", "hi.fir", "lo.fir", "mid.fir"))
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+
+    "deprecated execute method still works" in {
+      implicit val targetDir = "test_run_dir"
+      val optionsManager = new ExecutionOptionsManager (
+        "test",
+        Array( "-tn", name,
+               "-td", targetDir ) ) with HasFirrtlOptions with HasChiselExecutionOptions
+      Driver.execute(optionsManager, () => new DummyModule) match {
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          filesShouldExist(List("anno.json", "fir", "v"))
+          filesShouldNotExist(List("hi.fir", "lo.fir", "mid.fir"))
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+
     "execute returns a chisel execution result" in {
       val targetDir = "test_run_dir"
       val args = Array("--compiler", "low", "--target-dir", targetDir)

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -110,11 +110,11 @@ class DriverSpec extends FreeSpec with Matchers {
 
     "deprecated execute method still works" in {
       implicit val targetDir = "test_run_dir"
-      val optionsManager = new ExecutionOptionsManager (
-        "test",
-        Array( "-tn", name,
-               "-td", targetDir ) ) with HasFirrtlExecutionOptions with HasChiselExecutionOptions
-      Driver.execute(optionsManager, () => new DummyModule) match {
+      val optionsManager = new ExecutionOptionsManager ("test") with HasFirrtlExecutionOptions
+          with HasChiselExecutionOptions
+      val args = Array( "-tn", name,
+                        "-td", targetDir )
+      Driver.execute(args, () => new DummyModule) match {
         case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
           filesShouldExist(List("anno.json", "fir", "v"))
           filesShouldNotExist(List("hi.fir", "lo.fir", "mid.fir"))


### PR DESCRIPTION
This changes the way that options are parsed to align with a proposal for immutable option parsing in FIRRTL. This proposal uses immutable scopt parsing, specifically a `scopt.OptionParser[AnnotationSeq]` object. Each command line option maps to a single `firrtl.Annotation`. These will be consumed lazily to set `chiselOptions` (or `firrtlOptions` or `myFrontendOrBackendOptions`). This technically provides two equivalent methods for setting options:
  - Either through something which mimics a command line `Array[String]`
  - Through the explicit setting of `Seq[firrtl.Annotation]` written to a file

In consequence, `chiselOptions` is now immutable and the old approach of creating an options manager, explicitly calling a parse method, and then tweaking `chiselOptions` is disallowed.

@ucbjrl: This is a rough guide for how to migrate to use immutable parsing. Usually, it's just some fixes to the driver and a cleanup of any tests that may be using the options manager directly. I have not looked at the other repos (testers/treadle/firrtl-interpreter/rocket-chip) to see if there's any additional oddities there.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
- https://github.com/freechipsproject/firrtl/issues/764
- https://github.com/freechipsproject/firrtl/issues/765 (__depends on this__)

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API change 

Any attempt to mutably modify `firrtlOptions` or `chiselOptions` will no longer work. The old method of providing options via an options manager is still supported, but deprecated. Attempts to create an options manager that do not conform to mandatory options required by FIRRTL (e.g., the name of the top module cannot be determined) will fail.

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Switch to using immutable parsing of command line options

Add two new options for controlling whether or not specific
output files are generated:
  - `--dont-save-chirrtl`: Do not save CHIRRTL output
  - `--dont-save-annotations`: Do not save annotations file

Deprecates passing in an explicit options manager to
`chisel3.Driver.execute` in favor of passing in command line
arguments (`Array[String]`).