### PR TITLE
Inhibit aggressive resource file name mangling.

### DIFF
--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -31,8 +31,14 @@ object TesterDriver extends BackendCompilationUtilities {
     // Copy CPP harness and other Verilog sources from resources into files
     val cppHarness =  new File(path, "top.cpp")
     copyResourceToFile("/chisel3/top.cpp", cppHarness)
+    // NOTE: firrtl.Driver.execute() may end up copying these same resources in its BlackBoxSourceHelper code.
+    // As long as the same names are used for the output files, and we avoid including duplicate files
+    //  in BackendCompilationUtilities.verilogToCpp(), we should be okay.
+    // To that end, we need to minimize the amount of file name mangling we do.
     val additionalVFiles = additionalVResources.map((name: String) => {
-      val mangledResourceName = name.replace("/", "_")
+      // Don't convert a leading '/' to an '_'. Just skip the leading '/'.
+      val nameWithoutLeadingSlash = if (name(0) == '/') name.substring(1) else name
+      val mangledResourceName = nameWithoutLeadingSlash.replace("/", "_")
       val out = new File(path, mangledResourceName)
       copyResourceToFile(name, out)
       out

--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -7,6 +7,7 @@ import java.io._
 
 import chisel3.experimental.RunFirrtlTransform
 import firrtl.{Driver => _, _}
+import firrtl.transforms.BlackBoxSourceHelper.writeResourceToDirectory
 
 object TesterDriver extends BackendCompilationUtilities {
 
@@ -34,14 +35,9 @@ object TesterDriver extends BackendCompilationUtilities {
     // NOTE: firrtl.Driver.execute() may end up copying these same resources in its BlackBoxSourceHelper code.
     // As long as the same names are used for the output files, and we avoid including duplicate files
     //  in BackendCompilationUtilities.verilogToCpp(), we should be okay.
-    // To that end, we need to minimize the amount of file name mangling we do.
+    // To that end, we use the same method to write the resource to the target directory.
     val additionalVFiles = additionalVResources.map((name: String) => {
-      // Don't convert a leading '/' to an '_'. Just skip the leading '/'.
-      val nameWithoutLeadingSlash = name.stripPrefix("/")
-      val mangledResourceName = nameWithoutLeadingSlash.replace("/", "_")
-      val out = new File(path, mangledResourceName)
-      copyResourceToFile(name, out)
-      out
+      writeResourceToDirectory(name, path)
     })
 
     // Compile firrtl

--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -37,7 +37,7 @@ object TesterDriver extends BackendCompilationUtilities {
     // To that end, we need to minimize the amount of file name mangling we do.
     val additionalVFiles = additionalVResources.map((name: String) => {
       // Don't convert a leading '/' to an '_'. Just skip the leading '/'.
-      val nameWithoutLeadingSlash = if (name(0) == '/') name.substring(1) else name
+      val nameWithoutLeadingSlash = name.stripPrefix("/")
       val mangledResourceName = nameWithoutLeadingSlash.replace("/", "_")
       val out = new File(path, mangledResourceName)
       copyResourceToFile(name, out)


### PR DESCRIPTION
**Related issue**: #883.

**Type of change**: bug report

**Impact**: API modification
Although this should have minimal impact on existing code, it is observable.

**Development Phase**: implementation

**Release Notes**
Minimize the name mangling of output resource files.