### PR TITLE
Fix use of read-only refs on rhs of connect in compatibility mode

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -77,9 +77,9 @@ sealed abstract class Aggregate extends Data {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Connect.
     if (that == DontCare) {
-      pushCommand(DefInvalid(sourceInfo, this.lref))
+      pushCommand(DefInvalid(sourceInfo, Node(this)))
     } else {
-      pushCommand(BulkConnect(sourceInfo, this.lref, that.lref))
+      pushCommand(BulkConnect(sourceInfo, Node(this), Node(that)))
     }
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -36,9 +36,9 @@ abstract class Element(private[chisel3] val width: Width) extends Data {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Connect.
     if (that == DontCare) {
-      pushCommand(DefInvalid(sourceInfo, this.lref))
+      pushCommand(DefInvalid(sourceInfo, Node(this)))
     } else {
-      pushCommand(Connect(sourceInfo, this.lref, that.ref))
+      pushCommand(Connect(sourceInfo, Node(this), that.ref))
     }
   }
 }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -304,4 +304,22 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
     }
   }
 
+  "Mux return value" should "be able to be used on the RHS" in {
+    import Chisel._
+    elaborate(new Module {
+      val gen = new Bundle { val foo = UInt(width = 8) }
+      val io = new Bundle {
+        val a = Vec(2, UInt(width = 8)).asInput
+        val b = Vec(2, UInt(width = 8)).asInput
+        val c = gen.asInput
+        val d = gen.asInput
+        val en = Bool(INPUT)
+        val y = Vec(2, UInt(width = 8)).asOutput
+        val z = gen.asOutput
+      }
+      io.y := Mux(io.en, io.a, io.b)
+      io.z := Mux(io.en, io.c, io.d)
+    })
+  }
+
 }


### PR DESCRIPTION
https://github.com/freechipsproject/chisel3/pull/820 changed the implementations of `ref` and `lref` to do error checking which was problematic for compatibility mode. I changed `legacyConnect` to manually use the old implementation of `Node(this)` which fixes the issue in this instance. I'm a bit worried that other examples of this can creep up so we'll have to be vigilant but I have searched for all uses of `ref` and `lref` and I can't see any other problematic cases.

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
Fix bug preventing the use of the output of aggregate Muxes on the rhs of a connection in compatibility mode.