### PR TITLE
Add infinite-width bit extract operator

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -143,6 +143,15 @@ sealed abstract class Bits(width: Width)
 
   final def do_apply(x: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = apply(BigInt(x))
 
+  /** Returns the specified bit of an infinitely-padded copy of this wire
+    * as a [[Bool]], statically addressed.
+    *
+    * @note convenience method allowing direct use of Ints without implicits
+    */
+  final def i(x: Int): Bool = macro SourceInfoTransform.xArg
+
+  final def do_i(x: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = pad(x+1).apply(BigInt(x))
+
   /** Returns the specified bit on this wire as a [[Bool]], dynamically
     * addressed.
     */

--- a/src/test/scala/chiselTests/InfiniteExtract.scala
+++ b/src/test/scala/chiselTests/InfiniteExtract.scala
@@ -1,0 +1,32 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import Chisel.testers.BasicTester
+import chisel3._
+import org.scalatest._
+
+//scalastyle:off magic.number
+
+class InfiniteExtractMuxSpec extends FreeSpec with Matchers with ChiselRunners {
+  "All four common infinite-width extract cases should work" in {
+    assertTesterPasses(new SimpleInfiniteExtractTester)
+  }
+}
+
+class SimpleInfiniteExtractTester extends BasicTester {
+  val a = Wire(Bool())
+  val b = Wire(Bool())
+  val c = Wire(Bool())
+  val d = Wire(Bool())
+
+  a := 5.U.i(0)
+  b := 5.U.i(25)
+  c := -2.S.i(0)
+  d := -2.S.i(25)
+  assert(a === 1.U)
+  assert(b === 0.U)
+  assert(c === 0.U)
+  assert(d === 1.U)
+  stop()
+}


### PR DESCRIPTION
**Related issue**: #857 
**Type of change**: other enhancement
**Impact**: API addition (no impact on existing code)
**Development Phase**: hypothetical proposal

@jackkoenig @azidar @ducky64 This is an example of the hypothetical "infinite extract" operator. Not that I'm saying this is the right solution, but it is _one_ easy solution.

Note: `i` is a terrible name that I just made up as an example.
