### PR TITLE
Add instance inline API

### DIFF
--- a/src/main/scala/chisel3/util/experimental/Inline.scala
+++ b/src/main/scala/chisel3/util/experimental/Inline.scala
@@ -1,0 +1,50 @@
+// See LICENSE for license details.
+
+package chisel3.util.experimental
+
+import chisel3._
+import chisel3.internal.InstanceId
+import chisel3.experimental.{BaseModule, ChiselAnnotation, RunFirrtlTransform}
+import firrtl.Transform
+import firrtl.passes.{InlineAnnotation, InlineInstances}
+import firrtl.transforms.{NoDedupAnnotation, FlattenAnnotation, Flatten}
+import firrtl.annotations.{CircuitName, ModuleName, ComponentName, Annotation}
+
+/** Inlines an instance of a module
+  *
+  * @example {{{
+  * trait Internals { this: Module =>
+  *   val io = IO(new Bundle{ val a = Input(Bool()) })
+  * }
+  * class Sub extends Module with Internals
+  * trait HasSub { this: Module with Internals =>
+  *   val sub = Module(new Sub)
+  *   sub.io.a := io.a
+  * }
+  * /* InlineInstance is mixed directly into Foo's definition. Every instance
+  *  * of this will be inlined. */
+  * class Foo extends Module with Internals with InlineInstance with HasSub
+  * /* Bar will, by default, not be inlined */
+  * class Bar extends Module with Internals with HasSub
+  * /* The resulting instances will be:
+  *  - Top
+  *  - Top.x$sub
+  *  - Top.y$sub
+  *  - Top.z
+  *  - Top.z.sub */
+  * class Top extends Module with Internals {
+  *   val x = Module(new Foo)                     // x will be inlined
+  *   val y = Module(new Bar with InlineInstance) // y will also be inlined
+  *   val z = Module(new Bar)                     // z will not be inlined
+  *   Seq(x, y, z).map(_.io.a := io.a)
+  * }
+  * }}}
+  */
+trait InlineInstance { self: BaseModule =>
+  Seq(new ChiselAnnotation with RunFirrtlTransform {
+        def toFirrtl: Annotation = InlineAnnotation(self.toNamed)
+        def transformClass: Class[_ <: Transform] = classOf[InlineInstances] },
+      new ChiselAnnotation {
+        def toFirrtl: Annotation = NoDedupAnnotation(self.toNamed) })
+    .map(chisel3.experimental.annotate(_))
+}

--- a/src/test/scala/chiselTests/InlineSpec.scala
+++ b/src/test/scala/chiselTests/InlineSpec.scala
@@ -1,0 +1,57 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util.experimental.InlineInstance
+import chisel3.internal.firrtl.Circuit
+import firrtl.FirrtlExecutionSuccess
+import firrtl.passes.InlineAnnotation
+import firrtl.annotations.Annotation
+import firrtl.analyses.InstanceGraph
+import firrtl.{ir => fir}
+import firrtl.WDefInstance
+import firrtl.Mappers._
+import org.scalatest.{FreeSpec, Matchers}
+
+class InlineSpec extends FreeSpec with ChiselRunners with Matchers {
+
+  trait Internals { this: Module =>
+    val io = IO(new Bundle{ val a = Input(Bool()) })
+  }
+  class Sub extends Module with Internals
+  trait HasSub { this: Module with Internals =>
+    val sub = Module(new Sub)
+    sub.io.a := io.a
+  }
+
+  class Foo extends Module with Internals with InlineInstance with HasSub
+  class Bar extends Module with Internals with HasSub
+  class Baz extends Module with Internals with HasSub
+  class Qux extends Module with Internals with HasSub
+
+  def collectInstances(c: fir.Circuit, top: Option[String] = None): Seq[String] = new InstanceGraph(c)
+    .fullHierarchy.values.flatten.toSeq
+    .map( v => (top.getOrElse(v.head.name) +: v.tail.map(_.name)).mkString(".") )
+
+  "Module Inlining" - {
+    class Top extends Module with Internals {
+      val x = Module(new Foo)
+      val y = Module(new Bar with InlineInstance)
+      val z = Module(new Bar)
+      Seq(x, y, z).map(_.io.a := io.a)
+    }
+    "should compile to low FIRRTL" - {
+      Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new Top) match {
+        case ChiselExecutionSuccess(Some(chiselCircuit), _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
+          "emitting TWO InlineAnnotation at the CHIRRTL level" in {
+            chiselCircuit.annotations.map(_.toFirrtl).collect{ case a: InlineAnnotation => a }.size should be (2)
+          }
+          "low FIRRTL should contain only instance z" in {
+            val instances = collectInstances(firrtlResult.circuitState.circuit, Some("Top")).toSet
+            Set("Top", "Top.x$sub", "Top.y$sub", "Top.z", "Top.z.sub") should be (instances)
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a circuit/module/instance inlining and flattening API. This adds three new traits:
  - `InlineInstance` that will inline any Module/Instance it's mixed into
  - `FlattenInstance` that will flatten any Module/Instance it's mixed into

This provides Chisel-level access to existing FIRRTL annotations (`InlineAnnotation` and `FlattenAnnotation`) that map to existing FIRRTL passes/transforms (`InlineInstances` and `Flatten`).

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
Resolves #602
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Add instance inlining and flattening API