### PR TITLE
[F764.2] Add dumpAnnotations method to Driver

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -127,6 +127,20 @@ object Driver extends BackendCompilationUtilities {
     f
   }
 
+  /**
+    * Emit the annotations of a circuit
+    *
+    * @param ir The circuit containing annotations to be emitted
+    * @param optName An optional filename (will use s"${ir.name}.json" otherwise)
+    */
+  def dumpAnnotations(ir: Circuit, optName: Option[File]): File = {
+    val f = optName.getOrElse(new File(ir.name + ".anno.json"))
+    val w = new FileWriter(f)
+    w.write(JsonProtocol.serialize(ir.annotations.map(_.toFirrtl)))
+    w.close()
+    f
+  }
+
   /** Dumps the elaborated Circuit to ProtoBuf
     *
     * If no File is given as input, it will dump to a default filename based on the name of the


### PR DESCRIPTION
This adds a utility method to Chisel's `Driver` for writing the annotations associated with a specific Chisel circuit to a file.

Patch 2 for https://github.com/freechipsproject/firrtl/issues/764 implementation.

This can be merged in any order before F764.4+.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
