### PR TITLE
Ensure names work for bundles and literals.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -592,8 +592,7 @@ trait UIntFactory {
     val lit = ULit(value, width)
     val result = new UInt(lit.width)
     // Bind result to being an Literal
-    result.bind(ElementLitBinding(lit))
-    result
+    lit.bindLitArg(result)
   }
 
   /** Create a UInt with the specified range */
@@ -745,8 +744,7 @@ trait SIntFactory {
   protected[chisel3] def Lit(value: BigInt, width: Width): SInt = {
     val lit = SLit(value, width)
     val result = new SInt(lit.width)
-    result.bind(ElementLitBinding(lit))
-    result
+    lit.bindLitArg(result)
   }
 }
 
@@ -816,8 +814,9 @@ trait BoolFactory {
    */
   protected[chisel3] def Lit(x: Boolean): Bool = {
     val result = new Bool()
-    result.bind(ElementLitBinding(ULit(if (x) 1 else 0, Width(1))))
-    result
+    val lit = ULit(if (x) 1 else 0, Width(1))
+    // Ensure we have something capable of generating a name.
+    lit.bindLitArg(result)
   }
 }
 
@@ -1074,8 +1073,8 @@ object FixedPoint {
   def apply(value: BigInt, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
     val lit = FPLit(value, width, binaryPoint)
     val newLiteral = new FixedPoint(lit.width, lit.binaryPoint)
-    newLiteral.bind(ElementLitBinding(lit))
-    newLiteral
+    // Ensure we have something capable of generating a name.
+    lit.bindLitArg(newLiteral)
   }
 
   /**

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -112,11 +112,15 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def setRef(parent: HasId, index: Int): Unit = setRef(Index(Node(parent), ILit(index)))
   private[chisel3] def setRef(parent: HasId, index: UInt): Unit = setRef(Index(Node(parent), index.ref))
   private[chisel3] def getRef: Arg = _ref.get
+  private[chisel3] def getOptionRef: Option[Arg] = _ref
 
   // Implementation of public methods.
   def instanceName: String = _parent match {
     case Some(p) => p._component match {
-      case Some(c) => getRef fullName c
+      case Some(c) => _ref match {
+        case Some(arg) => arg fullName c
+        case None => suggested_name.getOrElse("??")
+      }
       case None => throwException("signalName/pathName should be called after circuit elaboration")
     }
     case None => throwException("this cannot happen")

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -24,25 +24,31 @@ class InstanceNameModule extends Module {
 
 class InstanceNameSpec extends ChiselFlatSpec {
   behavior of "instanceName"
-
+  val moduleName = "InstanceNameModule"
   var m: InstanceNameModule = _
   elaborate { m = new InstanceNameModule; m }
 
   it should "work with module IO" in {
-    println(m.io.pathName)
+    val io = m.io.pathName
+    assert(io == moduleName + ".io")
   }
 
   it should "work with internal vals" in {
-    println(m.x.pathName)
-    println(m.y.pathName)
-    println(m.z.pathName)
+    val x = m.x.pathName
+    val y = m.y.pathName
+    val z = m.z.pathName
+    assert(x == moduleName + ".UInt<2>(\"h03\")")
+    assert(y == moduleName + ".y")
+    assert(z == moduleName + ".z")
   }
 
   it should "work with bundle elements" in {
-    println(m.z.foo.pathName)
+    val foo = m.z.foo.pathName
+    assert(foo == moduleName + ".z.foo")
   }
 
   it should "work with modules" in {
-    println(m.q.pathName)
+    val q = m.q.pathName
+    assert(q == moduleName + ".q")
   }
 }

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -1,0 +1,48 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental.{DataMirror, FixedPoint}
+import chisel3.testers.BasicTester
+
+class InstanceNameModule extends Module {
+  val io = IO(new Bundle {
+    val foo = Input(UInt(32.W))
+    val bar = Output(UInt(32.W))
+  })
+  val x = 3.U
+  val y = UInt(8.W)
+  val z = new Bundle {
+    val foo = UInt(8.W)
+  }
+
+  val q = Module(new util.Queue(UInt(32.W), 4))
+
+  io.bar := io.foo + x
+}
+
+class InstanceNameSpec extends ChiselFlatSpec {
+  behavior of "instanceName"
+
+  var m: InstanceNameModule = _
+  elaborate { m = new InstanceNameModule; m }
+
+  it should "work with module IO" in {
+    println(m.io.pathName)
+  }
+
+  it should "work with internal vals" in {
+    println(m.x.pathName)
+    println(m.y.pathName)
+    println(m.z.pathName)
+  }
+
+  it should "work with bundle elements" in {
+    println(m.z.foo.pathName)
+  }
+
+  it should "work with modules" in {
+    println(m.q.pathName)
+  }
+}


### PR DESCRIPTION

**Related issue**: #852
**Type of change**: bug report
**Impact**: no functional change

**Development Phase**:  implementation
An alternative solution would be to address the "point of failure" - the removal of forceName in UserModule.scala

**Release Notes**
Ensure that `instanceName` can be called on any signal.