### PR TITLE
Fix UIntToOH for output widths larger than 2^(input width)

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -190,8 +190,10 @@ sealed abstract class Bits(width: Width, override val litArg: Option[LitArg])
     */
   final def pad(that: Int): this.type = macro SourceInfoTransform.thatArg
 
-  def do_pad(that: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): this.type =
-    binop(sourceInfo, cloneTypeWidth(this.width max Width(that)), PadOp, that)
+  def do_pad(that: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): this.type = this.width match {
+    case KnownWidth(w) if w >= that => this
+    case _ => binop(sourceInfo, cloneTypeWidth(this.width max Width(that)), PadOp, that)
+  }
 
   /** Returns this wire bitwise-inverted. */
   final def unary_~ (): Bits = macro SourceInfoWhiteboxTransform.noArg

--- a/src/main/scala/chisel3/util/OneHot.scala
+++ b/src/main/scala/chisel3/util/OneHot.scala
@@ -46,7 +46,8 @@ object UIntToOH {
   def apply(in: UInt, width: Int): UInt = width match {
     case 0 => 0.U(0.W)
     case _ =>
-      val shiftAmount = in((log2Ceil(width) - 1) max 0, 0)
+      val shiftAmountWidth = log2Ceil(width)
+      val shiftAmount = in.pad(shiftAmountWidth)((shiftAmountWidth - 1) max 0, 0)
       (1.U << shiftAmount)(width - 1, 0)
   }
 }

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import Chisel.testers.BasicTester
 import chisel3._
 import chisel3.experimental.FixedPoint
-import chisel3.util.Mux1H
+import chisel3.util.{Mux1H, UIntToOH}
 import org.scalatest._
 
 //scalastyle:off magic.number
@@ -41,9 +41,7 @@ class OneHotMuxSpec extends FreeSpec with Matchers with ChiselRunners {
     }
   }
   "UIntToOH with output width greater than 2^(input width)" in {
-    intercept[IllegalArgumentException] {
-      assertTesterPasses(new UIntToOHTester)
-    }
+    assertTesterPasses(new UIntToOHTester)
   }
 }
 

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -40,6 +40,11 @@ class OneHotMuxSpec extends FreeSpec with Matchers with ChiselRunners {
       assertTesterPasses(new DifferentBundleOneHotTester)
     }
   }
+  "UIntToOH with output width greater than 2^(input width)" in {
+    intercept[IllegalArgumentException] {
+      assertTesterPasses(new UIntToOHTester)
+    }
+  }
 }
 
 class SimpleOneHotTester extends BasicTester {
@@ -283,4 +288,11 @@ class DifferentBundleOneHotTester extends BasicTester {
   stop()
 }
 
+class UIntToOHTester extends BasicTester {
+  val out = UIntToOH(1.U, 3)
 
+  require(out.getWidth == 3)
+  assert(out === 2.U)
+
+  stop()
+}


### PR DESCRIPTION
UIntToOH(foo, bar) fails when bar > (2^foo.getWidth).

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/chisel3/issues/822

<!-- choose one -->
**Type of change**: bug report +/- feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
