### PR TITLE
Cleanup implicit conversions

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/package.scala
@@ -23,7 +23,7 @@ package chisel3 {
     * interpreting calls that have a non-Width parameter as a chained apply, otherwise things like
     * `0.asUInt(16)` (instead of `16.W`) compile without error and produce undesired results.
     */
-    implicit class fromBigIntToLiteral(val bigint: BigInt) {
+    implicit class fromBigIntToLiteral(bigint: BigInt) {
       /** Int to UInt conversion, recommended style for constants.
         */
       def U: UInt = UInt.Lit(bigint, Width())  // scalastyle:ignore method.name
@@ -51,10 +51,10 @@ package chisel3 {
       def asSInt(width: Width): SInt = SInt.Lit(bigint, width)
     }
 
-    implicit class fromIntToLiteral(val int: Int) extends fromBigIntToLiteral(int)
-    implicit class fromLongToLiteral(val long: Long) extends fromBigIntToLiteral(long)
+    implicit class fromIntToLiteral(int: Int) extends fromBigIntToLiteral(int)
+    implicit class fromLongToLiteral(long: Long) extends fromBigIntToLiteral(long)
 
-    implicit class fromStringToLiteral(val str: String) {
+    implicit class fromStringToLiteral(str: String) {
       /** String to UInt parse, recommended style for constants.
         */
       def U: UInt = str.asUInt() // scalastyle:ignore method.name
@@ -85,7 +85,7 @@ package chisel3 {
       }
     }
 
-    implicit class fromBooleanToLiteral(val boolean: Boolean) {
+    implicit class fromBooleanToLiteral(boolean: Boolean) {
       /** Boolean to Bool conversion, recommended style for constants.
         */
       def B: Bool = Bool.Lit(boolean)  // scalastyle:ignore method.name
@@ -96,7 +96,7 @@ package chisel3 {
     }
 
     //scalastyle:off method.name
-    implicit class fromDoubleToLiteral(val double: Double) {
+    implicit class fromDoubleToLiteral(double: Double) {
       @deprecated("Use notation <double>.F(<binary_point>.BP) instead", "chisel3")
       def F(binaryPoint: Int): FixedPoint = FixedPoint.fromDouble(double, binaryPoint = binaryPoint)
       def F(binaryPoint: BinaryPoint): FixedPoint = {
@@ -107,11 +107,11 @@ package chisel3 {
       }
     }
 
-    implicit class fromIntToWidth(val int: Int) {
+    implicit class fromIntToWidth(int: Int) {
       def W: Width = Width(int)  // scalastyle:ignore method.name
     }
 
-    implicit class fromIntToBinaryPoint(val int: Int) {
+    implicit class fromIntToBinaryPoint(int: Int) {
       def BP: BinaryPoint = BinaryPoint(int)  // scalastyle:ignore method.name
     }
   }

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -26,13 +26,13 @@ package object Chisel {     // scalastyle:ignore package.object.name
     def apply[T<:Data](target: T): T = chisel3.core.Flipped[T](target)
   }
 
-  implicit class AddDirectionToData[T<:Data](val target: T) extends AnyVal {
+  implicit class AddDirectionToData[T<:Data](target: T) {
     def asInput: T = chisel3.core.Input(target)
     def asOutput: T = chisel3.core.Output(target)
     def flip(): T = chisel3.core.Flipped(target)
   }
 
-  implicit class AddDirMethodToData[T<:Data](val target: T) extends AnyVal {
+  implicit class AddDirMethodToData[T<:Data](target: T) {
     import chisel3.core.{DataMirror, ActualDirection, requireIsHardware}
     def dir: Direction = {
       requireIsHardware(target) // This has the side effect of calling _autoWrapPorts
@@ -46,7 +46,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
       }
     }
   }
-  implicit class cloneTypeable[T <: Data](val target: T) extends AnyVal {
+  implicit class cloneTypeable[T <: Data](target: T) {
     import chisel3.core.DataMirror
     def chiselCloneType: T = {
       DataMirror.internal.chiselTypeClone(target).asInstanceOf[T]
@@ -80,7 +80,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   type Clock = chisel3.core.Clock
 
   // Implicit conversion to allow fromBits because it's being deprecated in chisel3
-  implicit class fromBitsable[T <: Data](val data: T) {
+  implicit class fromBitsable[T <: Data](data: T) {
     import chisel3.core.CompileOptions
     import chisel3.internal.sourceinfo.SourceInfo
 
@@ -352,12 +352,12 @@ package object Chisel {     // scalastyle:ignore package.object.name
   val when = chisel3.core.when
   type WhenContext = chisel3.core.WhenContext
 
-  implicit class fromBigIntToLiteral(val x: BigInt) extends chisel3.core.fromBigIntToLiteral(x)
-  implicit class fromtIntToLiteral(val x: Int) extends chisel3.core.fromIntToLiteral(x)
-  implicit class fromtLongToLiteral(val x: Long) extends chisel3.core.fromLongToLiteral(x)
-  implicit class fromStringToLiteral(val x: String) extends chisel3.core.fromStringToLiteral(x)
-  implicit class fromBooleanToLiteral(val x: Boolean) extends chisel3.core.fromBooleanToLiteral(x)
-  implicit class fromIntToWidth(val x: Int) extends chisel3.core.fromIntToWidth(x)
+  implicit class fromBigIntToLiteral(x: BigInt) extends chisel3.core.fromBigIntToLiteral(x)
+  implicit class fromtIntToLiteral(x: Int) extends chisel3.core.fromIntToLiteral(x)
+  implicit class fromtLongToLiteral(x: Long) extends chisel3.core.fromLongToLiteral(x)
+  implicit class fromStringToLiteral(x: String) extends chisel3.core.fromStringToLiteral(x)
+  implicit class fromBooleanToLiteral(x: Boolean) extends chisel3.core.fromBooleanToLiteral(x)
+  implicit class fromIntToWidth(x: Int) extends chisel3.core.fromIntToWidth(x)
 
   type BackendCompilationUtilities = firrtl.util.BackendCompilationUtilities
   val Driver = chisel3.Driver

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -46,7 +46,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   val Clock = chisel3.core.Clock
   type Clock = chisel3.core.Clock
 
-  implicit class AddDirectionToData[T<:Data](val target: T) extends AnyVal {
+  implicit class AddDirectionToData[T<:Data](target: T) {
     @chiselRuntimeDeprecated
     @deprecated("Input(Data) should be used over Data.asInput", "chisel3")
     def asInput: T = Input(target)
@@ -60,7 +60,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     def flip(): T = Flipped(target)
   }
 
-  implicit class fromBitsable[T <: Data](val data: T) {
+  implicit class fromBitsable[T <: Data](data: T) {
     import chisel3.core.CompileOptions
     import chisel3.internal.sourceinfo.SourceInfo
 
@@ -71,7 +71,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     }
   }
 
-  implicit class cloneTypeable[T <: Data](val target: T) extends AnyVal {
+  implicit class cloneTypeable[T <: Data](target: T) {
     @chiselRuntimeDeprecated
     @deprecated("chiselCloneType is deprecated, use chiselTypeOf(...) to get the Chisel Type of a hardware object", "chisel3")
     def chiselCloneType: T = {
@@ -355,16 +355,16 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
   implicit def string2Printable(str: String): Printable = PString(str)
 
-  implicit class fromBigIntToLiteral(val x: BigInt) extends chisel3.core.fromBigIntToLiteral(x)
-  implicit class fromtIntToLiteral(val x: Int) extends chisel3.core.fromIntToLiteral(x)
-  implicit class fromtLongToLiteral(val x: Long) extends chisel3.core.fromLongToLiteral(x)
-  implicit class fromStringToLiteral(val x: String) extends chisel3.core.fromStringToLiteral(x)
-  implicit class fromBooleanToLiteral(val x: Boolean) extends chisel3.core.fromBooleanToLiteral(x)
-  implicit class fromDoubleToLiteral(val x: Double) extends chisel3.core.fromDoubleToLiteral(x)
-  implicit class fromIntToWidth(val x: Int) extends chisel3.core.fromIntToWidth(x)
-  implicit class fromIntToBinaryPoint(val x: Int) extends chisel3.core.fromIntToBinaryPoint(x)
+  implicit class fromBigIntToLiteral(x: BigInt) extends chisel3.core.fromBigIntToLiteral(x)
+  implicit class fromtIntToLiteral(x: Int) extends chisel3.core.fromIntToLiteral(x)
+  implicit class fromtLongToLiteral(x: Long) extends chisel3.core.fromLongToLiteral(x)
+  implicit class fromStringToLiteral(x: String) extends chisel3.core.fromStringToLiteral(x)
+  implicit class fromBooleanToLiteral(x: Boolean) extends chisel3.core.fromBooleanToLiteral(x)
+  implicit class fromDoubleToLiteral(x: Double) extends chisel3.core.fromDoubleToLiteral(x)
+  implicit class fromIntToWidth(x: Int) extends chisel3.core.fromIntToWidth(x)
+  implicit class fromIntToBinaryPoint(x: Int) extends chisel3.core.fromIntToBinaryPoint(x)
 
-  implicit class fromUIntToBitPatComparable(val x: UInt) {
+  implicit class fromUIntToBitPatComparable(x: UInt) {
     import scala.language.experimental.macros
     import internal.sourceinfo.{SourceInfo, SourceInfoTransform}
 

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -33,7 +33,7 @@ abstract class ReadyValidIO[+T <: Data](gen: T) extends Bundle
 
 object ReadyValidIO {
 
-  implicit class AddMethodsToReadyValid[T<:Data](val target: ReadyValidIO[T]) extends AnyVal {
+  implicit class AddMethodsToReadyValid[T<:Data](target: ReadyValidIO[T]) {
     def fire(): Bool = target.ready && target.valid
 
     /** push dat onto the output bits of this interface to let the consumer know it has happened.

--- a/src/test/scala/chiselTests/ImplicitConversionsSpec.scala
+++ b/src/test/scala/chiselTests/ImplicitConversionsSpec.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+
+class ImplicitConversionsSpec extends ChiselFlatSpec {
+  ".data on arbitrary Data objects" should "not work" in {
+    assertTypeError("UInt(8.W).data")
+    assertTypeError("8.S.data")
+    assertTypeError("(new Bundle {}).data")
+    assertTypeError("VecInit(1.U).data")
+  }
+
+  ".target on arbitrary Data objects" should "not work" in {
+    assertTypeError("UInt(8.W).target")
+    assertTypeError("8.S.target")
+    assertTypeError("(new Bundle {}).target")
+    assertTypeError("VecInit(1.U).target")
+  }
+
+  ".x on Strings and Numerical values" should "not work" in {
+    assertTypeError("3.x")
+    assertTypeError("3L.x")
+    assertTypeError("BigInt(-4).x")
+    assertTypeError("false.x")
+    assertTypeError(""""a".x""")
+  }
+
+  ".bigint on Strings and Numerical values" should "not work" in {
+    assertTypeError("3.bigint")
+    assertTypeError("3L.bigint")
+    assertTypeError("BigInt(-4).bigint")
+    assertTypeError("false.bigint")
+    assertTypeError(""""a".bigint""")
+  }
+
+  ".target on DecoupledIO" should "not work" in {
+    import chisel3.util._
+    assertTypeError("Decoupled(UInt(8.W)).target")
+  }
+}
+


### PR DESCRIPTION
Remove public vals from implicit classes that can surprisingly be
invoked yet do nothing. Many implicit classes were Value Classes which
require the argument to be a public val but the avoidance of runtime
objects compared to the rest of Chisel runtime is minimal at best.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: NA

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API modification

This PR is not source-code compatible since someone could be accidentally invoking one of these "methods". We could instead do this via a deprecation schedule.

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Removed implicitly added identity methods `.data` and `.target` from `Data` and `DecoupledIO`, and removed `.x` from `String`, `Int`, `Long`, `BigInt`, and `Boolean`
