### PR TITLE
Undeprecate log2Up and log2Down

### DIFF
--- a/src/main/scala/chisel3/util/Math.scala
+++ b/src/main/scala/chisel3/util/Math.scala
@@ -10,8 +10,9 @@ import chisel3.internal.chiselRuntimeDeprecated
 
 /** Compute the log2 rounded up with min value of 1 */
 object log2Up {
-  @chiselRuntimeDeprecated
-  @deprecated("Use log2Ceil instead", "chisel3")
+  // Do not deprecate until zero-width wires fully work
+  //@chiselRuntimeDeprecated
+  //@deprecated("Use log2Ceil instead", "chisel3")
   def apply(in: BigInt): Int = Chisel.log2Up(in)
 }
 
@@ -26,8 +27,9 @@ object log2Ceil {
 
 /** Compute the log2 rounded down with min value of 1 */
 object log2Down {
-  @chiselRuntimeDeprecated
-  @deprecated("Use log2Floor instead", "chisel3")
+  // Do not deprecate until zero-width wires fully work
+  //@chiselRuntimeDeprecated
+  //@deprecated("Use log2Floor instead", "chisel3")
   def apply(in: BigInt): Int = Chisel.log2Down(in)
 }
 

--- a/src/main/scala/chisel3/util/Math.scala
+++ b/src/main/scala/chisel3/util/Math.scala
@@ -10,7 +10,8 @@ import chisel3.internal.chiselRuntimeDeprecated
 
 /** Compute the log2 rounded up with min value of 1 */
 object log2Up {
-  // Do not deprecate until zero-width wires fully work
+  // Do not deprecate until zero-width wires fully work:
+  // https://github.com/freechipsproject/chisel3/issues/847
   //@chiselRuntimeDeprecated
   //@deprecated("Use log2Ceil instead", "chisel3")
   def apply(in: BigInt): Int = Chisel.log2Up(in)
@@ -27,7 +28,8 @@ object log2Ceil {
 
 /** Compute the log2 rounded down with min value of 1 */
 object log2Down {
-  // Do not deprecate until zero-width wires fully work
+  // Do not deprecate until zero-width wires fully work:
+  // https://github.com/freechipsproject/chisel3/issues/847
   //@chiselRuntimeDeprecated
   //@deprecated("Use log2Floor instead", "chisel3")
   def apply(in: BigInt): Int = Chisel.log2Down(in)


### PR DESCRIPTION
They should not be deprecated until zero-width wires actually work. See https://github.com/freechipsproject/firrtl/pull/530.

Obviously the better solution is to make zero-width wires fully work but it's been a year and it hasn't happened. Lots of people are using chisel3 now and are pretty annoyed by the deprecation warnings when they really can't switch to `log2Ceil` and `log2Floor` yet.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

People have reported problems with this https://github.com/freechipsproject/chisel3/issues/652 and more have complained to me directly.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Undo the deprecation of log2Up and log2Down until zero-width wires work.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->