### PR TITLE
Bundle Literals Framework

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -62,6 +62,8 @@ sealed abstract class Aggregate extends Data {
     }
   }
 
+  def litToBigIntOption: Option[BigInt] = ???  // TODO implement me
+
   /** Returns a Seq of the immediate contents of this Aggregate, in order.
     */
   def getElements: Seq[Data]

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -738,7 +738,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     // (which could lead to data conflicts, since it's likely the user didn't know to re-bind them).
     // This is not guaranteed to catch all cases (for example, Data in Tuples or Iterables).
     val boundDataParamNames = ctorParamsNameVals.collect {
-      case (paramName, paramVal: Data) if paramVal.hasBinding => paramName
+      case (paramName, paramVal: Data) if paramVal.topBindingOpt.isDefined => paramName
     }
     if (boundDataParamNames.nonEmpty) {
       autoClonetypeError(s"constructor parameters (${boundDataParamNames.sorted.mkString(", ")}) have values that are hardware types, which is likely to cause subtle errors." +

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -64,6 +64,10 @@ sealed abstract class Aggregate extends Data {
 
   def litToBigIntOption: Option[BigInt] = ???  // TODO implement me
 
+  // Returns the LitArg of a Bits object.
+  // Internal API for Bundle literals, to copy the LitArg of argument literals into the top map.
+  protected def litArgOfBits(elt: Bits): LitArg = elt.litArgOption.get
+
   /** Returns a Seq of the immediate contents of this Aggregate, in order.
     */
   def getElements: Seq[Data]

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -62,7 +62,7 @@ sealed abstract class Aggregate extends Data {
     }
   }
 
-  def litToBigIntOption: Option[BigInt] = ???  // TODO implement me
+  override def litOption = ???  // TODO implement me
 
   // Returns the LitArg of a Bits object.
   // Internal API for Bundle literals, to copy the LitArg of argument literals into the top map.

--- a/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
@@ -60,7 +60,7 @@ object assert { // scalastyle:ignore object.name
         case None => s"Assertion failed\n    at $escLine\n"
       }
       printf.printfWithoutReset(fmt, data:_*)
-      pushCommand(Stop(sourceInfo, Node(Builder.forcedClock), 1))
+      pushCommand(Stop(sourceInfo, Builder.forcedClock.ref, 1))
     }
   }
 
@@ -81,7 +81,7 @@ object stop { // scalastyle:ignore object.name
   /** Terminate execution with a failure code. */
   def apply(code: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
     when (!Module.reset.toBool) {
-      pushCommand(Stop(sourceInfo, Node(Builder.forcedClock), code))
+      pushCommand(Stop(sourceInfo, Builder.forcedClock.ref, code))
     }
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/BiConnect.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BiConnect.scala
@@ -186,7 +186,7 @@ object BiConnect {
     // Source and sink are ambiguous in the case of a Bi/Bulk Connect (<>).
     // If either is a DontCareBinding, just issue a DefInvalid for the other,
     //  otherwise, issue a Connect.
-    (left.binding, right.binding) match {
+    (left.topBinding, right.topBinding) match {
       case (lb: DontCareBinding, _) => pushCommand(DefInvalid(sourceInfo, right.lref))
       case (_, rb: DontCareBinding) => pushCommand(DefInvalid(sourceInfo, left.lref))
       case (_, _) => pushCommand(Connect(sourceInfo, right.lref, left.ref))
@@ -197,7 +197,7 @@ object BiConnect {
     // Source and sink are ambiguous in the case of a Bi/Bulk Connect (<>).
     // If either is a DontCareBinding, just issue a DefInvalid for the other,
     //  otherwise, issue a Connect.
-    (left.binding, right.binding) match {
+    (left.topBinding, right.topBinding) match {
       case (lb: DontCareBinding, _) => pushCommand(DefInvalid(sourceInfo, right.lref))
       case (_, rb: DontCareBinding) => pushCommand(DefInvalid(sourceInfo, left.lref))
       case (_, _) => pushCommand(Connect(sourceInfo, left.lref, right.ref))

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -27,7 +27,7 @@ object requireIsHardware {
       case Some(x: BaseModule) => x._compatAutoWrapPorts
       case _ =>
     }
-    if (!node.hasBinding) {
+    if (!node.topBindingOpt.isDefined) {
       val prefix = if (msg.nonEmpty) s"$msg " else ""
       throw Binding.ExpectedHardwareException(s"$prefix'$node' must be hardware, " +
         "not a bare Chisel type. Perhaps you forgot to wrap it in Wire(_) or IO(_)?")
@@ -38,7 +38,7 @@ object requireIsHardware {
 /** Requires that a node is a chisel type (not hardware, "unbound")
   */
 object requireIsChiselType {
-  def apply(node: Data, msg: String = "") = if (node.hasBinding) {
+  def apply(node: Data, msg: String = "") = if (node.topBindingOpt.isDefined) {
     val prefix = if (msg.nonEmpty) s"$msg " else ""
     throw Binding.ExpectedChiselTypeException(s"$prefix'$node' must be a Chisel type, not hardware")
   }
@@ -102,7 +102,7 @@ case class RegBinding(enclosure: UserModule) extends ConstrainedBinding
 case class WireBinding(enclosure: UserModule) extends ConstrainedBinding
 
 case class ChildBinding(parent: Data) extends Binding {
-  def location = parent.binding.location
+  def location = parent.topBinding.location
 }
 // A DontCare element has a specific Binding, somewhat like a literal.
 // It is a source (RHS). It may only be connected/applied to sinks.

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -1,6 +1,7 @@
 package chisel3.core
 
 import chisel3.internal.Builder.{forcedModule}
+import chisel3.internal.firrtl.LitArg
 
 object Binding {
   class BindingException(message: String) extends Exception(message)
@@ -92,8 +93,6 @@ sealed trait ConstrainedBinding extends TopBinding {
 // A binding representing a data that cannot be (re)assigned to.
 sealed trait ReadOnlyBinding extends TopBinding
 
-// TODO literal info here
-case class LitBinding() extends UnconstrainedBinding with ReadOnlyBinding
 // TODO(twigg): Ops between unenclosed nodes can also be unenclosed
 // However, Chisel currently binds all op results to a module
 case class OpBinding(enclosure: UserModule) extends ConstrainedBinding with ReadOnlyBinding
@@ -108,3 +107,9 @@ case class ChildBinding(parent: Data) extends Binding {
 // A DontCare element has a specific Binding, somewhat like a literal.
 // It is a source (RHS). It may only be connected/applied to sinks.
 case class DontCareBinding() extends UnconstrainedBinding
+
+sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
+// Literal binding attached to a element that is not part of a Bundle.
+case class ElementLitBinding(litArg: LitArg) extends LitBinding
+// Literal binding attached to the root of a Bundle, containing literal values of its children.
+case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -86,7 +86,7 @@ sealed abstract class Bits(width: Width)
     case _ => None
   }
 
-  override def litToBigIntOption: Option[BigInt] = litArgOption.map(_.num)
+  override def litOption: Option[BigInt] = litArgOption.map(_.num)
   private[core] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
 
   // provide bits-specific literal handling functionality here
@@ -764,7 +764,7 @@ sealed class Bool() extends UInt(1.W) with Reset {
     new Bool().asInstanceOf[this.type]
   }
 
-  def litToBooleanOption: Option[Boolean] = litToBigIntOption.map {
+  def litToBooleanOption: Option[Boolean] = litOption.map {
     case intVal if intVal == 1 => true
     case intVal if intVal == 0 => false
     case intVal => throwException(s"Boolean with unexpected literal value $intVal")
@@ -851,7 +851,7 @@ sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint)
     case _ => this badConnect that
   }
 
-  def litToDoubleOption: Option[Double] = litToBigIntOption.map { intVal =>
+  def litToDoubleOption: Option[Double] = litOption.map { intVal =>
     val multiplier = math.pow(2, binaryPoint.get)
     intVal.toDouble / multiplier
   }
@@ -1125,6 +1125,8 @@ final class Analog private (width: Width) extends Element(width) {
   private[core] override def typeEquivalent(that: Data): Boolean =
     that.isInstanceOf[Analog] && this.width == that.width
 
+  override def litOption = None
+
   def cloneType: this.type = new Analog(width).asInstanceOf[this.type]
 
   // Used to enforce single bulk connect of Analog types, multi-attach is still okay
@@ -1152,8 +1154,6 @@ final class Analog private (width: Width) extends Element(width) {
     }
     binding = target
   }
-
-  override def litToBigIntOption = None
 
   override def do_asUInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
     throwException("Analog does not support asUInt")

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -77,10 +77,7 @@ sealed abstract class Bits(width: Width)
 
   protected def litArgOption: Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
-    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
-      case Some(litArg) => Some(litArg)
-      case _ => None
-    }
+    case Some(BundleLitBinding(litMap)) => litMap.get(this)
     case _ => None
   }
 
@@ -444,8 +441,7 @@ abstract trait Num[T <: Data] {
 /** A data type for unsigned integers, represented as a binary bitvector.
   * Defines arithmetic operations between other integer types.
   */
-sealed class UInt private[core] (width: Width)
-    extends Bits(width) with Num[UInt] {
+sealed class UInt private[core] (width: Width) extends Bits(width) with Num[UInt] {
 
   private[core] override def typeEquivalent(that: Data): Boolean =
     that.isInstanceOf[UInt] && this.width == that.width
@@ -862,7 +858,6 @@ sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint)
   }
 
   def litToDouble: Double = litToDoubleOption.get
-
 
   final def unary_- (): FixedPoint = macro SourceInfoTransform.noArg
   final def unary_-% (): FixedPoint = macro SourceInfoTransform.noArg

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -94,7 +94,7 @@ sealed abstract class Bits(width: Width)
     case Some(ElementLitBinding(litArg)) => litArg
     case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
       case Some(litArg) => litArg
-      case _ => throwException(s"internal error: DontCare should be caught before connect")
+      case _ => throwException(s"internal error: DontCare should be caught before getting ref")
     }
     case _ => super.ref
   }

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -95,7 +95,11 @@ sealed abstract class Bits(width: Width)
 
   // provide bits-specific literal handling functionality here
   override private[chisel3] def ref: Arg = topBindingOpt match {
-    case Some(binding: LitBinding) => binding.asInstanceOf[ElementLitBinding].litArg
+    case Some(ElementLitBinding(litArg)) => litArg
+    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => litArg
+      case _ => throwException(s"internal error: DontCare should be caught before connect")
+    }
     case _ => super.ref
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -72,11 +72,19 @@ sealed abstract class Bits(width: Width)
 
   def cloneType: this.type = cloneTypeWidth(width)
 
+  private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
+    // Translate Bundle lit bindings to Element lit bindings
+    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => Some(ElementLitBinding(litArg))
+      case _ => Some(DontCareBinding())
+    }
+    case topBindingOpt => topBindingOpt
+  }
+
   override def elementLitArg: Option[LitArg] = litArgOption
 
   protected def litArgOption: Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
-    case Some(BundleLitBinding(litMap)) => litMap.get(this)
     case _ => None
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -75,6 +75,8 @@ sealed abstract class Bits(width: Width)
 
   def cloneType: this.type = cloneTypeWidth(width)
 
+  override def elementLitArg: Option[LitArg] = litArgOption
+
   protected def litArgOption: Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case Some(BundleLitBinding(litMap)) => litMap.get(this)

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -67,9 +67,6 @@ sealed abstract class Bits(width: Width)
   // Arguments for: self-checking code (can't do arithmetic on bits)
   // Arguments against: generates down to a FIRRTL UInt anyways
 
-  // If this is a literal, setRef so that we don't allocate a name
-  litArg.foreach(setRef)
-
   // Only used for in a few cases, hopefully to be removed
   private[core] def cloneTypeWidth(width: Width): this.type
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -75,13 +75,10 @@ sealed abstract class Bits(width: Width)
 
   def cloneType: this.type = cloneTypeWidth(width)
 
-  protected def litArgOption: Option[LitArg] = bindingOpt match {
-    case Some(_) => topBinding match {
-      case ElementLitBinding(litArg) => Some(litArg)
-      case BundleLitBinding(litMap) => litMap.get(this) match {
-        case Some(litArg) => Some(litArg)
-        case _ => None
-      }
+  protected def litArgOption: Option[LitArg] = topBindingOpt match {
+    case Some(ElementLitBinding(litArg)) => Some(litArg)
+    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => Some(litArg)
       case _ => None
     }
     case _ => None
@@ -95,6 +92,12 @@ sealed abstract class Bits(width: Width)
   private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption match {
     case Some(litArg) => Some(litArg.forcedWidth)
     case _ => None
+  }
+
+  // provide bits-specific literal handling functionality here
+  override private[chisel3] def ref: Arg = topBindingOpt match {
+    case Some(binding: LitBinding) => binding.asInstanceOf[ElementLitBinding].litArg
+    case _ => super.ref
   }
 
   final def tail(n: Int): UInt = macro SourceInfoTransform.nArg

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -81,15 +81,13 @@ sealed abstract class Bits(width: Width)
     case topBindingOpt => topBindingOpt
   }
 
-  protected def litArgOption: Option[LitArg] = topBindingOpt match {
+  private[core] def litArgOption: Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case _ => None
   }
 
   override def litToBigIntOption: Option[BigInt] = litArgOption.map(_.num)
-  private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
-
-  override def elementLitArg: Option[LitArg] = litArgOption
+  private[core] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
 
   // provide bits-specific literal handling functionality here
   override private[chisel3] def ref: Arg = topBindingOpt match {

--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -70,7 +70,6 @@ abstract class ExtModule(val params: Map[String, Param] = Map.empty[String, Para
     // While BlackBoxes are not supposed to have an implementation, we still need to call
     // _onModuleClose on all nodes (for example, Aggregates use it for recursive naming).
     for (id <- getIds) {
-      id.forceName(default="_T", _namespace)
       id._onModuleClose
     }
 
@@ -155,7 +154,6 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     // Doing so would cause the wrong names to be assigned, since their parent
     // is now the module itself instead of the io bundle.
     for (id <- getIds; if id ne io) {
-      id.forceName(default="_T", _namespace)
       id._onModuleClose
     }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
@@ -23,6 +23,8 @@ sealed class Clock extends Element(Width(1)) {
     case _ => super.badConnect(that)(sourceInfo)
   }
 
+  override def litToBigIntOption = None
+
   /** Not really supported */
   def toPrintable: Printable = PString("CLOCK")
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
@@ -23,7 +23,7 @@ sealed class Clock extends Element(Width(1)) {
     case _ => super.badConnect(that)(sourceInfo)
   }
 
-  override def litToBigIntOption = None
+  override def litOption = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("CLOCK")

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -398,10 +398,6 @@ abstract class Data extends HasId with NamedComponent {
   @deprecated("isLit is deprecated, use litToBigIntOption or litTo*Option", "chisel3.2")
   def isLit(): Boolean = litArg.isDefined
 
-  // If this is an element literal, returns the LitArg bound to it.
-  // INTERNAL API, but this isn't protected to allow bundle literal constructors.
-  def elementLitArg: Option[LitArg] = None
-
   /**
    * If this is a literal that is representable as bits, returns the value as a BigInt.
    * If not a literal, or not representable as bits (for example, is or contains Analog), returns None.

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -364,8 +364,25 @@ abstract class Data extends HasId with NamedComponent {
 
   final def := (that: Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = this.connect(that)(sourceInfo, connectionCompileOptions)
   final def <> (that: Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = this.bulkConnect(that)(sourceInfo, connectionCompileOptions)
-  def litArg(): Option[LitArg] = None
+
+  @chiselRuntimeDeprecated
+  @deprecated("Literal accessors on Data are deprecated, a replacement is pending", "chisel3.2")
+  def litArg(): Option[LitArg] = bindingOpt match {
+    case Some(_) => topBinding match {
+      case ElementLitBinding(litArg) => Some(litArg)
+      case BundleLitBinding(litMap) => litMap.get(this) match {
+        case Some(litArg) => Some(litArg)
+        case _ => None  // DontCares in a bundle literal are treated as non-literal
+      }
+      case _ => None
+    }
+    case _ => None
+  }
+  @chiselRuntimeDeprecated
+  @deprecated("Literal accessors on Data are deprecated, a replacement is pending", "chisel3.2")
   def litValue(): BigInt = litArg.get.num
+  @chiselRuntimeDeprecated
+  @deprecated("Literal accessors on Data are deprecated, a replacement is pending", "chisel3.2")
   def isLit(): Boolean = litArg.isDefined
 
   /** Returns the width, in bits, if currently known.

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -385,29 +385,26 @@ abstract class Data extends HasId with NamedComponent {
   final def <> (that: Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = this.bulkConnect(that)(sourceInfo, connectionCompileOptions)
 
   @chiselRuntimeDeprecated
-  @deprecated("litArg is deprecated, use litToBigIntOption or litTo*Option", "chisel3.2")
+  @deprecated("litArg is deprecated, use litOption or litTo*Option", "chisel3.2")
   def litArg(): Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case Some(BundleLitBinding(litMap)) => None  // this API does not support Bundle literals
     case _ => None
   }
   @chiselRuntimeDeprecated
-  @deprecated("litValue deprecated, use litToBigInt or litTo*", "chisel3.2")
-  def litValue(): BigInt = litArg.get.num
-  @chiselRuntimeDeprecated
-  @deprecated("isLit is deprecated, use litToBigIntOption or litTo*Option", "chisel3.2")
+  @deprecated("isLit is deprecated, use litOption.isDefined", "chisel3.2")
   def isLit(): Boolean = litArg.isDefined
 
   /**
    * If this is a literal that is representable as bits, returns the value as a BigInt.
    * If not a literal, or not representable as bits (for example, is or contains Analog), returns None.
    */
-  def litToBigIntOption: Option[BigInt]
+  def litOption(): Option[BigInt]
 
   /**
    * Returns the literal value if this is a literal that is representable as bits, otherwise crashes.
    */
-  def litToBigInt: BigInt = litToBigIntOption.get
+  def litValue(): BigInt = litOption.get
 
   /** Returns the width, in bits, if currently known.
     * @throws java.util.NoSuchElementException if the width is not known. */
@@ -518,7 +515,7 @@ object DontCare extends Element(width = UnknownWidth()) {
   bind(DontCareBinding(), SpecifiedDirection.Output)
   override def cloneType = DontCare
 
-  override def litToBigIntOption = None
+  override def litOption = None
 
   def toPrintable: Printable = PString("DONTCARE")
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -405,6 +405,10 @@ abstract class Data extends HasId with NamedComponent {
   @deprecated("isLit is deprecated, use litToBigIntOption or litTo*Option", "chisel3.2")
   def isLit(): Boolean = litArg.isDefined
 
+  // If this is an element literal, returns the LitArg bound to it.
+  // INTERNAL API, but this isn't protected to allow bundle literal constructors.
+  def elementLitArg: Option[LitArg] = None
+
   /**
    * If this is a literal that is representable as bits, returns the value as a BigInt.
    * If not a literal, or not representable as bits (for example, is or contains Analog), returns None.

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -270,6 +270,8 @@ abstract class Data extends HasId with NamedComponent {
     * binding and direction are valid after this call completes.
     */
   private[chisel3] def bind(target: Binding, parentDirection: SpecifiedDirection = SpecifiedDirection.Unspecified)
+  // Variant of bind that can be called from subclasses, used for bundle literals
+  protected def selfBind(target: Binding) = bind(target)
 
   // Both _direction and _resolvedUserDirection are saved versions of computed variables (for
   // efficiency, avoid expensive recomputation of frequent operations).

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -250,14 +250,9 @@ abstract class Data extends HasId with NamedComponent {
     _binding = Some(target)
   }
 
-  private[core] def topBindingOpt: Option[TopBinding] = {
-    _binding match {
-      case Some(binding) => binding match {
-        case ChildBinding(parent) => parent.topBindingOpt
-        case binding: TopBinding => Some(binding)
-      }
-      case None => None
-    }
+  private[core] def topBindingOpt: Option[TopBinding] = _binding.map {
+    case ChildBinding(parent) => parent.topBinding
+    case bindingVal: TopBinding => bindingVal
   }
 
   private[core] def topBinding: TopBinding = topBindingOpt.get

--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -99,7 +99,7 @@ sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId wi
 
     val port = pushCommand(
       DefMemPort(sourceInfo,
-       t.cloneTypeFull, Node(this), dir, i.ref, Node(Builder.forcedClock))
+       t.cloneTypeFull, Node(this), dir, i.ref, Builder.forcedClock.ref)
     ).id
     // Bind each element of port to being a MemoryPort
     port.bind(MemoryPortBinding(Builder.forcedUserModule))

--- a/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
@@ -142,7 +142,7 @@ object MonoConnect {
   private def issueConnect(sink: Element, source: Element)(implicit sourceInfo: SourceInfo): Unit = {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Connect.
-    source.binding match {
+    source.topBinding match {
       case b: DontCareBinding => pushCommand(DefInvalid(sourceInfo, sink.lref))
       case _ => pushCommand(Connect(sourceInfo, sink.lref, source.ref))
     }
@@ -154,8 +154,8 @@ object MonoConnect {
     import BindingDirection.{Internal, Input, Output} // Using extensively so import these
     // If source has no location, assume in context module
     // This can occur if is a literal, unbound will error previously
-    val sink_mod: BaseModule   = sink.binding.location.getOrElse(throw UnwritableSinkException)
-    val source_mod: BaseModule = source.binding.location.getOrElse(context_mod)
+    val sink_mod: BaseModule   = sink.topBinding.location.getOrElse(throw UnwritableSinkException)
+    val source_mod: BaseModule = source.topBinding.location.getOrElse(context_mod)
 
     val sink_direction = BindingDirection.from(sink.topBinding, sink.direction)
     val source_direction = BindingDirection.from(source.topBinding, source.direction)

--- a/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
@@ -93,7 +93,7 @@ object printf { // scalastyle:ignore object.name
 
   private[chisel3] def printfWithoutReset(pable: Printable)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
     val clock = Builder.forcedClock
-    pushCommand(Printf(sourceInfo, Node(clock), pable))
+    pushCommand(Printf(sourceInfo, clock.ref, pable))
   }
   private[chisel3] def printfWithoutReset(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit =
     printfWithoutReset(Printable.pack(fmt, data:_*))

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -69,13 +69,10 @@ object RegInit {
     * Register type is inferred from the initializer.
     */
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-    val model = (init.litArg match {
+    val model = (init match {
       // For e.g. Reg(init=UInt(0, k)), fix the Reg's width to k
-      case Some(lit) if lit.forcedWidth => init.cloneTypeFull
-      case _ => init match {
-        case init: Bits => init.cloneTypeWidth(Width())
-        case init => init.cloneTypeFull
-      }
+      case init: Bits if init.litIsForcedWidth == Some(false) => init.cloneTypeWidth(Width())
+      case init => init.cloneTypeFull
     }).asInstanceOf[T]
     RegInit(model, init)
   }

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -84,8 +84,8 @@ object RegInit {
       requireIsChiselType(t, "reg type")
     }
     val reg = t.cloneTypeFull
-    val clock = Node(Builder.forcedClock)
-    val reset = Node(Builder.forcedReset)
+    val clock = Builder.forcedClock.ref
+    val reset = Builder.forcedReset.ref
 
     reg.bind(RegBinding(Builder.forcedUserModule))
     requireIsHardware(init, "reg initializer")

--- a/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
@@ -72,11 +72,13 @@ abstract class UserModule(implicit moduleCompileOptions: CompileOptions)
     for (id <- getIds) {
       id match {
         case id: BaseModule => id.forceName(default=id.desiredName, _namespace)
-        case id: Data => id.topBinding match {
+        case id: MemBase[_] => id.forceName(default="_T", _namespace)
+        case id: Data if id.topBindingOpt.isDefined => id.topBinding match {
           case OpBinding(_) | MemoryPortBinding(_) | PortBinding(_) | RegBinding(_) | WireBinding(_) =>
             id.forceName(default="_T", _namespace)
-          case _ =>
+          case _ =>  // don't name literals
         }
+        case id: Data if id.topBindingOpt.isEmpty =>  // don't name unbound types
       }
       id._onModuleClose
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
@@ -72,7 +72,11 @@ abstract class UserModule(implicit moduleCompileOptions: CompileOptions)
     for (id <- getIds) {
       id match {
         case id: BaseModule => id.forceName(default=id.desiredName, _namespace)
-        case id => id.forceName(default="_T", _namespace)
+        case id: Data => id.topBinding match {
+          case OpBinding(_) | MemoryPortBinding(_) | PortBinding(_) | RegBinding(_) | WireBinding(_) =>
+            id.forceName(default="_T", _namespace)
+          case _ =>
+        }
       }
       id._onModuleClose
     }
@@ -156,11 +160,11 @@ abstract class LegacyModule(implicit moduleCompileOptions: CompileOptions)
   @chiselRuntimeDeprecated
   @deprecated("Module constructor with override _clock deprecated, use withClock", "chisel3")
   def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), None)(moduleCompileOptions)
-  
+
   @chiselRuntimeDeprecated
   @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
   def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  = this(None, Option(_reset))(moduleCompileOptions)
-  
+
   @chiselRuntimeDeprecated
   @deprecated("Module constructor with override _clock, _reset deprecated, use withClockAndReset", "chisel3")
   def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), Option(_reset))(moduleCompileOptions)

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -299,7 +299,7 @@ private[chisel3] object Builder {
   }
 
   def build[T <: UserModule](f: => T): Circuit = {
-    //chiselContext.withValue(new ChiselContext) {
+    chiselContext.withValue(new ChiselContext) {
       dynamicContextVar.withValue(Some(new DynamicContext())) {
         errors.info("Elaborating design...")
         val mod = f
@@ -309,7 +309,7 @@ private[chisel3] object Builder {
 
         Circuit(components.last.name, components, annotations)
       }
-    //}
+   }
   }
   initializeSingletons()
 }

--- a/src/main/scala/chisel3/testers/BasicTester.scala
+++ b/src/main/scala/chisel3/testers/BasicTester.scala
@@ -26,7 +26,7 @@ class BasicTester extends Module() {
   def stop()(implicit sourceInfo: SourceInfo) {
     // TODO: rewrite this using library-style SourceInfo passing.
     when (!reset.toBool) {
-      pushCommand(Stop(sourceInfo, Node(clock), 0))
+      pushCommand(Stop(sourceInfo, clock.ref, 0))
     }
   }
 

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -91,8 +91,10 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
 /** Hardware module that is used to sequence n producers into 1 consumer.
   * Producers are chosen in round robin order.
   *
+  * @param gen data type
+  * @param n number of inputs
   * @example {{{
-  * val arb = new RRArbiter(2, UInt())
+  * val arb = Module(new RRArbiter(UInt(), 2))
   * arb.io.in(0) <> producer0.io.out
   * arb.io.in(1) <> producer1.io.out
   * consumer.io.in <> arb.io.out
@@ -104,8 +106,11 @@ class RRArbiter[T <: Data](gen:T, n: Int) extends LockingRRArbiter[T](gen, n, 1)
 /** Hardware module that is used to sequence n producers into 1 consumer.
   * Priority is given to lower producer.
   *
+  * @param gen data type
+  * @param n number of inputs
+  *
   * @example {{{
-  * val arb = Module(new Arbiter(2, UInt()))
+  * val arb = Module(new Arbiter(UInt(), 2))
   * arb.io.in(0) <> producer0.io.out
   * arb.io.in(1) <> producer1.io.out
   * consumer.io.in <> arb.io.out

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -75,7 +75,7 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     val len = if (x.isWidthKnown) x.getWidth else 0
-    apply("b" + x.litToBigInt.toString(2).reverse.padTo(len, "0").reverse.mkString)
+    apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 }
 

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -74,9 +74,8 @@ object BitPat {
     * @note the UInt must be a literal
     */
   def apply(x: UInt): BitPat = {
-    require(x.isLit)
     val len = if (x.isWidthKnown) x.getWidth else 0
-    apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
+    apply("b" + x.litToBigInt.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 }
 
@@ -93,7 +92,7 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) {
   def getWidth: Int = width
   def === (that: UInt): Bool = macro SourceInfoTransform.thatArg
   def =/= (that: UInt): Bool = macro SourceInfoTransform.thatArg
-  
+
   def do_=== (that: UInt)  // scalastyle:ignore method.name
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     value.asUInt === (that & mask.asUInt)
@@ -102,7 +101,7 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) {
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     !(this === that)
   }
-  
+
   def != (that: UInt): Bool = macro SourceInfoTransform.thatArg
   @chiselRuntimeDeprecated
   @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -28,7 +28,7 @@ class SwitchContext[T <: Bits](cond: T, whenContext: Option[WhenContext], lits: 
   def is(v: Iterable[T])(block: => Unit): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
-        require(w.litToBigIntOption != None, "is condition must be literal")
+        require(w.litToBigIntOption.isDefined, "is condition must be literal")
         val value = w.litToBigInt
         require(!lits.contains(value), "all is conditions must be mutually exclusive!")
         value

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -28,8 +28,8 @@ class SwitchContext[T <: Bits](cond: T, whenContext: Option[WhenContext], lits: 
   def is(v: Iterable[T])(block: => Unit): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
-        require(w.litToBigIntOption.isDefined, "is condition must be literal")
-        val value = w.litToBigInt
+        require(w.litOption.isDefined, "is condition must be literal")
+        val value = w.litValue
         require(!lits.contains(value), "all is conditions must be mutually exclusive!")
         value
       }

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -28,8 +28,8 @@ class SwitchContext[T <: Bits](cond: T, whenContext: Option[WhenContext], lits: 
   def is(v: Iterable[T])(block: => Unit): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
-        require(w.isLit, "is conditions must be literals!")
-        val value = w.litValue
+        require(w.litToBigIntOption != None, "is condition must be literal")
+        val value = w.litToBigInt
         require(!lits.contains(value), "all is conditions must be mutually exclusive!")
         value
       }

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -1,0 +1,76 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.core.FixedPoint
+import chisel3.experimental.RawModule
+import chisel3.testers.BasicTester
+import org.scalatest._
+
+class BundleLiteralSpec extends ChiselFlatSpec {
+  class MyBundle extends Bundle {
+    val a = UInt(8.W)
+    val b = Bool()
+
+    // Bundle literal constructor code, which will be auto-generated using macro annotations in
+    // the future.
+    import chisel3.core.BundleLitBinding
+    import chisel3.internal.firrtl.{ULit, Width}
+    // Full bundle literal constructor
+    def Lit(aVal: UInt, bVal: Bool): MyBundle = {
+      val clone = cloneType
+      clone.selfBind(BundleLitBinding(Map(
+        clone.a -> aVal.elementLitArg.get,
+        clone.b -> bVal.elementLitArg.get
+      )))
+      clone
+    }
+    // Partial bundle literal constructor
+    def Lit(aVal: UInt): MyBundle = {
+      val clone = cloneType
+      clone.selfBind(BundleLitBinding(Map(
+        clone.a -> aVal.elementLitArg.get
+      )))
+      clone
+    }
+  }
+
+  "bundle literals" should "work in RTL" in {
+    val outsideBundleLit = (new MyBundle).Lit(42.U, true.B)
+    assertTesterPasses{ new BasicTester{
+      // TODO: add direct bundle compare operations, when that feature is added
+      chisel3.assert(outsideBundleLit.a === 42.U)
+      chisel3.assert(outsideBundleLit.b === true.B)
+
+      val bundleLit = (new MyBundle).Lit(42.U, true.B)
+      chisel3.assert(bundleLit.a === 42.U)
+      chisel3.assert(bundleLit.b === true.B)
+
+      chisel3.assert(bundleLit.a === outsideBundleLit.a)
+      chisel3.assert(bundleLit.b === outsideBundleLit.b)
+
+      val bundleWire = Wire(new MyBundle)
+      bundleWire := outsideBundleLit
+
+      chisel3.assert(bundleWire.a === 42.U)
+      chisel3.assert(bundleWire.b === true.B)
+
+      stop()
+    } }
+  }
+
+  "partial bundle literals" should "work in RTL" in {
+    assertTesterPasses{ new BasicTester{
+      val bundleLit = (new MyBundle).Lit(42.U)
+      chisel3.assert(bundleLit.a === 42.U)
+
+      val bundleWire = Wire(new MyBundle)
+      bundleWire := bundleLit
+
+      chisel3.assert(bundleWire.a === 42.U)
+
+      stop()
+    } }
+  }
+}

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -21,8 +21,8 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     def Lit(aVal: UInt, bVal: Bool): MyBundle = {
       val clone = cloneType
       clone.selfBind(BundleLitBinding(Map(
-        clone.a -> aVal.elementLitArg.get,
-        clone.b -> bVal.elementLitArg.get
+        clone.a -> litArgOfBits(aVal),
+        clone.b -> litArgOfBits(bVal)
       )))
       clone
     }
@@ -30,7 +30,7 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     def Lit(aVal: UInt): MyBundle = {
       val clone = cloneType
       clone.selfBind(BundleLitBinding(Map(
-        clone.a -> aVal.elementLitArg.get
+        clone.a -> litArgOfBits(aVal)
       )))
       clone
     }

--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -41,58 +41,58 @@ class ConnectSpec extends ChiselPropSpec {
     assertTesterPasses{ new CrossConnectTester(SInt(16.W), SInt(16.W)) }
   }
   property("SInt := UInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(UInt(16.W), SInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), SInt(16.W)) } }
   }
   property("SInt := FixedPoint should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } }
   }
   property("UInt := UInt should succeed") {
     assertTesterPasses{ new CrossConnectTester(UInt(16.W), UInt(16.W)) }
   }
   property("UInt := SInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(SInt(16.W), UInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), UInt(16.W)) } }
   }
   property("UInt := FixedPoint should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } }
   }
 
   property("Clock := Clock should succeed") {
     assertTesterPasses{ new CrossConnectTester(Clock(), Clock()) }
   }
   property("Clock := UInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(Clock(), UInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(Clock(), UInt(16.W)) } }
   }
 
   property("FixedPoint := FixedPoint should succeed") {
     assertTesterPasses{ new CrossConnectTester(FixedPoint(16.W, 8.BP), FixedPoint(16.W, 8.BP)) }
   }
   property("FixedPoint := SInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(SInt(16.W), FixedPoint(16.W, 8.BP)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), FixedPoint(16.W, 8.BP)) } }
   }
   property("FixedPoint := UInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(UInt(16.W), FixedPoint(16.W, 8.BP)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), FixedPoint(16.W, 8.BP)) } }
   }
 
   property("Analog := Analog should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(Analog(16.W), Analog(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), Analog(16.W)) } }
   }
   property("Analog := FixedPoint should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(Analog(16.W), FixedPoint(16.W, 8.BP)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), FixedPoint(16.W, 8.BP)) } }
   }
   property("FixedPoint := Analog should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(FixedPoint(16.W, 8.BP), Analog(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), Analog(16.W)) } }
   }
   property("Analog := UInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(Analog(16.W), UInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), UInt(16.W)) } }
   }
   property("Analog := SInt should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(Analog(16.W), SInt(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), SInt(16.W)) } }
   }
   property("UInt := Analog should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(UInt(16.W), Analog(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), Analog(16.W)) } }
   }
   property("SInt := Analog should fail") {
-    intercept[ChiselException]{ new CrossConnectTester(SInt(16.W), Analog(16.W)) }
+    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), Analog(16.W)) } }
   }
   property("Pipe internal connections should succeed") {
     elaborate( new PipeInternalWires)

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -70,7 +70,9 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     }
     val myBundleLiteral = (new MyBundle).Lit(42, true)
     println(myBundleLiteral.a)
+    println(myBundleLiteral.a.hashCode)
     println(myBundleLiteral.b)
+    println(myBundleLiteral.b.hashCode)
     println(myBundleLiteral.a == myBundleLiteral.b)
     assert(myBundleLiteral.a.litToBigInt == 42)
     assert(myBundleLiteral.b.litToBigInt == 1)

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -59,16 +59,16 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       // the future.
       import chisel3.core.BundleLitBinding
       import chisel3.internal.firrtl.{ULit, Width}
-      def Lit(aVal: BigInt, bVal: Boolean): MyBundle = {
+      def Lit(aVal: UInt, bVal: Bool): MyBundle = {
         val clone = cloneType
         clone.selfBind(BundleLitBinding(Map(
-            clone.a -> ULit(aVal, Width()),
-            clone.b -> ULit(if (bVal) 1 else 0, Width(1)))
-        ))
+            clone.a -> aVal.elementLitArg.get,
+            clone.b -> bVal.elementLitArg.get
+        )))
         clone
       }
     }
-    val myBundleLiteral = (new MyBundle).Lit(42, true)
+    val myBundleLiteral = (new MyBundle).Lit(42.U, true.B)
     assert(myBundleLiteral.a.litToBigInt == 42)
     assert(myBundleLiteral.b.litToBigInt == 1)
     assert(myBundleLiteral.b.litToBoolean == true)

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -76,7 +76,8 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
 
       // the following errors with "assertion failed"
 
-      chisel3.core.assert(outsideLiteral === insideLiteral)
+      println(outsideLiteral === insideLiteral)
+      // chisel3.core.assert(outsideLiteral === insideLiteral)
 
       // the following lines of code error
       // with "chisel3.core.BundleLitBinding cannot be cast to chisel3.core.ElementLitBinding"

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.core.FixedPoint
 import chisel3.experimental.RawModule
 import chisel3.testers.BasicTester
-import chisel3.util.Counter
 import org.scalatest._
 
 class LiteralExtractorSpec extends ChiselFlatSpec {

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -69,11 +69,6 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       }
     }
     val myBundleLiteral = (new MyBundle).Lit(42, true)
-    println(myBundleLiteral.a)
-    println(myBundleLiteral.a.hashCode)
-    println(myBundleLiteral.b)
-    println(myBundleLiteral.b.hashCode)
-    println(myBundleLiteral.a == myBundleLiteral.b)
     assert(myBundleLiteral.a.litToBigInt == 42)
     assert(myBundleLiteral.b.litToBigInt == 1)
     assert(myBundleLiteral.b.litToBoolean == true)

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -1,0 +1,79 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental.RawModule
+import org.scalatest._
+
+class LiteralExtractorSpec extends ChiselFlatSpec {
+  "litToBigInt" should "return the literal value" in {
+    assert(0.U.litToBigInt === BigInt(0))
+    assert(1.U.litToBigInt === BigInt(1))
+    assert(42.U.litToBigInt === BigInt(42))
+
+    assert(0.S.litToBigInt === BigInt(0))
+    assert(-1.S.litToBigInt === BigInt(-1))
+    assert(-42.S.litToBigInt === BigInt(-42))
+
+    assert(true.B.litToBigInt === BigInt(1))
+    assert(false.B.litToBigInt === BigInt(0))
+
+    assert(1.25.F(2.BP).litToBigInt === BigInt("101", 2))
+    assert(2.25.F(2.BP).litToBigInt === BigInt("1001", 2))
+
+    assert(-1.25.F(2.BP).litToBigInt === BigInt("-101", 2))
+    assert(-2.25.F(2.BP).litToBigInt === BigInt("-1001", 2))
+  }
+
+  "litToBoolean" should "return the literal value" in {
+    assert(true.B.litToBoolean === true)
+    assert(false.B.litToBoolean === false)
+  }
+
+  "litToDouble" should "return the literal value" in {
+    assert(1.25.F(2.BP).litToDouble == 1.25)
+    assert(2.25.F(2.BP).litToDouble == 2.25)
+
+    assert(-1.25.F(2.BP).litToDouble == -1.25)
+    assert(-2.25.F(2.BP).litToDouble == -2.25)
+
+    // test rounding
+    assert(1.24.F(1.BP).litToDouble == 1.0)
+    assert(1.25.F(1.BP).litToDouble == 1.5)
+  }
+
+  "litToBigIntOption" should "return None for non-literal hardware" in {
+    elaborate { new RawModule {
+      val a = Wire(UInt())
+      assert(a.litToBigIntOption == None)
+    }}
+  }
+
+  "bundle literals" should "do the right thing" in {
+    class MyBundle extends Bundle {
+      val a = UInt(8.W)
+      val b = Bool()
+
+      // Bundle literal constructor code, which will be auto-generated using macro annotations in
+      // the future.
+      import chisel3.core.BundleLitBinding
+      import chisel3.internal.firrtl.{ULit, Width}
+      def Lit(aVal: BigInt, bVal: Boolean): MyBundle = {
+        val clone = cloneType
+        clone.selfBind(BundleLitBinding(Map(
+            clone.a -> ULit(aVal, Width()),
+            clone.b -> ULit(if (bVal) 1 else 0, Width(1)))
+        ))
+        clone
+      }
+    }
+    val myBundleLiteral = (new MyBundle).Lit(42, true)
+    println(myBundleLiteral.a)
+    println(myBundleLiteral.b)
+    println(myBundleLiteral.a == myBundleLiteral.b)
+    assert(myBundleLiteral.a.litToBigInt == 42)
+    assert(myBundleLiteral.b.litToBigInt == 1)
+    assert(myBundleLiteral.b.litToBoolean == true)
+  }
+}

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -9,24 +9,24 @@ import chisel3.testers.BasicTester
 import org.scalatest._
 
 class LiteralExtractorSpec extends ChiselFlatSpec {
-  "litToBigInt" should "return the literal value" in {
-    assert(0.U.litToBigInt === BigInt(0))
-    assert(1.U.litToBigInt === BigInt(1))
-    assert(42.U.litToBigInt === BigInt(42))
-    assert(42.U.litToBigInt === 42.U.litToBigInt)
+  "litValue" should "return the literal value" in {
+    assert(0.U.litValue === BigInt(0))
+    assert(1.U.litValue === BigInt(1))
+    assert(42.U.litValue === BigInt(42))
+    assert(42.U.litValue === 42.U.litValue)
 
-    assert(0.S.litToBigInt === BigInt(0))
-    assert(-1.S.litToBigInt === BigInt(-1))
-    assert(-42.S.litToBigInt === BigInt(-42))
+    assert(0.S.litValue === BigInt(0))
+    assert(-1.S.litValue === BigInt(-1))
+    assert(-42.S.litValue === BigInt(-42))
 
-    assert(true.B.litToBigInt === BigInt(1))
-    assert(false.B.litToBigInt === BigInt(0))
+    assert(true.B.litValue === BigInt(1))
+    assert(false.B.litValue === BigInt(0))
 
-    assert(1.25.F(2.BP).litToBigInt === BigInt("101", 2))
-    assert(2.25.F(2.BP).litToBigInt === BigInt("1001", 2))
+    assert(1.25.F(2.BP).litValue === BigInt("101", 2))
+    assert(2.25.F(2.BP).litValue === BigInt("1001", 2))
 
-    assert(-1.25.F(2.BP).litToBigInt === BigInt("-101", 2))
-    assert(-2.25.F(2.BP).litToBigInt === BigInt("-1001", 2))
+    assert(-1.25.F(2.BP).litValue === BigInt("-101", 2))
+    assert(-2.25.F(2.BP).litValue === BigInt("-1001", 2))
   }
 
   "litToBoolean" should "return the literal value" in {
@@ -46,10 +46,10 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     assert(1.25.F(1.BP).litToDouble == 1.5)
   }
 
-  "litToBigIntOption" should "return None for non-literal hardware" in {
+  "litOption" should "return None for non-literal hardware" in {
     elaborate { new RawModule {
       val a = Wire(UInt())
-      assert(a.litToBigIntOption == None)
+      assert(a.litOption == None)
     }}
   }
 
@@ -114,8 +114,8 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       }
     }
     val myBundleLiteral = (new MyBundle).Lit(42.U, true.B)
-    assert(myBundleLiteral.a.litToBigInt == 42)
-    assert(myBundleLiteral.b.litToBigInt == 1)
+    assert(myBundleLiteral.a.litValue == 42)
+    assert(myBundleLiteral.b.litValue == 1)
     assert(myBundleLiteral.b.litToBoolean == true)
   }
 }

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -63,8 +63,8 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       def Lit(aVal: SInt, bVal: FixedPoint): InsideBundle = {
         val clone = cloneType
         clone.selfBind(BundleLitBinding(Map(
-          clone.x -> aVal.elementLitArg.get,
-          clone.y -> bVal.elementLitArg.get
+          clone.x -> litArgOfBits(aVal),
+          clone.y -> litArgOfBits(bVal)
         )))
         clone
       }
@@ -107,8 +107,8 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       def Lit(aVal: UInt, bVal: Bool): MyBundle = {
         val clone = cloneType
         clone.selfBind(BundleLitBinding(Map(
-          clone.a -> aVal.elementLitArg.get,
-          clone.b -> bVal.elementLitArg.get
+          clone.a -> litArgOfBits(aVal),
+          clone.b -> litArgOfBits(bVal)
         )))
         clone
       }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #805

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition, API deprecation

<!-- choose one -->
**Development Phase**: proposed implementation

**Release Notes**
- Adds litToBigInt[Option], litToBoolean[Option], and litToDouble[Option] APIs. Deprecates previous isLit, litArg, litValue APIs, since those expose implementation details (LitArg), do not have Option variants, and may not return the type desired (BigInt/Boolean/Double).
- [internal] literals now specified in Bindings, instead of in Data subtypes.
- [internal] adds support for Bundle literals by introducing a Bundle literal binding that contains a map of leaf subelements to their literal values.
- ~[internal] ids are now persistent through runs, necessary to allow Bundle literals outside a Builder context (otherwise, a new IdGen is created for each element, and the ids alias).~
- [internal] HasId `hashcode` and `equals` reverted to the Java Object defaults, which allows Data created outside a Builder context to be Map-indexable
- [internal] Created a ChiselContext (like DynamicContext) for global operations (like _id creation) that can be done outside a Builder context.
- [internal] lref/ref checks are more strict, but Bindings should ensure they don't trip, and cases where they do trip are likely to be FIRRTL errors.
- [internal] Made accesses to DynamicContext more strict, and will throw an error in most cases. The exceptions are error logging (errors are discarded) and getting the current Module (which will return None if outside a Builder context).

Other notes:
- Support for bundle literal extractors is not yet implemented (the TODO is intentional), proposal is to have litToBigInt[Option] do the right thing. Note that bundle subelement literals can be extracted.
- Support for generating Bundle literal constructors by macro annotation will be in a future PR. This only provides the internal framework to support Bundle literals at all. A mockup of what the generated code could look like is in the Bundle literal test case.
- litArg, litValue, isLit are deprecated globally, even in Chisel context. If anyone really cares (as in, this causes problems for someone), I can move those into the compatibility layer without the deprecation warning through implicit conversions.