### PR TITLE
Mill ivy or module dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,19 @@ MKDIR ?= mkdir -p
 CURL ?= curl -L
 MILL_BIN ?= $(HOME)/bin/mill
 MILL ?= $(MILL_BIN) --color false
+MILL_REMOTE_RELEASE ?= https://github.com/ucbjrl/mill/releases/download/v0.2.6-FDF/mill-0.2.6-FDF
 
 # Fetch mill (if we don't have it).
 $(MILL_BIN):
 	$(MKDIR) $(dir $@)
-	$(CURL) -o $@ https://github.com/ucbjrl/mill/releases/download/v0.2.3-FDF/mill-0.2.3-FDF && chmod +x $@
+	@echo $(CURL) --silent --output $@.curl --write-out "%{http_code}" $(MILL_REMOTE_RELEASE)
+	STATUSCODE=$(shell $(CURL) --silent --output $@.curl --write-out "%{http_code}" $(MILL_REMOTE_RELEASE)) && \
+	if test $$STATUSCODE -eq 200; then \
+	  mv $@.curl $@ && chmod +x $@ ;\
+	else \
+	  echo "Can't fetch $(MILL_REMOTE_RELEASE)" && cat $@.curl && echo ;\
+	  false ;\
+	fi
 
 mill-tools:	$(MILL_BIN)
 

--- a/build.sc
+++ b/build.sc
@@ -71,7 +71,7 @@ trait PublishChiselModule extends CommonChiselModule with PublishModule {
 //  other PublishModules.
 trait UnpublishedChiselModule extends PublishChiselModule
 
-val crossVersions = Seq("2.11.12", "2.12.4")
+val crossVersions = Seq("2.12.4", "2.11.12")
 
 // Make this available to external tools.
 object chisel3 extends Cross[ChiselTopModule](crossVersions: _*) {

--- a/build.sc
+++ b/build.sc
@@ -9,11 +9,6 @@ import mill.modules.Jvm._
 
 import $file.CommonBuild
 
-// An sbt layout with src in the top directory.
-trait CrossUnRootedSbtModule extends CrossSbtModule {
-  override def millSourcePath = super.millSourcePath / ammonite.ops.up
-}
-
 object chiselCompileOptions {
   def scalacOptions = Seq(
     "-deprecation",
@@ -104,10 +99,7 @@ object chisel3 extends Cross[ChiselTopModule](crossVersions: _*) {
 
 class ChiselTopModule(val crossScalaVersion: String) extends AbstractChiselModule
 
-// This submodule is unrooted - its source directory is in the top level directory.
-trait AbstractChiselModule extends PublishChiselModule with CommonBuild.BuildInfo with CrossUnRootedSbtModule { top =>
-
-  override def moduleDeps = Seq(coreMacros, chiselFrontend)
+trait AbstractChiselModule extends PublishChiselModule with CommonBuild.BuildInfo with CrossSbtModule { top =>
 
   object coreMacros extends UnpublishedChiselModule {
     def crossScalaVersion = top.crossScalaVersion
@@ -119,6 +111,11 @@ trait AbstractChiselModule extends PublishChiselModule with CommonBuild.BuildInf
     def scalaVersion = crossScalaVersion
     def moduleDeps = Seq(coreMacros)
   }
+
+  override def moduleDeps = Seq(coreMacros, chiselFrontend)
+
+  // This submodule is unrooted - its source directory is in the top level directory.
+  override def millSourcePath = super.millSourcePath / ammonite.ops.up
 
   // In order to preserve our "all-in-one" policy for published jars,
   //  we define allModuleSources() to include transitive sources, and define


### PR DESCRIPTION
This does quite a few things, each commit is an individual piece of work.

An important addendum to the commit "Support firrtl as either an ivy and a module dependency" is that it nests the coreMacros and chiselFrontend modules within the chisel3 Module which makes it possible to set `firrtlDep` once and thus change it for the full build.

@ucbjrl I manually inspected that this preserves mono-jar properly, but can you verify?