### PR TITLE
Give type annotation to litOption.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -63,7 +63,7 @@ sealed abstract class Aggregate extends Data {
     }
   }
 
-  override def litOption = ???  // TODO implement me
+  override def litOption: Option[BigInt] = ???  // TODO implement me
 
   // Returns the LitArg of a Bits object.
   // Internal API for Bundle literals, to copy the LitArg of argument literals into the top map.


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The litOption field currently has no type that can be inferred. Some subtypes override it and give it a type, but the original declaration should have a type so things like bundles can override it.