### PR TITLE
Remove extraneous traversal in cloneSupertype

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -108,7 +108,7 @@ private[core] object cloneSupertype {
                                                           compileOptions: CompileOptions): T = {
     require(!elts.isEmpty, s"can't create $createdType with no inputs")
 
-    if (elts forall {_.isInstanceOf[Bits]}) {
+    if (elts.head.isInstanceOf[Bits]) {
       val model: T = elts reduce { (elt1: T, elt2: T) => ((elt1, elt2) match {
         case (elt1: Bool, elt2: Bool) => elt1
         case (elt1: Bool, elt2: UInt) => elt2  // TODO: what happens with zero width UInts?
@@ -130,7 +130,7 @@ private[core] object cloneSupertype {
         }
         case (elt1, elt2) =>
           throw new AssertionError(
-            s"can't create $createdType with heterogeneous Bits types ${elt1.getClass} and ${elt2.getClass}")
+            s"can't create $createdType with heterogeneous types ${elt1.getClass} and ${elt2.getClass}")
       }).asInstanceOf[T] }
       model.cloneTypeFull
     }


### PR DESCRIPTION
This removes an unnecessary traversal, it does mean that non-bits type can end up in the `reduce` rather than the `else`, but this is an error case anyway and the error message is identical (it will, however, use different elements of the Seq to express the error, but it's the same error).

VecInit is especially slow, this PR halves the runtime of `VecInit(Seq.fill(16384)(true.B))` from ~10s to ~5s. Even 5s is atrocious considering the `Seq.fill` call takes ~30**ms** on the same machine, but this is still a big win.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Improve performance of Mux and VecInit cloning