### PR TITLE
Correcting documentation errors in Arbiter.scala

### DIFF
--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -91,8 +91,10 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
 /** Hardware module that is used to sequence n producers into 1 consumer.
   * Producers are chosen in round robin order.
   *
+  * @param gen data type
+  * @param n number of inputs
   * @example {{{
-  * val arb = new RRArbiter(2, UInt())
+  * val arb = Module(new RRArbiter(UInt(), 2))
   * arb.io.in(0) <> producer0.io.out
   * arb.io.in(1) <> producer1.io.out
   * consumer.io.in <> arb.io.out
@@ -104,8 +106,11 @@ class RRArbiter[T <: Data](gen:T, n: Int) extends LockingRRArbiter[T](gen, n, 1)
 /** Hardware module that is used to sequence n producers into 1 consumer.
   * Priority is given to lower producer.
   *
+  * @param gen data type
+  * @param n number of inputs
+  *
   * @example {{{
-  * val arb = Module(new Arbiter(2, UInt()))
+  * val arb = Module(new Arbiter(UInt(), 2))
   * arb.io.in(0) <> producer0.io.out
   * arb.io.in(1) <> producer1.io.out
   * consumer.io.in <> arb.io.out


### PR DESCRIPTION
Documentation for example had parameters in wrong order, and was missing @param. Additionally, it was lacking a module wrapper. This has been corrected.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Documentation Fixes in Arbiter.scala
