### PR TITLE
Literals set the ref so that they no longer get named

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -67,6 +67,9 @@ sealed abstract class Bits(width: Width, override val litArg: Option[LitArg])
   // Arguments for: self-checking code (can't do arithmetic on bits)
   // Arguments against: generates down to a FIRRTL UInt anyways
 
+  // If this is a literal, setRef so that we don't allocate a name
+  litArg.foreach(setRef)
+
   // Only used for in a few cases, hopefully to be removed
   private[core] def cloneTypeWidth(width: Width): this.type
 

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -142,6 +142,18 @@ class MultiClockSpec extends ChiselFlatSpec {
       assert(withReset(this.reset) { 5 } == 5)
     })
   }
+  it should "support literal Bools" in {
+    assertTesterPasses(new BasicTester {
+      val reg = withReset(true.B) {
+        RegInit(6.U)
+      }
+      reg := reg - 1.U
+      // The reg is always in reset so will never decrement
+      chisel3.assert(reg === 6.U)
+      val (_, done) = Counter(true.B, 4)
+      when (done) { stop() }
+    })
+  }
 
   "withClockAndReset" should "return like a normal Scala block" in {
     elaborate(new BasicTester {


### PR DESCRIPTION
Have literals set their ref so that a name isn't allocated

This has a few implications
* Constructing a literal no longer increments `_T_` suffixes
* Internally, wrapping a literal Bits in Node(...) will work
* Literal Bools work in withReset/withClockAndReset
* Data.ref is potentially redundant

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**:  Fixes #763.

@azidar beat me to fixing #472, but this would also have fixed that issue (I added a test in this PR as well)

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Literal Bools work for reset in withClockAndReset and withReset
Literals no longer increment temporary names suffix