### PR TITLE
Use Vec.apply instead of new Vec in VecInit.apply

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -277,7 +277,7 @@ object VecInit {
     require(!elts.isEmpty)
     elts.foreach(requireIsHardware(_, "vec element"))
 
-    val vec = Wire(new Vec(cloneSupertype(elts, "Vec"), elts.length))
+    val vec = Wire(Vec(elts.length, cloneSupertype(elts, "Vec")))
 
     // TODO: try to remove the logic for this mess
     elts.head.direction match {


### PR DESCRIPTION
The Vec constructor invokes the gen argument for each element in the
Vec. Since VecInit invokes cloneSupertype which touches every element of
the input Seq, this was an n^2 operation. Vec.apply accepts its
arguments by value so cloneSupertype is only called once. It then calls
cloneType on that once for each element in the Vec, which is constant
time reducing the overall complexity of VecInit to just n.


<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Speed up VecInit performance by a factor of n