### PR TITLE
Catch returns from within when blocks and provide an error message

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -49,7 +49,7 @@ object Module {
     val module: T = bc  // bc is actually evaluated here
 
     if (Builder.whenDepth != 0) {
-      throwException("Internal Error! \"When\" scope depth is != 0, this should have been caught!")
+      throwException("Internal Error! when() scope depth is != 0, this should have been caught!")
     }
     if (Builder.readyForModuleConstr) {
       throwException("Error: attempted to instantiate a Module, but nothing happened. " +

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -49,7 +49,7 @@ object Module {
     val module: T = bc  // bc is actually evaluated here
 
     if (Builder.whenDepth != 0) {
-      throwException("Internal Error! When depth is != 0, this should not be possible")
+      throwException("Internal Error! \"When\" scope depth is != 0, this should have been caught!")
     }
     if (Builder.readyForModuleConstr) {
       throwException("Error: attempted to instantiate a Module, but nothing happened. " +

--- a/chiselFrontend/src/main/scala/chisel3/core/When.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/When.scala
@@ -75,7 +75,7 @@ final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block:
     block
   } catch {
     case ret: scala.runtime.NonLocalReturnControl[_] =>
-      throwException("Cannot exit from a \"when\" block with a \"return\"!" +
+      throwException("Cannot exit from a when() block with a \"return\"!" +
         " Perhaps you meant to use Mux or a Wire as a return value?"
       )
   }

--- a/chiselFrontend/src/main/scala/chisel3/core/When.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/When.scala
@@ -71,7 +71,14 @@ final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block:
   if (firrtlDepth > 0) { pushCommand(AltBegin(sourceInfo)) }
   cond.foreach( c => pushCommand(WhenBegin(sourceInfo, c().ref)) )
   Builder.whenDepth += 1
-  block
+  try {
+    block
+  } catch {
+    case ret: scala.runtime.NonLocalReturnControl[_] =>
+      throwException("Cannot exit from a \"when\" block with a \"return\"!" +
+        " Perhaps you meant to use Mux or a Wire as a return value?"
+      )
+  }
   Builder.whenDepth -= 1
   cond.foreach( c => pushCommand(WhenEnd(sourceInfo,firrtlDepth)) )
   if (cond.isEmpty) { pushCommand(OtherwiseEnd(sourceInfo,firrtlDepth)) }

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -126,6 +126,6 @@ class WhenSpec extends ChiselFlatSpec {
         io.out := func()
       })
     }
-    e.getMessage should include ("Cannot exit from a \"when\" block with a \"return\"")
+    e.getMessage should include ("Cannot exit from a when() block with a \"return\"")
   }
 }

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -106,4 +106,26 @@ class WhenSpec extends ChiselFlatSpec {
   "Conditional connections to submodule ports" should "be handled properly" in {
     assertTesterPasses(new SubmoduleWhenTester)
   }
+
+  "Returning in a when scope" should "give a reasonable error message" in {
+    val e = the [ChiselException] thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {
+          val foo = Input(UInt(8.W))
+          val bar = Input(UInt(8.W))
+          val cond = Input(Bool())
+          val out = Output(UInt(8.W))
+        })
+        def func(): UInt = {
+          when(io.cond) {
+            return io.foo
+          }
+          return io.bar
+        }
+        io.out := func()
+        println("Here!")
+      })
+    }
+    e.getMessage should include ("Cannot exit from a \"when\" block with a \"return\"")
+  }
 }

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -123,7 +123,6 @@ class WhenSpec extends ChiselFlatSpec {
           return io.bar
         }
         io.out := func()
-        println("Here!")
       })
     }
     e.getMessage should include ("Cannot exit from a \"when\" block with a \"return\"")

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -118,6 +118,7 @@ class WhenSpec extends ChiselFlatSpec {
         })
         def func(): UInt = {
           when(io.cond) {
+            // This is bad, do not do this!!!
             return io.foo
           }
           return io.bar


### PR DESCRIPTION
Resolves #841 

It turns out that non-local returns are an exception so we can catch this 💯 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable --> #841 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change (better error message)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Returns within when scopes used to give opaque error messages. Now they are caught earlier (with a stack trace) and explained in the error message.