### PR TITLE
Add support for Input() and Output() and test for same.

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -19,6 +19,9 @@ package object Chisel {     // scalastyle:ignore package.object.name
   case object OUTPUT extends Direction
   case object NODIR extends Direction
 
+  val Input   = chisel3.core.Input
+  val Output  = chisel3.core.Output
+
   object Flipped {
     def apply[T<:Data](target: T): T = chisel3.core.Flipped[T](target)
   }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -322,4 +322,18 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
     })
   }
 
+  "Chisel3 IO constructs" should "be useable in Chisel2" in {
+    import Chisel._
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val in = Input(Bool())
+        val foo = Output(Bool())
+        val bar = Flipped(Bool())
+      })
+      Chisel.assert(io.in.dir == INPUT)
+      Chisel.assert(io.foo.dir == OUTPUT)
+      Chisel.assert(io.bar.dir == INPUT)
+    })
+  }
+
 }


### PR DESCRIPTION
**Related issue**: #861

**Type of change**: bug report

**Impact**: API addition (no impact on existing code)

**Development Phase**: implementation

**Release Notes**
 `Input()` and `Output()` have been available in Chisel2 since ucb-bar/chisel2-deprecated#734. Provide support for them in the compatibility package.

