### PR TITLE
Modify ReadyValidIO noenq to set the data payload to DontCare.

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -36,7 +36,7 @@ object ReadyValidIO {
   implicit class AddMethodsToReadyValid[T<:Data](target: ReadyValidIO[T]) {
     def fire(): Bool = target.ready && target.valid
 
-    /** push dat onto the output bits of this interface to let the consumer know it has happened.
+    /** Push dat onto the output bits of this interface to let the consumer know it has happened.
       * @param dat the values to assign to bits.
       * @return    dat.
       */
@@ -47,7 +47,7 @@ object ReadyValidIO {
     }
 
     /** Indicate no enqueue occurs. Valid is set to false, and bits are
-      * connected to an uninitialized wire
+      * connected to an uninitialized wire.
       */
     def noenq(): Unit = {
       target.valid := false.B
@@ -56,14 +56,14 @@ object ReadyValidIO {
 
     /** Assert ready on this port and return the associated data bits.
       * This is typically used when valid has been asserted by the producer side.
-      * @return the data for this device,
+      * @return The data bits.
       */
     def deq(): T = {
       target.ready := true.B
       target.bits
     }
 
-    /** Indicate no dequeue occurs. Ready is set to false
+    /** Indicate no dequeue occurs. Ready is set to false.
       */
     def nodeq(): Unit = {
       target.ready := false.B

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -51,6 +51,7 @@ object ReadyValidIO {
       */
     def noenq(): Unit = {
       target.valid := false.B
+      target.bits := DontCare
     }
 
     /** Assert ready on this port and return the associated data bits.


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change (probably)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Modified ReadyValidIO (also used in DecoupledIO) to set the data payload (.bits) to don't care when a no enqueue action (noenq) is called. This will clean up the frequently used idiom:
````scala
c.noenq
when( cond) {
  c.enq( data)
}
````
This currently needs to be written as:
````scala
c.noenq
c.bits := DontCare
when( cond) {
  c.enq( data)
}
````
It is possible that `noenq` was used like this in some existing code:
````scala
c.bits := 47.U
c.noenq
when( cond) {
  c.valid := true.B
}
````
If this was the case, then the PR will change the behavior of the circuit.
The comment for `noenq` is:
````
    /** Indicate no enqueue occurs. Valid is set to false, and bits are
      * connected to an uninitialized wire
      */
````
so it wasn't supposed to be used this way.