### PR TITLE
Heterogeneous Vec (MixedVec)

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -479,6 +479,21 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   def toPrintable: Printable = toPrintableHelper(elements.toList)
 }
 
+/**
+  * Mix-in for Bundles that have arbitrary Seqs of Chisel types that aren't
+  * involved in hardware construction.
+  *
+  * Used to avoid raising an error/exception when a Seq is a public member of the
+  * bundle.
+  * This is useful if we those public Seq fields in the Bundle are unrelated to
+  * hardware construction.
+  */
+trait IgnoreSeqInBundle {
+  this: Bundle =>
+
+  override def ignoreSeq: Boolean = true
+}
+
 class AutoClonetypeException(message: String) extends ChiselException(message, null)
 
 /** Base class for data types defined as a bundle of other data types.
@@ -555,8 +570,8 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
                 case d: Data => throwException("Public Seq members cannot be used to define Bundle elements " +
                   s"(found public Seq member '${m.getName}'). " +
                   "Either use a Vec() if all elements are of the same type, or HeterogeneousVec() if the elements " +
-                  "are of different types. If this Seq member is not intended to construct RTL, override ignoreSeq " +
-                  "to be true.")
+                  "are of different types. If this Seq member is not intended to construct RTL, mix in the trait " +
+                  "IgnoreSeqInBundle.")
                 case _ => // don't care about non-Data Seq
               }
               case _ => // not a Seq
@@ -568,8 +583,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
   }
 
   /**
-    * Override this to be true to avoid raising an error/exception when a Seq is a public member of the bundle.
-    * This is useful if you have public Seq fields in the Bundle that are unrelated to hardware construction.
+    * Overridden by [[IgnoreSeqInBundle]] to allow arbitrary Seqs of Chisel elements.
     */
   def ignoreSeq: Boolean = false
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -569,7 +569,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
                 // Ignore empty Seq()
                 case d: Data => throwException("Public Seq members cannot be used to define Bundle elements " +
                   s"(found public Seq member '${m.getName}'). " +
-                  "Either use a Vec() if all elements are of the same type, or HeterogeneousVec() if the elements " +
+                  "Either use a Vec if all elements are of the same type, or MixedVec if the elements " +
                   "are of different types. If this Seq member is not intended to construct RTL, mix in the trait " +
                   "IgnoreSeqInBundle.")
                 case _ => // don't care about non-Data Seq

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -119,6 +119,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   type Vec[T <: Data] = chisel3.core.Vec[T]
   type VecLike[T <: Data] = chisel3.core.VecLike[T]
   type Bundle = chisel3.core.Bundle
+  type IgnoreSeqInBundle = chisel3.core.IgnoreSeqInBundle
   type Record = chisel3.core.Record
 
   val assert = chisel3.core.assert

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -77,18 +77,21 @@ final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with 
 
   /**
     * Dynamically (via a mux) retrieve the element at the given index.
+    * This is implemented via a mux with the width of the widest element in this MixedVec.
+    * For example, a MixedVec of type Seq(UInt(4.W), UInt(8.W)) will create an 8-bit mux for this operation.
+    * Note: it is up to the user to process the resultant UInt (e.g. unflatten, etc).
     *
-    * @param index Index with which to retrieve.
-    * @return Retrieved index.
+    * @param index Index to retrieve. If the index is out of range, it will return the first element.
+    * @return Retrieved index as a UInt with the width of the widest element.
     */
-  def apply(index: UInt): T = {
+  def apply(index: UInt): UInt = {
     requireIsHardware(index, "index must be hardware")
 
     if (length < 1) {
       throw new IndexOutOfBoundsException("Collection is empty")
     }
 
-    MuxLookup(index, elts.head, elts.zipWithIndex.map { case (el, el_index) => el_index.U -> el })
+    MuxLookup(index, elts.head.asUInt, elts.zipWithIndex.map { case (el, el_index) => el_index.U -> el.asUInt })
   }
 
   /** Strong bulk connect, assigning elements in this MixedVec from elements in a Seq.

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -8,7 +8,7 @@ import chisel3.internal.naming.chiselName
 
 import scala.collection.immutable.ListMap
 
-object MixedVecWireInit {
+object MixedVecInit {
   /**
     * Construct a new wire with the given bound values.
     * This is analogous to [[chisel3.core.VecInit]].

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -1,0 +1,129 @@
+// See LICENSE for license details.
+
+package chisel3.util
+
+import chisel3._
+import chisel3.core.{Data, requireIsChiselType, requireIsHardware}
+import chisel3.internal.naming.chiselName
+
+import scala.collection.immutable.ListMap
+
+object MixedVecWireInit {
+  /**
+    * Construct a new wire with the given bound values.
+    * This is analogous to [[chisel3.core.VecInit]].
+    * @param vals Values to create a MixedVec with and assign
+    * @return MixedVec with given values assigned
+    */
+  def apply[T <: Data](vals: Seq[T]): MixedVec[T] = {
+    // Create a wire of this type.
+    val hetVecWire = Wire(MixedVec(vals.map(_.cloneTypeFull)))
+    // Assign the given vals to this new wire.
+    for ((a, b) <- hetVecWire.zip(vals)) {
+      a := b
+    }
+    hetVecWire
+  }
+}
+
+object MixedVec {
+  /**
+    * Create a MixedVec from that holds the given types.
+    * @param eltsIn Element types. Must be Chisel types.
+    * @return MixedVec with the given types.
+    */
+  def apply[T <: Data](eltsIn: Seq[T]): MixedVec[T] = new MixedVec(eltsIn)
+
+  /**
+    * Create a MixedVec from the type of the given Vec.
+    * For example, given a Vec(2, UInt(8.W)), this creates MixedVec(Seq.fill(2){UInt(8.W)}).
+    * @param vec Vec to use as template
+    * @return MixedVec analogous to the given Vec.
+    */
+  def apply[T <: Data](vec: Vec[T]): MixedVec[T] = {
+    MixedVec(Seq.fill(vec.length)(vec.sample_element))
+  }
+}
+
+/**
+  * A hardware array of elements that can hold values of different types/widths,
+  * unlike Vec which can only hold elements of the same type/width.
+  *
+  * @param eltsIn Element types. Must be Chisel types.
+  *
+  * @example {{{
+  * val v = Wire(MixedVec(Seq(UInt(8.W), UInt(16.W), UInt(32.W))))
+  * v(0) := 100.U(8.W)
+  * v(1) := 10000.U(16.W)
+  * v(2) := 101.U(32.W)
+  * }}}
+  */
+@chiselName
+final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with collection.IndexedSeq[T] {
+  // We want to create MixedVec only with Chisel types.
+  if (compileOptions.declaredTypeMustBeUnbound) {
+    eltsIn.foreach(e => requireIsChiselType(e))
+  }
+
+  // Clone the inputs so that we have our own references.
+  private val elts: IndexedSeq[T] = eltsIn.map(_.cloneTypeFull).toIndexedSeq
+
+  /**
+    * Statically (elaboration-time) retrieve the element at the given index.
+    * @param index Index with which to retrieve.
+    * @return Retrieved index.
+    */
+  def apply(index: Int): T = elts(index)
+
+  /**
+    * Dynamically (via a mux) retrieve the element at the given index.
+    *
+    * @param index Index with which to retrieve.
+    * @return Retrieved index.
+    */
+  def apply(index: UInt): T = {
+    requireIsHardware(index, "index must be hardware")
+
+    if (length < 1) {
+      throw new IndexOutOfBoundsException("Collection is empty")
+    }
+
+    MuxLookup(index, elts.head, elts.zipWithIndex.map { case (el, el_index) => el_index.U -> el })
+  }
+
+  /** Strong bulk connect, assigning elements in this MixedVec from elements in a Seq.
+    *
+    * @note the lengths of this and that must match
+    */
+  def :=(that: Seq[T]): Unit = {
+    require(this.length == that.length)
+    for ((a, b) <- this zip that)
+      a := b
+  }
+
+  /** Strong bulk connect, assigning elements in this MixedVec from elements in a Vec.
+    *
+    * @note the lengths of this and that must match
+    */
+  def :=(that: Vec[T]): Unit = {
+    require(this.length == that.length)
+    for ((a, b) <- this zip that)
+      a := b
+  }
+
+  /**
+    * Get the length of this MixedVec.
+    * @return Number of elements in this MixedVec.
+    */
+  def length: Int = elts.length
+
+  override val elements = ListMap(elts.zipWithIndex.map { case (element, index) => (index.toString, element) }: _*)
+
+  // Need to re-clone again since we could have been bound since object creation.
+  override def cloneType: this.type = MixedVec(elts.map(_.cloneTypeFull)).asInstanceOf[this.type]
+
+  // IndexedSeq has its own hashCode/equals that we must not use
+  override def hashCode: Int = super[Record].hashCode
+
+  override def equals(that: Any): Boolean = super[Record].equals(that)
+}

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -75,25 +75,6 @@ final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with 
     */
   def apply(index: Int): T = elts(index)
 
-  /**
-    * Dynamically (via a mux) retrieve the element at the given index.
-    * This is implemented via a mux with the width of the widest element in this MixedVec.
-    * For example, a MixedVec of type Seq(UInt(4.W), UInt(8.W)) will create an 8-bit mux for this operation.
-    * Note: it is up to the user to process the resultant UInt (e.g. unflatten, etc).
-    *
-    * @param index Index to retrieve. If the index is out of range, it will return the first element.
-    * @return Retrieved index as a UInt with the width of the widest element.
-    */
-  def apply(index: UInt): UInt = {
-    requireIsHardware(index, "index must be hardware")
-
-    if (length < 1) {
-      throw new IndexOutOfBoundsException("Collection is empty")
-    }
-
-    MuxLookup(index, elts.head.asUInt, elts.zipWithIndex.map { case (el, el_index) => el_index.U -> el.asUInt })
-  }
-
   /** Strong bulk connect, assigning elements in this MixedVec from elements in a Seq.
     *
     * @note the lengths of this and that must match

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -101,16 +101,6 @@ final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with 
       a := b
   }
 
-  /** Strong bulk connect, assigning elements in this MixedVec from elements in a Vec.
-    *
-    * @note the lengths of this and that must match
-    */
-  def :=(that: Vec[T]): Unit = {
-    require(this.length == that.length)
-    for ((a, b) <- this zip that)
-      a := b
-  }
-
   /**
     * Get the length of this MixedVec.
     * @return Number of elements in this MixedVec.

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -24,6 +24,13 @@ object MixedVecInit {
     }
     hetVecWire
   }
+
+  /**
+    * Construct a new wire with the given bound values.
+    * This is analogous to [[chisel3.core.VecInit]].
+    * @return MixedVec with given values assigned
+    */
+  def apply[T <: Data](val0: T, vals: T*): MixedVec[T] = apply(val0 +: vals.toSeq)
 }
 
 object MixedVec {
@@ -33,6 +40,19 @@ object MixedVec {
     * @return MixedVec with the given types.
     */
   def apply[T <: Data](eltsIn: Seq[T]): MixedVec[T] = new MixedVec(eltsIn)
+
+  /**
+    * Create a MixedVec from that holds the given types.
+    * The types passed to this constructor must be Chisel types.
+    * @return MixedVec with the given types.
+    */
+  def apply[T <: Data](val0: T, vals: T*): MixedVec[T] = new MixedVec(val0 +: vals.toSeq)
+
+  /**
+    * Create a new MixedVec from an unbound MixedVec type.
+    * @return MixedVec with the given types.
+    */
+  def apply[T <: Data](mixedVec: MixedVec[T]): MixedVec[T] = new MixedVec(mixedVec.elts)
 
   /**
     * Create a MixedVec from the type of the given Vec.

--- a/src/main/scala/chisel3/util/util.scala
+++ b/src/main/scala/chisel3/util/util.scala
@@ -11,5 +11,4 @@ package object util {
   type ValidIO[+T <: Data] = chisel3.util.Valid[T]
   val ValidIO = chisel3.util.Valid
   val DecoupledIO = chisel3.util.Decoupled
-
 }

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.core.IgnoreSeqInBundle
 import chisel3.testers.BasicTester
 
 trait BundleSpecUtils {
@@ -91,9 +92,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
       new BasicTester {
         val m = Module(new Module {
           val io = IO(new Bundle {
-            val b = new BadSeqBundle {
-              override def ignoreSeq = true
-            }
+            val b = new BadSeqBundle with IgnoreSeqInBundle
           })
         })
         stop()

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -25,6 +25,11 @@ trait BundleSpecUtils {
     override def cloneType = (new BundleBar).asInstanceOf[this.type]
   }
 
+  class BadSeqBundle extends Bundle {
+    val bar = Seq(UInt(16.W), UInt(8.W), UInt(4.W))
+    override def cloneType = (new BadSeqBundle).asInstanceOf[this.type]
+  }
+
   class MyModule(output: Bundle, input: Bundle) extends Module {
     val io = IO(new Bundle {
       val in = Input(input)
@@ -67,5 +72,48 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
     (the [ChiselException] thrownBy {
       elaborate { new MyModule(new BundleFoo, new BundleFooBar) }
     }).getMessage should include ("Left Record missing field")
+  }
+
+  "Bundles" should "not be able to use Seq for constructing hardware" in {
+    (the[ChiselException] thrownBy {
+      elaborate {
+        new Module {
+          val io = IO(new Bundle {
+            val b = new BadSeqBundle
+          })
+        }
+      }
+    }).getMessage should include("Public Seq members cannot be used to define Bundle elements")
+  }
+
+  "Bundles" should "be allowed to have Seq if need be" in {
+    assertTesterPasses {
+      new BasicTester {
+        val m = Module(new Module {
+          val io = IO(new Bundle {
+            val b = new BadSeqBundle {
+              override def ignoreSeq = true
+            }
+          })
+        })
+        stop()
+      }
+    }
+  }
+
+  "Bundles" should "be allowed to have non-Chisel Seqs" in {
+    assertTesterPasses {
+      new BasicTester {
+        val m = Module(new Module {
+          val io = IO(new Bundle {
+            val f = Output(UInt(8.W))
+            val unrelated = (0 to 10).toSeq
+            val unrelated2 = Seq("Hello", "World", "Chisel")
+          })
+          io.f := 0.U
+        })
+        stop()
+      }
+    }
   }
 }

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -9,7 +9,7 @@ import chisel3.util._
 import org.scalacheck.Shrink
 
 class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
-  val v = MixedVecWireInit(values.map(v => v.U(w.W)))
+  val v = MixedVecInit(values.map(v => v.U(w.W)))
   for ((a, b) <- v.zip(values)) {
     assert(a === b.asUInt)
   }
@@ -17,7 +17,7 @@ class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
 }
 
 class MixedVecRegTester(w: Int, values: List[Int]) extends BasicTester {
-  val valuesInit = MixedVecWireInit(values.map(v => v.U(w.W)))
+  val valuesInit = MixedVecInit(values.map(v => v.U(w.W)))
   val reg = Reg(MixedVec(chiselTypeOf(valuesInit)))
 
   val doneReg = RegInit(false.B)
@@ -44,7 +44,7 @@ class MixedVecIOPassthroughModule[T <: Data](hvec: MixedVec[T]) extends Module {
 }
 
 class MixedVecIOTester(boundVals: Seq[Data]) extends BasicTester {
-  val v = MixedVecWireInit(boundVals)
+  val v = MixedVecInit(boundVals)
   val dut = Module(new MixedVecIOPassthroughModule(MixedVec(chiselTypeOf(v))))
   dut.io.in := v
   for ((a, b) <- dut.io.out.zip(boundVals)) {
@@ -102,7 +102,7 @@ class MixedVecSmallTestBundle extends Bundle {
 
 class MixedVecFromVecTester extends BasicTester {
   val wire = Wire(MixedVec(Vec(3, UInt(8.W))))
-  wire := MixedVecWireInit(Seq(20.U, 40.U, 80.U))
+  wire := MixedVecInit(Seq(20.U, 40.U, 80.U))
 
   assert(wire(0) === 20.U)
   assert(wire(1) === 40.U)

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -74,20 +74,18 @@ class MixedVecZeroEntryTester extends BasicTester {
   stop()
 }
 
-class MixedVecUIntDynamicIndexTester(n: Int) extends BasicTester {
-  val wire = Wire(MixedVec(Seq.fill(n) { UInt() }))
-
-  val (cycle, done) = Counter(true.B, n)
+class MixedVecUIntDynamicIndexTester extends BasicTester {
+  val wire = Wire(MixedVec(Seq(UInt(8.W), UInt(16.W), UInt(4.W), UInt(7.W))))
+  val n = wire.length
 
   for (i <- 0 until n) {
-    when(cycle === i.U) {
-      wire(i) := i.U
-    } .otherwise {
-      wire(i) := DontCare
-    }
+    wire(i) := i.U
   }
 
-  assert(wire(cycle) === cycle)
+  val vecWire = VecInit(wire.toSeq)
+
+  val (cycle, done) = Counter(true.B, n)
+  assert(vecWire(cycle) === cycle)
 
   when (done) { stop() }
 }
@@ -100,50 +98,6 @@ class MixedVecTestBundle extends Bundle {
 class MixedVecSmallTestBundle extends Bundle {
   val x = UInt(3.W)
   val y = UInt(3.W)
-}
-
-class MixedVecDynamicIndexTester extends BasicTester {
-  val wire = Wire(MixedVec(Seq(UInt(8.W), SInt(8.W), Bool(), new MixedVecTestBundle, new MixedVecSmallTestBundle)))
-
-  val val0 = 163.U(8.W)
-  val val1 = (-96).S(8.W)
-  val val2 = true.B
-  val val3 = 126.U(8.W)
-  val val4 = 6.U(3.W)
-
-  wire(0) := val0
-  wire(1) := val1
-  wire(2) := val2
-  val wire3 = wire(3).asInstanceOf[MixedVecTestBundle]
-  wire3.x := val3
-  wire3.y := val3
-  val wire4 = wire(4).asInstanceOf[MixedVecSmallTestBundle]
-  wire4.x := val4
-  wire4.y := val4
-
-  val (cycle, done) = Counter(true.B, wire.length)
-  val currentData = wire(cycle)
-
-  when(cycle === 0.U) {
-    assert(currentData === val0)
-  } .elsewhen(cycle === 1.U) {
-    // We need to trim the width appropriately before calling asSInt
-    assert(currentData(7, 0).asSInt === val1)
-  } .elsewhen(cycle === 2.U) {
-    assert(currentData === val2.asUInt)
-  } .elsewhen(cycle === 3.U) {
-    val currentBundle = currentData.asTypeOf(new MixedVecTestBundle)
-    assert(currentBundle.x === val3)
-    assert(currentBundle.y === val3)
-  } .otherwise {
-    val currentBundle = currentData.asTypeOf(new MixedVecSmallTestBundle)
-    assert(currentBundle.x === val4)
-    assert(currentBundle.y === val4)
-  }
-
-  when(done) {
-    stop()
-  }
 }
 
 class MixedVecFromVecTester extends BasicTester {
@@ -264,12 +218,8 @@ class MixedVecSpec extends ChiselPropSpec {
     assertTesterPasses { new MixedVecZeroEntryTester }
   }
 
-  property("MixedVecs of UInts should be dynamically indexable") {
-    assertTesterPasses{ new MixedVecUIntDynamicIndexTester(4) }
-  }
-
-  property("MixedVecs in general should be dynamically indexable") {
-    assertTesterPasses{ new MixedVecDynamicIndexTester }
+  property("MixedVecs of UInts should be dynamically indexable (via VecInit)") {
+    assertTesterPasses{ new MixedVecUIntDynamicIndexTester }
   }
 
   property("MixedVecs should be creatable from Vecs") {

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -1,0 +1,253 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.core.Binding
+import chisel3.testers.BasicTester
+import chisel3.util._
+import org.scalacheck.Shrink
+
+class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
+  val v = MixedVecWireInit(values.map(v => v.U(w.W)))
+  for ((a, b) <- v.zip(values)) {
+    assert(a === b.asUInt)
+  }
+  stop()
+}
+
+class MixedVecRegTester(w: Int, values: List[Int]) extends BasicTester {
+  val valuesInit = MixedVecWireInit(values.map(v => v.U(w.W)))
+  val reg = Reg(MixedVec(chiselTypeOf(valuesInit)))
+
+  val doneReg = RegInit(false.B)
+  doneReg := true.B
+
+  when(!doneReg) {
+    // First cycle: write to reg
+    reg := valuesInit
+  }.otherwise {
+    // Second cycle: read back from reg
+    for ((a, b) <- reg.zip(values)) {
+      assert(a === b.asUInt)
+    }
+    stop()
+  }
+}
+
+class MixedVecIOPassthroughModule[T <: Data](hvec: MixedVec[T]) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(hvec)
+    val out = Output(hvec)
+  })
+  io.out := io.in
+}
+
+class MixedVecIOTester(boundVals: Seq[Data]) extends BasicTester {
+  val v = MixedVecWireInit(boundVals)
+  val dut = Module(new MixedVecIOPassthroughModule(MixedVec(chiselTypeOf(v))))
+  dut.io.in := v
+  for ((a, b) <- dut.io.out.zip(boundVals)) {
+    assert(a.asUInt === b.asUInt)
+  }
+  stop()
+}
+
+class MixedVecZeroEntryTester extends BasicTester {
+  def zeroEntryMixedVec: MixedVec[Data] = MixedVec(Seq.empty)
+
+  require(zeroEntryMixedVec.getWidth == 0)
+
+  val bundleWithZeroEntryVec = new Bundle {
+    val foo = Bool()
+    val bar = zeroEntryMixedVec
+  }
+  require(0.U.asTypeOf(bundleWithZeroEntryVec).getWidth == 1)
+  require(bundleWithZeroEntryVec.asUInt.getWidth == 1)
+
+  val m = Module(new Module {
+    val io = IO(Output(bundleWithZeroEntryVec))
+    io.foo := false.B
+  })
+  WireInit(m.io.bar)
+
+  stop()
+}
+
+class MixedVecDynamicIndexTester(n: Int) extends BasicTester {
+  val wire = Wire(MixedVec(Seq.fill(n) { UInt() }))
+
+  val (cycle, done) = Counter(true.B, n)
+
+  for (i <- 0 until n) {
+    when(cycle === i.U) {
+      wire(i) := i.U
+    } .otherwise {
+      wire(i) := DontCare
+    }
+  }
+
+  assert(wire(cycle) === cycle)
+
+  when (done) { stop() }
+}
+
+class MixedVecFromVecTester extends BasicTester {
+  val wire = Wire(MixedVec(Vec(3, UInt(8.W))))
+  wire := MixedVecWireInit(Seq(20.U, 40.U, 80.U))
+
+  assert(wire(0) === 20.U)
+  assert(wire(1) === 40.U)
+  assert(wire(2) === 80.U)
+
+  stop()
+}
+
+class MixedVecConnectWithVecTester extends BasicTester {
+  val mixedVecType = MixedVec(Vec(3, UInt(8.W)))
+
+  val m = Module(new MixedVecIOPassthroughModule(mixedVecType))
+  m.io.in := VecInit(Seq(20.U, 40.U, 80.U))
+  val wire = m.io.out
+
+  assert(wire(0) === 20.U)
+  assert(wire(1) === 40.U)
+  assert(wire(2) === 80.U)
+
+  stop()
+}
+
+class MixedVecConnectWithSeqTester extends BasicTester {
+  val mixedVecType = MixedVec(Vec(3, UInt(8.W)))
+
+  val m = Module(new MixedVecIOPassthroughModule(mixedVecType))
+  m.io.in := Seq(20.U, 40.U, 80.U)
+  val wire = m.io.out
+
+  assert(wire(0) === 20.U)
+  assert(wire(1) === 40.U)
+  assert(wire(2) === 80.U)
+
+  stop()
+}
+
+class MixedVecOneBitTester extends BasicTester {
+  val flag = RegInit(false.B)
+
+  val oneBit = Reg(MixedVec(Seq(UInt(1.W))))
+  when (!flag) {
+    oneBit(0) := 1.U(1.W)
+    flag := true.B
+  } .otherwise {
+    assert(oneBit(0) === 1.U)
+    assert(oneBit.asUInt === 1.U)
+    stop()
+  }
+}
+
+class MixedVecSpec extends ChiselPropSpec {
+  // Disable shrinking on error.
+  // Not sure why this needs to be here, but the test behaves very weirdly without it (e.g. empty Lists, etc).
+  implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
+  implicit val noShrinkInt = Shrink[Int](_ => Stream.empty)
+
+  property("MixedVecs should be assignable") {
+    forAll(safeUIntN(8)) { case (w: Int, v: List[Int]) =>
+      assertTesterPasses {
+        new MixedVecAssignTester(w, v)
+      }
+    }
+  }
+
+  property("MixedVecs should be usable as the type for Reg()") {
+    forAll(safeUIntN(8)) { case (w: Int, v: List[Int]) =>
+      assertTesterPasses {
+        new MixedVecRegTester(w, v)
+      }
+    }
+  }
+
+  property("MixedVecs should be passed through IO") {
+    forAll(safeUIntN(8)) { case (w: Int, v: List[Int]) =>
+      assertTesterPasses {
+        new MixedVecIOTester(v.map(i => i.U(w.W)))
+      }
+    }
+  }
+
+  property("MixedVecs should work with mixed types") {
+    assertTesterPasses {
+      new MixedVecIOTester(Seq(true.B, 168.U(8.W), 888.U(10.W), -3.S))
+    }
+  }
+
+  property("MixedVecs should not be able to take hardware types") {
+    a [Binding.ExpectedChiselTypeException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {})
+        val hw = Wire(MixedVec(Seq(UInt(8.W), Bool())))
+        val illegal = MixedVec(hw)
+      })
+    }
+    a [Binding.ExpectedChiselTypeException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {})
+        val hw = Reg(MixedVec(Seq(UInt(8.W), Bool())))
+        val illegal = MixedVec(hw)
+      })
+    }
+    a [Binding.ExpectedChiselTypeException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {
+          val v = Input(MixedVec(Seq(UInt(8.W), Bool())))
+        })
+        val illegal = MixedVec(io.v)
+      })
+    }
+  }
+
+  property("MixedVecs with zero entries should compile and have zero width") {
+    assertTesterPasses { new MixedVecZeroEntryTester }
+  }
+
+  property("MixedVecs should be dynamically indexable") {
+    assertTesterPasses{ new MixedVecDynamicIndexTester(4) }
+  }
+
+  property("MixedVecs should be creatable from Vecs") {
+    assertTesterPasses{ new MixedVecFromVecTester }
+  }
+
+  property("It should be possible to bulk connect a MixedVec and a Vec") {
+    assertTesterPasses{ new MixedVecConnectWithVecTester }
+  }
+
+  property("It should be possible to bulk connect a MixedVec and a Seq") {
+    assertTesterPasses{ new MixedVecConnectWithSeqTester }
+  }
+
+  property("MixedVecs of a single 1 bit element should compile and work") {
+    assertTesterPasses { new MixedVecOneBitTester }
+  }
+
+  property("Connecting a MixedVec and something of different size should report a ChiselException") {
+    an [IllegalArgumentException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {
+          val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
+        })
+        val seq = Seq.fill(5)(0.U)
+        io.out := seq
+      })
+    }
+    an [IllegalArgumentException] should be thrownBy {
+      elaborate(new Module {
+        val io = IO(new Bundle {
+          val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
+        })
+        val seq = VecInit(Seq(100.U(8.W)))
+        io.out := seq
+      })
+    }
+  }
+}

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -159,6 +159,25 @@ class MixedVecSpec extends ChiselPropSpec {
   implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
   implicit val noShrinkInt = Shrink[Int](_ => Stream.empty)
 
+  property("MixedVec varargs API should work") {
+    assertTesterPasses {
+      new BasicTester {
+        val wire = Wire(MixedVec(UInt(1.W), UInt(8.W)))
+        wire(0) := 1.U
+        wire(1) := 101.U
+
+        chisel3.assert(wire(0) === 1.U)
+        chisel3.assert(wire(1) + 1.U === 102.U)
+
+        val wireInit = MixedVecInit(1.U, 101.U)
+        chisel3.assert(wireInit(0) === 1.U)
+        chisel3.assert(wireInit(1) + 1.U === 102.U)
+
+        stop()
+      }
+    }
+  }
+
   property("MixedVecs should be assignable") {
     forAll(safeUIntN(8)) { case (w: Int, v: List[Int]) =>
       assertTesterPasses {


### PR DESCRIPTION
As discussed with @jackkoenig, this implements the action items which fell out of our discussion in #844.

This PR creates a new `HeterogeneousVec` type inspired by rocket-chip's `HeterogeneousBag` or `HetVec` from dsptools. This is a dynamically indexable type like `Vec` but supports different underlying types - e.g. `myVec(0)` could return a `UInt(8.W)` while `myVec(1)` could return `UInt(16.W)`, which is not supported by `Vec`, and as shown in #844 we cannot use the Seq alternative in Bundle construction as we can in Module construction.

Additionally, as discussed in #844, this PR also adds an (optionally-overridable) warning when public `Seq[Data]` members are present so that users can get a better error message than the current one. The ability to have non-Chisel `Data` `Seq`s are unaffected. (along with unit test demonstrating this)

As for the name, HVec is ambiguous (can be confused for Haskell HList or in VLSI can be confused for *hierarchical*) as noted in #844. `HetVec` is another option as noted in #844 as well but seems strange as a user (what is "Het"?). Another option that seems reasonable and short is `MixedVec`, which seems preferable.

For now the compromise is to make the class name `HeterogeneousVec` and add shorter aliases for `HetVec` and `MixedVec`. In addition, rocket-chip has been using the longer name `HeterogeneousBag` without much issue.

<!-- choose one -->
**Type of change**: bug report | feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
- Add a new dynamically indexable sequence like Vec that supports different underlying widths/types.