### PR TITLE
Strong enums

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -17,7 +17,7 @@ import chisel3.internal.firrtl.PrimOp._
 /** Element is a leaf data type: it cannot contain other Data objects. Example
   * uses are for representing primitive data types, like integers and bits.
   */
-abstract class Element(private[chisel3] val width: Width) extends Data {
+abstract class Element extends Data {
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection) {
     binding = target
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
@@ -61,8 +61,8 @@ private[chisel3] sealed trait ToBoolable extends Element {
   * bitwise operations.
   */
 //scalastyle:off number.of.methods
-sealed abstract class Bits(width: Width)
-    extends Element(width) with ToBoolable {
+sealed abstract class Bits(private[chisel3] val width: Width)
+    extends Element with ToBoolable {
   // TODO: perhaps make this concrete?
   // Arguments for: self-checking code (can't do arithmetic on bits)
   // Arguments against: generates down to a FIRRTL UInt anyways
@@ -1130,7 +1130,7 @@ object FixedPoint {
   *
   * @note This API is experimental and subject to change
   */
-final class Analog private (width: Width) extends Element(width) {
+final class Analog private (private[chisel3] val width: Width) extends Element {
   require(width.known, "Since Analog is only for use in BlackBoxes, width must be known")
 
   private[core] override def typeEquivalent(that: Data): Boolean =

--- a/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Clock.scala
@@ -12,7 +12,7 @@ object Clock {
 }
 
 // TODO: Document this.
-sealed class Clock extends Element(Width(1)) {
+sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element {
   def cloneType: this.type = Clock().asInstanceOf[this.type]
 
   private[core] def typeEquivalent(that: Data): Boolean =

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -508,9 +508,11 @@ object WireInit {
 /** RHS (source) for Invalidate API.
   * Causes connection logic to emit a DefInvalid when connected to an output port (or wire).
   */
-object DontCare extends Element(width = UnknownWidth()) {
+object DontCare extends Element {
   // This object should be initialized before we execute any user code that refers to it,
   //  otherwise this "Chisel" object will end up on the UserModule's id list.
+
+  private[chisel3] override val width: Width = UnknownWidth()
 
   bind(DontCareBinding(), SpecifiedDirection.Output)
   override def cloneType = DontCare

--- a/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
@@ -79,6 +79,12 @@ object MonoConnect {
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: Clock, source_e: Clock) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
+      case (sink_e: EnumType, source_e: UnsafeEnum) =>
+        elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
+      case (sink_e: EnumType, source_e: EnumType) if sink_e.getClass.equals(source_e.getClass) =>
+        elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
+      case (sink_e: UnsafeEnum, source_e: UInt) =>
+        elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
 
       // Handle Vec case
       case (sink_v: Vec[Data @unchecked], source_v: Vec[Data @unchecked]) =>

--- a/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
@@ -81,7 +81,7 @@ object MonoConnect {
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: EnumType, source_e: UnsafeEnum) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
-      case (sink_e: EnumType, source_e: EnumType) if sink_e.getClass.equals(source_e.getClass) =>
+      case (sink_e: EnumType, source_e: EnumType) if sink_e.typeEquivalent(source_e) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: UnsafeEnum, source_e: UInt) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)

--- a/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
@@ -264,14 +264,12 @@ abstract class StrongEnum[T <: EnumType : ClassTag] {
   }
 
   def castFromNonLit(n: UInt): T = {
-    if (!n.isWidthKnown) {
+    if (n.litOption.isDefined) {
+      apply(n)
+    } else if (!n.isWidthKnown) {
       throwException(s"Non-literal UInts being cast to $enumTypeName must have a defined width")
     } else if (n.getWidth > this.getWidth) {
       throwException(s"The UInt being cast to $enumTypeName is wider than $enumTypeName's width ($getWidth)")
-    }
-
-    if (n.litOption.isDefined) {
-      apply(n)
     } else {
       Builder.warning(s"A non-literal UInt is being cast to $enumTypeName. You can check that the value is legal by calling isValid")
 

--- a/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
@@ -1,0 +1,276 @@
+package chisel3.core
+
+import scala.language.experimental.macros
+import scala.reflect.ClassTag
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe.{MethodSymbol, runtimeMirror}
+import scala.collection.mutable
+
+import chisel3.internal.Builder.pushOp
+import chisel3.internal.firrtl.PrimOp._
+import chisel3.internal.firrtl._
+import chisel3.internal.sourceinfo._
+import chisel3.internal.{Builder, InstanceId, throwException}
+import firrtl.annotations._
+
+object EnumExceptions {
+  case class EnumTypeMismatch(message: String) extends Exception(message)
+  case class EnumHasNoCompanionObject(message: String) extends Exception(message)
+  case class NonLiteralEnum(message: String) extends Exception(message)
+  case class NonIncreasingEnum(message: String) extends Exception(message)
+  case class IllegalDefinitionOfEnum(message: String) extends Exception(message)
+  case class IllegalCastToEnum(message: String) extends Exception(message)
+  case class NoEmptyConstructor(message: String) extends Exception(message)
+}
+
+object EnumAnnotations {
+  case class EnumComponentAnnotation(target: Named, enumTypeName: String) extends SingleTargetAnnotation[Named] {
+    def duplicate(n: Named) = this.copy(target = n)
+  }
+
+  case class EnumComponentChiselAnnotation(target: InstanceId, enumTypeName: String) extends ChiselAnnotation {
+    def toFirrtl = EnumComponentAnnotation(target.toNamed, enumTypeName)
+  }
+
+  case class EnumDefAnnotation(enumTypeName: String, definition: Map[String, UInt]) extends NoTargetAnnotation
+
+  case class EnumDefChiselAnnotation(enumTypeName: String, definition: Map[String, UInt]) extends ChiselAnnotation {
+    override def toFirrtl: Annotation = EnumDefAnnotation(enumTypeName, definition)
+  }
+}
+
+import EnumExceptions._
+import EnumAnnotations._
+
+abstract class EnumType(selfAnnotating: Boolean = true) extends Element {
+  def cloneType: this.type = getClass.getConstructor().newInstance().asInstanceOf[this.type]
+
+  private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
+    // Translate Bundle lit bindings to Element lit bindings
+    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => Some(ElementLitBinding(litArg))
+      case _ => Some(DontCareBinding())
+    }
+    case topBindingOpt => topBindingOpt
+  }
+
+  private[core] def litArgOption: Option[LitArg] = topBindingOpt match {
+    case Some(ElementLitBinding(litArg)) => Some(litArg)
+    case _ => None
+  }
+
+  override def litOption: Option[BigInt] = litArgOption.map(_.num)
+  private[core] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
+
+  // provide bits-specific literal handling functionality here
+  override private[chisel3] def ref: Arg = topBindingOpt match {
+    case Some(ElementLitBinding(litArg)) => litArg
+    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => litArg
+      case _ => throwException(s"internal error: DontCare should be caught before getting ref")
+    }
+    case _ => super.ref
+  }
+
+  private[core] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {
+    requireIsHardware(this, "bits operated on")
+    requireIsHardware(other, "bits operated on")
+
+    checkTypeEquivalency(other)
+
+    pushOp(DefPrim(sourceInfo, Bool(), op, this.ref, other.ref))
+  }
+
+  private[core] override def typeEquivalent(that: Data): Boolean = this.getClass == that.getClass
+
+  // This isn't actually used anywhere (and it would throw an exception anyway). But it has to be defined since we
+  // inherit it from Data.
+  private[core] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
+      compileOptions: CompileOptions): Unit = {
+    this := that.asUInt
+  }
+
+  final def === (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+  final def =/= (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+  final def < (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+  final def <= (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+  final def > (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+  final def >= (that: EnumType): Bool = macro SourceInfoTransform.thatArg
+
+  def do_=== (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, EqualOp, that)
+  def do_=/= (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, NotEqualOp, that)
+  def do_< (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, LessOp, that)
+  def do_> (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, GreaterOp, that)
+  def do_<= (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, LessEqOp, that)
+  def do_>= (that: EnumType)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, GreaterEqOp, that)
+
+  override def do_asUInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    pushOp(DefPrim(sourceInfo, UInt(width), AsUIntOp, ref))
+
+  val companionModule = currentMirror.reflect(this).symbol.companion.asModule
+  val companionObject =
+    try {
+      currentMirror.reflectModule(companionModule).instance.asInstanceOf[StrongEnum[this.type]]
+    } catch {
+      case ex: java.lang.ClassNotFoundException =>
+        throw EnumHasNoCompanionObject(s"$enumTypeName's companion object was not found")
+    }
+
+  private[chisel3] override def width: Width = companionObject.width
+
+  private[core] def bindToLiteral(bits: UInt): Unit = {
+    val litNum = bits.litOption.get
+    val lit = ULit(litNum, width) // We must make sure to use the enum's width, rather than the UInt's width
+    lit.bindLitArg(this)
+  }
+
+  override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
+    super.bind(target, parentDirection)
+
+    // If we try to annotate something that is bound to a literal, we get a FIRRTL annotation exception.
+    // To workaround that, we only annotate enums that are not bound to literals.
+    if (selfAnnotating && !litOption.isDefined)
+      annotate(EnumComponentChiselAnnotation(this, enumTypeName))
+  }
+
+  private def enumTypeName: String = getClass.getName
+
+  // TODO: See if there is a way to catch this at compile-time
+  def checkTypeEquivalency(that: EnumType): Unit =
+    if (!typeEquivalent(that))
+      throw EnumTypeMismatch(s"${this.getClass.getName} and ${that.getClass.getName} are different enum types")
+
+  def toPrintable: Printable = FullName(this) // TODO: Find a better pretty printer
+}
+
+// This is an enum type that can be connected directly to UInts. It is used as a "glue" to cast non-literal UInts
+// to enums.
+sealed private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(selfAnnotating = false) {
+  override def cloneType: this.type = getClass.getConstructor(classOf[Width]).newInstance(width).asInstanceOf[this.type]
+}
+private object UnsafeEnum extends StrongEnum[UnsafeEnum] {
+  override def checkEmptyConstructorExists(): Unit = {}
+}
+
+abstract class StrongEnum[T <: EnumType : ClassTag] {
+  private var id: BigInt = 0
+  private[core] var width: Width = 0.W
+
+  private val enum_names = getEnumNames
+  private val enum_values = mutable.ArrayBuffer.empty[BigInt]
+  private val enum_instances = mutable.ArrayBuffer.empty[T]
+
+  private def getEnumNames(implicit ct: ClassTag[T]): Seq[String] = {
+    val mirror = runtimeMirror(this.getClass.getClassLoader)
+    val reflection  = mirror.reflect(this)
+
+    // We use Java reflection to get all the enum fields, and then we use Scala reflection to sort them in declaration
+    // order. TODO: Use only Scala reflection here
+    val fields = getClass.getDeclaredFields.filter(_.getType == ct.runtimeClass).map(_.getName)
+    val getters = mirror.classSymbol(this.getClass).toType.members.sorted.collect {
+      case m: MethodSymbol if m.isGetter => m.name.toString
+    }
+
+    getters.filter(fields.contains(_))
+  }
+
+  private def bindAllEnums(): Unit =
+    (enum_instances, enum_values).zipped.foreach((inst, v) => inst.bindToLiteral(v.U(width)))
+
+  private def createAnnotation(): Unit =
+    annotate(EnumDefChiselAnnotation(enumTypeName,
+      (enum_names, enum_values.map(_.U(width))).zipped.toMap))
+
+  private def newEnum()(implicit ct: ClassTag[T]): T =
+    ct.runtimeClass.newInstance.asInstanceOf[T]
+
+  // TODO: This depends upon undocumented behavior (which, to be fair, is unlikely to change). Use reflection to find
+  // the companion class's name in a more robust way.
+  private val enumTypeName = getClass.getName.init
+
+  def getWidth: BigInt = width.get
+
+  def all: List[T] = enum_instances.toList
+
+  def Value: T = {
+    val result = newEnum()
+    enum_instances.append(result)
+    enum_values.append(id)
+
+    width = (1 max id.bitLength).W
+    id += 1
+
+    // Check whether we've instantiated all the enums
+    if (enum_instances.length == enum_names.length && isTopLevelConstructor) {
+      bindAllEnums()
+      createAnnotation()
+    }
+
+    result
+  }
+
+  def Value(id: UInt): T = {
+    // TODO: These throw ExceptionInInitializerError which can be confusing to the user. Get rid of the error, and just
+    // throw an exception
+    if (!id.litOption.isDefined)
+      throw NonLiteralEnum(s"$enumTypeName defined with a non-literal type in companion object")
+    if (id.litValue() <= this.id)
+      throw NonIncreasingEnum(s"Enums must be strictly increasing: $enumTypeName")
+
+    this.id = id.litValue()
+    Value
+  }
+
+  def apply(): T = newEnum()
+
+  def apply(n: UInt)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): T = {
+    if (n.litOption.isDefined) {
+      if (!enum_values.contains(n.litValue))
+        throwException(s"${n.litValue}.U is not a valid value for $enumTypeName")
+
+      val result = newEnum()
+      result.bindToLiteral(n)
+      result
+    } else {
+      Builder.warning(s"A non-literal UInt is being cast to $enumTypeName. No automatic bounds checking will be done!")
+
+      val glue = Wire(new UnsafeEnum(width))
+      glue := n
+      val result = Wire(newEnum())
+      result := glue
+      result
+    }
+  }
+
+  // StrongEnum basically has a recursive constructor. It instantiates a copy of itself internally, so that it can
+  // make sure that all EnumType's inside of it were instantiated using the "Value" function. However, in order to
+  // instantiate its copy, as well as to instantiate new enums, it has to make sure that it has a no-args constructor
+  // as it won't know what parameters to add otherwise.
+
+  protected def checkEmptyConstructorExists(): Unit = {
+    try {
+      implicitly[ClassTag[T]].runtimeClass.getDeclaredConstructor()
+      getClass.getDeclaredConstructor()
+    } catch {
+      case ex: NoSuchMethodException => throw NoEmptyConstructor(s"$enumTypeName does not have a no-args constructor. Did you declare it inside a class?")
+    }
+  }
+
+  private val isTopLevelConstructor: Boolean = {
+    val stack_trace = Thread.currentThread().getStackTrace
+    val constructorName = "<init>"
+
+    stack_trace.count(se => se.getClassName.equals(getClass.getName) && se.getMethodName.equals(constructorName)) == 1
+  }
+
+  if (isTopLevelConstructor) {
+    checkEmptyConstructorExists()
+
+    val constructor = getClass.getDeclaredConstructor()
+    constructor.setAccessible(true)
+    val childInstance = constructor.newInstance()
+
+    if (childInstance.enum_names.length != childInstance.enum_instances.length)
+      throw IllegalDefinitionOfEnum(s"$enumTypeName defined illegally. Did you forget to call Value when defining a new enum?")
+  }
+}

--- a/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
@@ -120,14 +120,14 @@ abstract class EnumType(selfAnnotating: Boolean = true) extends Element {
 
   private[chisel3] override def width: Width = companionObject.width
 
-  def isValid: Bool = {
+  def isValid(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     if (!companionObject.finishedInstantiation)
       throwException(s"Not all enums values have been defined yet")
 
     if (litOption.isDefined) {
       true.B
     } else {
-      def mux_builder(enums: Seq[this.type]): Bool = enums match {
+      def mux_builder(enums: List[this.type]): Bool = enums match {
         case Nil => false.B
         case e :: es => Mux(this === e, true.B, mux_builder(es))
       }
@@ -263,7 +263,7 @@ abstract class StrongEnum[T <: EnumType : ClassTag] {
     result
   }
 
-  def castFromNonLit(n: UInt): T = {
+  def castFromNonLit(n: UInt)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): T = {
     if (n.litOption.isDefined) {
       apply(n)
     } else if (!n.isWidthKnown) {

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -68,10 +68,10 @@ abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
   private[chisel3] def width: Width = if (forcedWidth) widthArg else Width(minWidth)
   override def fullName(ctx: Component): String = name
   // Ensure the node representing this LitArg has a ref to it and a literal binding.
-  def bindLitArg[T <: Bits](bits: T): T = {
-    bits.bind(ElementLitBinding(this))
-    bits.setRef(this)
-    bits
+  def bindLitArg[T <: Element](elem: T): T = {
+    elem.bind(ElementLitBinding(this))
+    elem.setRef(this)
+    elem
   }
 
   protected def minWidth: Int

--- a/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -2,7 +2,7 @@
 
 package chisel3.internal.firrtl
 import chisel3._
-import chisel3.core.SpecifiedDirection
+import chisel3.core.{SpecifiedDirection, EnumType}
 import chisel3.experimental._
 import chisel3.internal.sourceinfo.{NoSourceInfo, SourceLine, SourceInfo}
 import firrtl.{ir => fir}

--- a/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -211,6 +211,7 @@ private[chisel3] object Converter {
 
   def extractType(data: Data, clearDir: Boolean = false): fir.Type = data match {
     case _: Clock => fir.ClockType
+    case d: EnumType => fir.UIntType(convert(d.width))
     case d: UInt => fir.UIntType(convert(d.width))
     case d: SInt => fir.SIntType(convert(d.width))
     case d: FixedPoint => fir.FixedType(convert(d.width), convert(d.binaryPoint))

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -28,6 +28,7 @@ private class Emitter(circuit: Circuit) {
 
   private def emitType(d: Data, clearDir: Boolean = false): String = d match {
     case d: Clock => "Clock"
+    case d: EnumType => s"UInt${d.width}"
     case d: UInt => s"UInt${d.width}"
     case d: SInt => s"SInt${d.width}"
     case d: FixedPoint => s"Fixed${d.width}${d.binaryPoint}"

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -2,7 +2,7 @@
 
 package chisel3.internal.firrtl
 import chisel3._
-import chisel3.core.SpecifiedDirection
+import chisel3.core.{SpecifiedDirection, EnumType}
 import chisel3.experimental._
 import chisel3.internal.sourceinfo.{NoSourceInfo, SourceLine}
 
@@ -28,7 +28,7 @@ private class Emitter(circuit: Circuit) {
 
   private def emitType(d: Data, clearDir: Boolean = false): String = d match {
     case d: Clock => "Clock"
-    case d: EnumType => s"UInt${d.width}"
+    case d: chisel3.core.EnumType => s"UInt${d.width}"
     case d: UInt => s"UInt${d.width}"
     case d: SInt => s"SInt${d.width}"
     case d: FixedPoint => s"Fixed${d.width}${d.binaryPoint}"

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -243,8 +243,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   object Bool extends BoolFactory
   val Mux = chisel3.core.Mux
 
-  type EnumType = chisel3.core.EnumType
-  type StrongEnum[T <: EnumType] = chisel3.core.StrongEnum[T]
+  type ChiselEnum = chisel3.core.EnumFactory
   val EnumAnnotations = chisel3.core.EnumAnnotations
 
   type BlackBox = chisel3.core.BlackBox

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -243,6 +243,10 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   object Bool extends BoolFactory
   val Mux = chisel3.core.Mux
 
+  type EnumType = chisel3.core.EnumType
+  type StrongEnum[T <: EnumType] = chisel3.core.StrongEnum[T]
+  val EnumAnnotations = chisel3.core.EnumAnnotations
+
   type BlackBox = chisel3.core.BlackBox
 
   type InstanceId = chisel3.internal.InstanceId

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -243,9 +243,6 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   object Bool extends BoolFactory
   val Mux = chisel3.core.Mux
 
-  type ChiselEnum = chisel3.core.EnumFactory
-  val EnumAnnotations = chisel3.core.EnumAnnotations
-
   type BlackBox = chisel3.core.BlackBox
 
   type InstanceId = chisel3.internal.InstanceId
@@ -422,6 +419,9 @@ package object chisel3 {    // scalastyle:ignore package.object.name
     type Analog = chisel3.core.Analog
     val Analog = chisel3.core.Analog
     val attach = chisel3.core.attach
+
+    type ChiselEnum = chisel3.core.EnumFactory
+    val EnumAnnotations = chisel3.core.EnumAnnotations
 
     val withClockAndReset = chisel3.core.withClockAndReset
     val withClock = chisel3.core.withClock

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -24,7 +24,7 @@ object unless {  // scalastyle:ignore object.name
   * user-facing API.
   * @note DO NOT USE. This API is subject to change without warning.
   */
-class SwitchContext[T <: Bits](cond: T, whenContext: Option[WhenContext], lits: Set[BigInt]) {
+class SwitchContext[T <: Element](cond: T, whenContext: Option[WhenContext], lits: Set[BigInt]) {
   def is(v: Iterable[T])(block: => Unit): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
@@ -60,19 +60,19 @@ object is {   // scalastyle:ignore object.name
   // TODO: Begin deprecation of non-type-parameterized is statements.
   /** Executes `block` if the switch condition is equal to any of the values in `v`.
     */
-  def apply(v: Iterable[Bits])(block: => Unit) {
+  def apply(v: Iterable[Element])(block: => Unit) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to `v`.
     */
-  def apply(v: Bits)(block: => Unit) {
+  def apply(v: Element)(block: => Unit) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to any of the values in the argument list.
     */
-  def apply(v: Bits, vr: Bits*)(block: => Unit) {
+  def apply(v: Element, vr: Element*)(block: => Unit) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 }
@@ -91,7 +91,7 @@ object is {   // scalastyle:ignore object.name
   * }}}
   */
 object switch {  // scalastyle:ignore object.name
-  def apply[T <: Bits](cond: T)(x: => Unit): Unit = macro impl
+  def apply[T <: Element](cond: T)(x: => Unit): Unit = macro impl
   def impl(c: Context)(cond: c.Tree)(x: c.Tree): c.Tree = { import c.universe._
     val q"..$body" = x
     val res = body.foldLeft(q"""new SwitchContext($cond, None, Set.empty)""") {

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -3,13 +3,16 @@
 package chiselTests
 
 import chisel3._
-import chisel3.core.{EnumAnnotations, FixedPoint}
-import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform, annotate}
+import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
 import chisel3.internal.InstanceId
-import chisel3.internal.firrtl.BinaryPoint
 import chisel3.testers.BasicTester
 import firrtl.{CircuitState, LowForm, Transform}
-import firrtl.annotations.{Annotation, ModuleName, Named, SingleTargetAnnotation}
+import firrtl.annotations.{
+  Annotation,
+  SingleTargetAnnotation,
+  ModuleName,
+  Named
+}
 import org.scalatest._
 
 /** These annotations and the IdentityTransform class serve as an example of how to write a
@@ -95,39 +98,14 @@ class ModB(widthB: Int) extends Module {
   modC.io.in := io.in
   io.out := modC.io.out
 
-  val reg = RegInit(MyEnum.enum)
-
   identify(io.in, s"modB.io.in annotated from inside modB")
 }
-
-class MyEnum extends EnumType
-object MyEnum extends StrongEnum[MyEnum] {
-  val enum, e2 = Value
-  val e3 = Value(5.U)
-  val e4, e10, e11 = Value
-}
-
-/*class OtherEnum extends EnumType
-object OtherEnum extends StrongEnum[OtherEnum] {
-  val err = Value
-}*/
 
 class TopOfDiamond extends Module {
   val io = IO(new Bundle {
     val in   = Input(UInt(32.W))
-    // val out  = Output(UInt(32.W))
-    val out = Output(MyEnum())
+    val out  = Output(UInt(32.W))
   })
-
-  val wire = WireInit(MyEnum.enum)
-  println(MyEnum.e11.litValue)
-
-  val uiWire = WireInit(1.U)
-
-  wire :=  MyEnum(uiWire)// OtherEnum.err
-
-  val m = Mux(wire === MyEnum.enum, wire, MyEnum.e2)
-
   val x = Reg(UInt(32.W))
   val y = Reg(UInt(32.W))
 
@@ -139,8 +117,7 @@ class TopOfDiamond extends Module {
   modB.io.in := x
 
   y := modA.io.out + modB.io.out
-  // io.out := y
-  io.out := m//.asUInt()
+  io.out := y
 
   identify(this, s"TopOfDiamond\nWith\nSome new lines")
 
@@ -179,27 +156,6 @@ class AnnotatingDiamondSpec extends FreeSpec with Matchers {
             case IdentityAnnotation(ModuleName("ModC_1", _), "ModC(32)") => true
             case _ => false
           } should be (1)
-
-          println(s"Enum defs:")
-          annos.foreach {
-            case EnumAnnotations.EnumDefAnnotation(name, m) =>
-              print(s"\t$name: ")
-              for ((k,v) <- m) {
-                print(s"($k -> ${v.litValue()}), ")
-              }
-              println()
-            case _ =>
-          }
-
-          println(s"Enum comps:")
-          annos.foreach {
-            case EnumAnnotations.EnumComponentAnnotation(target, eName) =>
-              println(s"\t$target: $eName")
-            case _ =>
-          }
-
-          println("\n\n-----------\n\n")
-          println(emitted)
         case _ =>
           assert(false)
       }

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -287,6 +287,7 @@ class StrongEnumSpec extends ChiselFlatSpec {
 
   it should "connect enums of the same type" in {
     elaborate(new SimpleConnector(EnumExample(), EnumExample()))
+    elaborate(new SimpleConnector(EnumExample(), EnumExample.Type()))
   }
 
   it should "fail to connect a strong enum to a UInt" in {
@@ -296,8 +297,12 @@ class StrongEnumSpec extends ChiselFlatSpec {
   }
 
   it should "fail to connect enums of different types" in {
-    an [ChiselException] should be thrownBy {
+    a [ChiselException] should be thrownBy {
       elaborate(new SimpleConnector(EnumExample(), OtherEnum()))
+    }
+
+    a [ChiselException] should be thrownBy {
+      elaborate(new SimpleConnector(EnumExample.Type(), OtherEnum.Type()))
     }
   }
 
@@ -357,7 +362,7 @@ class StrongEnumSpec extends ChiselFlatSpec {
   }
 
   it should "maintain Scala-level type-safety" in {
-    def foo(e: EnumExample.Value) = {}
+    def foo(e: EnumExample.Type) = {}
 
     "foo(EnumExample.e1); foo(EnumExample.e1.next)" should compile
     "foo(OtherEnum.otherEnum)" shouldNot compile

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -3,11 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.core.EnumAnnotations
+import chisel3.experimental.ChiselEnum
 import chisel3.internal.firrtl.UnknownWidth
 import chisel3.util._
 import chisel3.testers.BasicTester
-import firrtl.annotations.ComponentName
 import org.scalatest.{FreeSpec, Matchers}
 
 object EnumExample extends ChiselEnum {
@@ -67,7 +66,7 @@ class CastFromNonLit extends Module {
     val valid = Output(Bool())
   })
 
-  io.out := EnumExample.fromBits(io.in)
+  io.out := EnumExample(io.in)
   io.valid := io.out.isValid
 }
 
@@ -79,7 +78,7 @@ class CastFromNonLitWidth(w: Option[Int] = None) extends Module {
     val out = Output(EnumExample())
   })
 
-  io.out := EnumExample.fromBits(io.in)
+  io.out := EnumExample(io.in)
 }
 
 class EnumOps(val xType: ChiselEnum, val yType: ChiselEnum) extends Module {
@@ -374,7 +373,8 @@ class StrongEnumSpec extends ChiselFlatSpec {
 }
 
 class StrongEnumAnnotationSpec extends FreeSpec with Matchers {
-  import EnumAnnotations._
+  import chisel3.experimental.EnumAnnotations._
+  import firrtl.annotations.ComponentName
 
   "Test that strong enums annotate themselves appropriately" in {
 

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -198,16 +198,19 @@ class StrongEnumFSMTester extends BasicTester {
 }
 
 class StrongEnumSpec extends ChiselFlatSpec {
+  import chisel3.core.EnumExceptions._
+  import chisel3.internal.ChiselException
+
   behavior of "Strong enum tester"
 
   it should "fail to instantiate enums without a companion class" in {
-    an [Exception] should be thrownBy {
+    an [EnumHasNoCompanionObjectException] should be thrownBy {
       elaborate(new SimpleConnector(new EnumWithoutCompanionObj(), new EnumWithoutCompanionObj()))
     }
   }
 
   it should "fail to instantiate non-literal enums in a companion object" in {
-    an [Error] should be thrownBy {
+    an [ExceptionInInitializerError] should be thrownBy {
       elaborate(new SimpleConnector(new NonLiteralEnumType(), new NonLiteralEnumType()))
     }
   }
@@ -217,13 +220,13 @@ class StrongEnumSpec extends ChiselFlatSpec {
   }
 
   it should "fail to connect a strong enum to a UInt" in {
-    an [Exception] should be thrownBy {
+    a [ChiselException] should be thrownBy {
       elaborate(new SimpleConnector(EnumExample(), UInt()))
     }
   }
 
   it should "fail to connect enums of different types" in {
-    an [Exception] should be thrownBy {
+    an [ChiselException] should be thrownBy {
       elaborate(new SimpleConnector(EnumExample(), OtherEnum()))
     }
   }
@@ -237,7 +240,7 @@ class StrongEnumSpec extends ChiselFlatSpec {
   }
 
   it should "catch illegal literal casts to enums" in {
-    an [Exception] should be thrownBy {
+    an [ChiselException] should be thrownBy {
       elaborate(new CastToInvalidEnumTester)
     }
   }
@@ -247,7 +250,7 @@ class StrongEnumSpec extends ChiselFlatSpec {
   }
 
   it should "fail to compare enums of different types" in {
-    an [Exception] should be thrownBy {
+    an [EnumTypeMismatchException] should be thrownBy {
       elaborate(new InvalidEnumOpsTester)
     }
   }

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -1,0 +1,303 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.core.{EnumAnnotations, EnumExceptions}
+import chisel3.util._
+import chisel3.testers.BasicTester
+import firrtl.annotations.ComponentName
+import org.scalatest.{FreeSpec, Matchers}
+
+class EnumExample extends EnumType
+object EnumExample extends StrongEnum[EnumExample] {
+  val e0, e1, e2 = Value
+  val e100 = Value(100.U)
+  val e101 = Value
+
+  val litValues = List(0.U, 1.U, 2.U, 100.U, 101.U)
+}
+
+class OtherEnum extends EnumType
+object OtherEnum extends StrongEnum[OtherEnum] {
+  val otherEnum = Value
+}
+
+class EnumWithoutCompanionObj extends EnumType
+
+class NonLiteralEnumType extends EnumType
+object NonLiteralEnumType extends StrongEnum[NonLiteralEnumType] {
+  val nonLit = Value(UInt())
+}
+
+class SimpleConnector(inType: Data, outType: Data) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(inType)
+    val out = Output(outType)
+  })
+
+  io.out := io.in
+}
+
+class CastToUInt extends Module {
+  val io = IO(new Bundle {
+    val in = Input(EnumExample())
+    val out = Output(UInt())
+  })
+
+  io.out := io.in.asUInt()
+}
+
+class CastToEnum extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt())
+    val out = Output(EnumExample())
+  })
+
+  io.out := EnumExample(io.in)
+}
+
+class EnumOps(xType: EnumType, yType: EnumType) extends Module {
+  val io = IO(new Bundle {
+    val x = Input(xType)
+    val y = Input(yType)
+
+    val lt = Output(Bool())
+    val le = Output(Bool())
+    val gt = Output(Bool())
+    val ge = Output(Bool())
+    val eq = Output(Bool())
+    val ne = Output(Bool())
+  })
+
+  io.lt := io.x < io.y
+  io.le := io.x <= io.y
+  io.gt := io.x > io.y
+  io.ge := io.x >= io.y
+  io.eq := io.x === io.y
+  io.ne := io.x =/= io.y
+}
+
+object StrongEnumFSM {
+  class State extends EnumType
+  object State extends StrongEnum[State] {
+    val sNone, sOne1, sTwo1s = Value
+
+    val correct_annotation_map = Map[String, UInt]("sNone" -> 0.U(2.W), "sOne1" -> 1.U(2.W), "sTwo1s" -> 2.U(2.W))
+  }
+}
+
+class StrongEnumFSM extends Module {
+  // This FSM detects two 1's one after the other
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
+
+  import StrongEnumFSM.State._
+
+  val state = RegInit(sNone)
+
+  io.out := (state === sTwo1s)
+
+  switch (state) {
+    is (sNone) {
+      when (io.in) {
+        state := sOne1
+      }
+    }
+    is (sOne1) {
+      when (io.in) {
+        state := sTwo1s
+      } .otherwise {
+        state := sNone
+      }
+    }
+    is (sTwo1s) {
+      when (!io.in) {
+        state := sNone
+      }
+    }
+  }
+}
+
+class CastToUIntTester extends BasicTester {
+  for ((enum,lit) <- EnumExample.all zip EnumExample.litValues) {
+    val mod = Module(new CastToUInt)
+    mod.io.in := enum
+    assert(mod.io.out === lit)
+  }
+  stop()
+}
+
+class CastToEnumTester extends BasicTester {
+  for ((enum,lit) <- EnumExample.all zip EnumExample.litValues) {
+    val mod = Module(new CastToEnum)
+    mod.io.in := lit
+    assert(mod.io.out === enum)
+  }
+  stop()
+}
+
+class CastToInvalidEnumTester extends BasicTester {
+  val invalid_value: UInt = EnumExample.litValues.last + 1.U
+  val mod = Module(new CastToEnum {
+    io.out := invalid_value
+  })
+}
+
+class EnumOpsTester extends BasicTester {
+  for (x <- EnumExample.all;
+       y <- EnumExample.all) {
+    val mod = Module(new EnumOps(EnumExample(), EnumExample()))
+    mod.io.x := x
+    mod.io.y := y
+
+    assert(mod.io.lt === (x.asUInt() < y.asUInt()))
+    assert(mod.io.le === (x.asUInt() <= y.asUInt()))
+    assert(mod.io.gt === (x.asUInt() > y.asUInt()))
+    assert(mod.io.ge === (x.asUInt() >= y.asUInt()))
+    assert(mod.io.eq === (x.asUInt() === y.asUInt()))
+    assert(mod.io.ne === (x.asUInt() =/= y.asUInt()))
+  }
+  stop()
+}
+
+class InvalidEnumOpsTester extends BasicTester {
+  val mod = Module(new EnumOps(EnumExample(), OtherEnum()))
+  mod.io.x := EnumExample.e0
+  mod.io.y := OtherEnum.otherEnum
+}
+
+class IsLitTester extends BasicTester {
+  for (e <- EnumExample.all) {
+    val wire = WireInit(e)
+
+    assert(e.isLit())
+    assert(!wire.isLit())
+  }
+  stop()
+}
+
+class StrongEnumFSMTester extends BasicTester {
+  val dut = Module(new StrongEnumFSM)
+
+  // Inputs and expected results
+  val inputs: Vec[Bool] = VecInit(false.B, true.B, false.B, true.B, true.B, true.B, false.B, true.B, true.B, false.B)
+  val expected: Vec[Bool] = VecInit(false.B, false.B, false.B, false.B, false.B, true.B, true.B, false.B, false.B, true.B)
+
+  val cntr = Counter(inputs.length)
+  val cycle = cntr.value
+
+  dut.io.in := inputs(cycle)
+  assert(dut.io.out === expected(cycle))
+
+  when(cntr.inc()) {
+    stop()
+  }
+}
+
+class StrongEnumSpec extends ChiselFlatSpec {
+  behavior of "Strong enum tester"
+
+  it should "fail to instantiate enums without a companion class" in {
+    an [Exception] should be thrownBy {
+      elaborate(new SimpleConnector(new EnumWithoutCompanionObj(), new EnumWithoutCompanionObj()))
+    }
+  }
+
+  it should "fail to instantiate non-literal enums in a companion object" in {
+    an [Error] should be thrownBy {
+      elaborate(new SimpleConnector(new NonLiteralEnumType(), new NonLiteralEnumType()))
+    }
+  }
+
+  it should "connect enums of the same type" in {
+    elaborate(new SimpleConnector(EnumExample(), EnumExample()))
+  }
+
+  it should "fail to connect a strong enum to a UInt" in {
+    an [Exception] should be thrownBy {
+      elaborate(new SimpleConnector(EnumExample(), UInt()))
+    }
+  }
+
+  it should "fail to connect enums of different types" in {
+    an [Exception] should be thrownBy {
+      elaborate(new SimpleConnector(EnumExample(), OtherEnum()))
+    }
+  }
+
+  it should "cast enums to UInts correctly" in {
+    assertTesterPasses(new CastToUIntTester)
+  }
+
+  it should "cast UInts to enums correctly" in {
+    assertTesterPasses(new CastToEnumTester)
+  }
+
+  it should "catch illegal literal casts to enums" in {
+    an [Exception] should be thrownBy {
+      elaborate(new CastToInvalidEnumTester)
+    }
+  }
+
+  it should "execute enum comparison operations correctly" in {
+    assertTesterPasses(new EnumOpsTester)
+  }
+
+  it should "fail to compare enums of different types" in {
+    an [Exception] should be thrownBy {
+      elaborate(new InvalidEnumOpsTester)
+    }
+  }
+
+  it should "correctly check whether or not enums are literal" in {
+    assertTesterPasses(new IsLitTester)
+  }
+
+  it should "return the correct widths for enums" in {
+    EnumExample.getWidth == EnumExample.litValues.last.getWidth
+  }
+
+  "StrongEnum FSM" should "work" in {
+    assertTesterPasses(new StrongEnumFSMTester)
+  }
+}
+
+class StrongEnumAnnotationSpec extends FreeSpec with Matchers {
+  "Test that strong enums annotate themselves appropriately" in {
+
+    Driver.execute(Array("--target-dir", "test_run_dir"), () => new StrongEnumFSM) match {
+      case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
+        val annos = circuit.annotations.map(_.toFirrtl)
+
+        // Check that the global annotation is correct
+        annos.exists {
+          case EnumAnnotations.EnumDefAnnotation(name, map) =>
+            name.endsWith("State") &&
+              map.size == StrongEnumFSM.State.correct_annotation_map.size &&
+              map.forall {
+                case (k, v) =>
+                  val correctValue = StrongEnumFSM.State.correct_annotation_map(k)
+
+                  val correctValLit = correctValue.litValue()
+                  val vLitValue = v.litValue()
+
+                  correctValue.getWidth == v.getWidth && correctValue.litValue() == v.litValue()
+              }
+          case _ => false
+        } should be(true)
+
+        // Check that the component annotations are correct
+        annos.exists {
+          case EnumAnnotations.EnumComponentAnnotation(target, enumName) =>
+            val ComponentName(targetName, _) = target
+            targetName == "state" && enumName.endsWith("State")
+          case _ => false
+        } should be(true)
+      case _ =>
+        assert(false)
+    }
+  }
+}

--- a/src/test/scala/cookbook/FSM.scala
+++ b/src/test/scala/cookbook/FSM.scala
@@ -4,6 +4,7 @@ package cookbook
 
 import chisel3._
 import chisel3.util._
+import chisel3.experimental.ChiselEnum
 
 /* ### How do I create a finite state machine?
  *
@@ -20,28 +21,27 @@ class DetectTwoOnes extends Module {
   object State extends ChiselEnum {
     val sNone, sOne1, sTwo1s = Value
   }
-  import State._
 
-  val state = RegInit(sNone)
+  val state = RegInit(State.sNone)
 
-  io.out := (state === sTwo1s)
+  io.out := (state === State.sTwo1s)
 
   switch (state) {
-    is (sNone) {
+    is (State.sNone) {
       when (io.in) {
-        state := sOne1
+        state := State.sOne1
       }
     }
-    is (sOne1) {
+    is (State.sOne1) {
       when (io.in) {
-        state := sTwo1s
+        state := State.sTwo1s
       } .otherwise {
-        state := sNone
+        state := State.sNone
       }
     }
-    is (sTwo1s) {
+    is (State.sTwo1s) {
       when (!io.in) {
-        state := sNone
+        state := State.sNone
       }
     }
   }

--- a/src/test/scala/cookbook/FSM.scala
+++ b/src/test/scala/cookbook/FSM.scala
@@ -11,20 +11,17 @@ import chisel3.util._
  * control logic
  */
 
-object DetectTwoOnes {
-  class State extends EnumType
-  object State extends StrongEnum[State] {
-    val sNone, sOne1, sTwo1s = Value
-  }
-}
-
 class DetectTwoOnes extends Module {
   val io = IO(new Bundle {
     val in = Input(Bool())
     val out = Output(Bool())
   })
 
-  import DetectTwoOnes.State._
+  object State extends ChiselEnum {
+    val sNone, sOne1, sTwo1s = Value
+  }
+  import State._
+
   val state = RegInit(sNone)
 
   io.out := (state === sTwo1s)

--- a/src/test/scala/cookbook/FSM.scala
+++ b/src/test/scala/cookbook/FSM.scala
@@ -7,16 +7,24 @@ import chisel3.util._
 
 /* ### How do I create a finite state machine?
  *
- * Use Chisel Enum to construct the states and switch & is to construct the FSM
+ * Use Chisel StrongEnum to construct the states and switch & is to construct the FSM
  * control logic
  */
+
+object DetectTwoOnes {
+  class State extends EnumType
+  object State extends StrongEnum[State] {
+    val sNone, sOne1, sTwo1s = Value
+  }
+}
+
 class DetectTwoOnes extends Module {
   val io = IO(new Bundle {
     val in = Input(Bool())
     val out = Output(Bool())
   })
 
-  val sNone :: sOne1 :: sTwo1s :: Nil = Enum(3)
+  import DetectTwoOnes.State._
   val state = RegInit(sNone)
 
   io.out := (state === sTwo1s)


### PR DESCRIPTION
This is an implementation of the strongly-typed enums proposed in #885. It satisfies all the conditions laid out there, along with these extra features:
- UInts can be cast into enums
- The user can retrieve a list of all valid enum values through the `StrongEnum.all` function

### Caveats
The enums do have two primary caveats that should be considered:
- An enum class must be "static" in the Java sense. In other words, you can't define an enum class inside of another class, although you can define it globally, or in an object, as in this example:
```scala
object FSM { // The companion object to a module named FSM
    class State extends EnumType
    object State extends StrongEnum[EnumType] {
        val s1, s2 = Value
    }
}
```
- Casting non-literal UInts to enums is an inherently dangerous procedure, because Chisel has no way of knowing whether or not the UInt is a valid enum value. When this happens, we emit warnings, but @jackkoenig has suggested completely removing this feature unless users demand its inclusion. Needless to say, casting _literal_ UInts to enums is safe, and provides compile-time guarantees.

### API Modifications
- In the `master` branch, `Element` inherits from `Data` and override's `Data`'s `def width` with a `val width` in the constructor. I removed this constructor parameter from `Element`, so that `EnumType` could inherit from `Element` without having to specify the width directly in the constructor (since `EnumType`'s width isn't actually known until all `EnumType`s have been instantiated). Now, other subclasses of `Element`, like `Bits` and `Clock`, must explicitly override `Data`'s `width` with their own implementations (which I have already taken care of).
- Numerous functions, like `switch`, `is` and `bindLitArg` require parameters of type `Bits` in the `master` branch. However, since `EnumType` must also work with these functions, and since `EnumType` isn't a subclass of `Bits`, I modified these functions so that they instead take in parameters of type `Element`.

Neither of these API modifications should break any existing user code. All the old tests still pass.

**Related issue**: #885 

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
- Added support for strongly-typed, self-annotating enums