### PR TITLE
Add DataMirror.modulePorts

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -140,7 +140,8 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     require(!_closed, "Can't generate module more than once")
     _closed = true
 
-    val namedPorts = io.elements.toSeq
+    val namedPorts = io.elements.toSeq.reverse  // ListMaps are stored in reverse order
+
     // setRef is not called on the actual io.
     // There is a risk of user improperly attempting to connect directly with io
     // Long term solution will be to define BlackBox IO differently as part of

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -86,6 +86,7 @@ object DataMirror {
     requireIsHardware(target, "node requested directionality on")
     target.direction
   }
+  def modulePorts(target: BaseModule): Map[String, Data] = target.getChiselPorts
 
   // Internal reflection-style APIs, subject to change and removal whenever.
   object internal {

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -86,7 +86,10 @@ object DataMirror {
     requireIsHardware(target, "node requested directionality on")
     target.direction
   }
-  def modulePorts(target: BaseModule): Map[String, Data] = target.getChiselPorts
+
+  // TODO: maybe move to something like Driver or DriverUtils, since this is mainly for interacting
+  // with compiled artifacts (vs. elaboration-time reflection)?
+  def modulePorts(target: BaseModule): Seq[(String, Data)] = target.getChiselPorts
 
   // Internal reflection-style APIs, subject to change and removal whenever.
   object internal {

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -187,6 +187,20 @@ abstract class BaseModule extends HasId {
     */
   final def toNamed: ModuleName = ModuleName(this.name, CircuitName(this.circuitName))
 
+  /**
+   * Internal API. Returns a list of this module's generated top-level ports as a map of a String
+   * (FIRRTL name) to the IO object. Only valid after the module is closed.
+   *
+   * Note: for BlackBoxes (but not ExtModules), this returns the contents of the top-level io
+   * object, consistent with what is emitted in FIRRTL.
+   */
+  private[core] def getChiselPorts: Map[String, Data] = {
+    require(_closed, "Can't get ports before module close")
+    _component.get.ports.map { port =>
+      (port.id.getRef.asInstanceOf[ModuleIO].name, port.id)
+    }.toMap
+  }
+
   /** Called at the Module.apply(...) level after this Module has finished elaborating.
     * Returns a map of nodes -> names, for named nodes.
     *

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -193,12 +193,14 @@ abstract class BaseModule extends HasId {
    *
    * Note: for BlackBoxes (but not ExtModules), this returns the contents of the top-level io
    * object, consistent with what is emitted in FIRRTL.
+   *
+   * TODO: Use SeqMap/VectorMap when those data structures become available.
    */
-  private[core] def getChiselPorts: Map[String, Data] = {
+  private[core] def getChiselPorts: Seq[(String, Data)] = {
     require(_closed, "Can't get ports before module close")
     _component.get.ports.map { port =>
       (port.id.getRef.asInstanceOf[ModuleIO].name, port.id)
-    }.toMap
+    }
   }
 
   /** Called at the Module.apply(...) level after this Module has finished elaborating.

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -172,4 +172,12 @@ class BlackBoxSpec extends ChiselFlatSpec {
     assertTesterPasses({ new BlackBoxWithParamsTester },
         Seq("/chisel3/BlackBoxTest.v"))
   }
+  "DataMirror.modulePorts" should "work with BlackBox" in {
+    elaborate(new Module {
+      val io = IO(new Bundle { })
+      val m = Module(new BlackBoxPassthrough)
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+          "in" -> m.io.in, "out" -> m.io.out))
+    })
+  }
 }

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -176,7 +176,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
     elaborate(new Module {
       val io = IO(new Bundle { })
       val m = Module(new BlackBoxPassthrough)
-      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Seq(
           "in" -> m.io.in, "out" -> m.io.out))
     })
   }

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -68,4 +68,12 @@ class ExtModuleSpec extends ChiselFlatSpec {
     assertTesterPasses({ new MultiExtModuleTester },
         Seq("/chisel3/BlackBoxTest.v"))
   }
+  "DataMirror.modulePorts" should "work with ExtModule" in {
+    elaborate(new Module {
+      val io = IO(new Bundle { })
+      val m = Module(new ExtModule.BlackBoxPassthrough)
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+          "in" -> m.in, "out" -> m.out))
+    })
+  }
 }

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -72,7 +72,7 @@ class ExtModuleSpec extends ChiselFlatSpec {
     elaborate(new Module {
       val io = IO(new Bundle { })
       val m = Module(new ExtModule.BlackBoxPassthrough)
-      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Seq(
           "in" -> m.in, "out" -> m.out))
     })
   }

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -126,4 +126,16 @@ class ModuleSpec extends ChiselPropSpec {
       assert(checkModule(this))
     })
   }
+  property("DataMirror.modulePorts should work") {
+    elaborate(new Module {
+      val io = IO(new Bundle { })
+      val m = Module(new chisel3.experimental.MultiIOModule {
+        val a = IO(UInt(8.W))
+        val b = IO(Bool())
+      })
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+          "clock" -> m.clock, "reset" -> m.reset,
+          "a" -> m.a, "b" -> m.b))
+    })
+  }
 }

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -133,7 +133,7 @@ class ModuleSpec extends ChiselPropSpec {
         val a = IO(UInt(8.W))
         val b = IO(Bool())
       })
-      assert(chisel3.experimental.DataMirror.modulePorts(m) == Map(
+      assert(chisel3.experimental.DataMirror.modulePorts(m) == Seq(
           "clock" -> m.clock, "reset" -> m.reset,
           "a" -> m.a, "b" -> m.b))
     })


### PR DESCRIPTION
Adds `modulePorts(module: BaseModule): Map[String, Data]` to `experimental.DataMirror`. This provides the necessary interfaces to split out Testers2 development (#866) into its own repo.

Points which may or may not warrant discussion:
- This returns things as an unordered Map. Are there ever cases where we want to preserve ordering? Alternatives would be either a ListMap or a Seq.
- BlackBox has its `io` contents flattened out in the return here, consistent with the generated component. Note that using `io` directly on a BlackBox can be illegal in some cases, because the top-level object actually does not get emitted (as an artifact of dropping the `io_` prefix in the pre-ExtModule/MultiIOModule dats). The only alternative would be to error out if a BlackBox is passed in.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Add chisel3.experimental.DataMirror.modulePorts(module: BaseModule): Map[String, Data]
