### PR TITLE
Add Emacs temporaries, backups to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 *.iml
 *.swp
 test_run_dir
+*~
+\#*\#
+.\#*


### PR DESCRIPTION
Apparently I'm the only one doing development on Chisel with Emacs... This adds the usual `*~`, `.#*` Emacs backups/temporary files to the top-level `.gitignore`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Add Emacs temporaries, backups to top-level .gitignore