### PR TITLE
Field

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -72,6 +72,8 @@ trait InstanceId {
 
 }
 
+class GetReferenceException(message: String) extends Exception(message)
+
 private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def _onModuleClose: Unit = {} // scalastyle:ignore method.name
   private[chisel3] val _parent: Option[BaseModule] = Builder.currentModule
@@ -111,7 +113,7 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def setRef(parent: HasId, name: String): Unit = setRef(Slot(Node(parent), name))
   private[chisel3] def setRef(parent: HasId, index: Int): Unit = setRef(Index(Node(parent), ILit(index)))
   private[chisel3] def setRef(parent: HasId, index: UInt): Unit = setRef(Index(Node(parent), index.ref))
-  private[chisel3] def getRef: Arg = _ref.get
+  private[chisel3] def getRef: Arg = _ref.getOrElse(throw new GetReferenceException(s"bad .getRef on None"))
   private[chisel3] def getOptionRef: Option[Arg] = _ref
 
   // Implementation of public methods.

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -113,7 +113,8 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def setRef(parent: HasId, name: String): Unit = setRef(Slot(Node(parent), name))
   private[chisel3] def setRef(parent: HasId, index: Int): Unit = setRef(Index(Node(parent), ILit(index)))
   private[chisel3] def setRef(parent: HasId, index: UInt): Unit = setRef(Index(Node(parent), index.ref))
-  private[chisel3] def getRef: Arg = _ref.getOrElse(throw new GetReferenceException(s"bad .getRef on None"))
+  private[chisel3] def getRef: Arg = _ref.getOrElse(throw new GetReferenceException(
+    "Ill-defined reference to component in " + _parent.map(_.pathName).getOrElse("??")))
   private[chisel3] def getOptionRef: Option[Arg] = _ref
 
   // Implementation of public methods.

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -48,8 +48,7 @@ private class Emitter(circuit: Circuit) {
           }
           catch {
             case getRef: GetReferenceException =>
-              throw new GetReferenceException(s"Cannot emit ports for ${d.className}" +
-                      s" with fields ${d.elements.keys.mkString(",")}, perhaps you forgot a cloneType")
+              throw new GetReferenceException(s"Cannot emit field(s) ${d.elements.keys.mkString(",")} for ${d.className}, perhaps you forgot a Field(...)")
           }
         case (false, SpecifiedDirection.Flip | SpecifiedDirection.Input) =>
           s"flip ${elt.getRef.name} : ${emitType(elt, false)}"

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -2,8 +2,9 @@
 
 package chisel3.internal.firrtl
 import chisel3._
-import chisel3.core.{SpecifiedDirection, EnumType}
+import chisel3.core.{EnumType, SpecifiedDirection}
 import chisel3.experimental._
+import chisel3.internal.GetReferenceException
 import chisel3.internal.sourceinfo.{NoSourceInfo, SourceLine}
 
 private[chisel3] object Emitter {
@@ -26,6 +27,7 @@ private class Emitter(circuit: Circuit) {
     s"$dirString ${e.id.getRef.name} : ${emitType(e.id, clearDir)}"
   }
 
+  //scalastyle:off cyclomatic.complexity
   private def emitType(d: Data, clearDir: Boolean = false): String = d match {
     case d: Clock => "Clock"
     case d: chisel3.core.EnumType => s"UInt${d.width}"
@@ -41,7 +43,14 @@ private class Emitter(circuit: Circuit) {
         case (true, _) =>
           s"${elt.getRef.name} : ${emitType(elt, true)}"
         case (false, SpecifiedDirection.Unspecified | SpecifiedDirection.Output) =>
-          s"${elt.getRef.name} : ${emitType(elt, false)}"
+          try {
+            s"${elt.getRef.name} : ${emitType(elt, false)}"
+          }
+          catch {
+            case getRef: GetReferenceException =>
+              throw new GetReferenceException(s"Cannot emit ports for ${d.className}" +
+                      s" with fields ${d.elements.keys.mkString(",")}, perhaps you forgot a cloneType")
+          }
         case (false, SpecifiedDirection.Flip | SpecifiedDirection.Input) =>
           s"flip ${elt.getRef.name} : ${emitType(elt, false)}"
       }

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.core.IgnoreSeqInBundle
+import chisel3.internal.GetReferenceException
 import chisel3.testers.BasicTester
 
 trait BundleSpecUtils {
@@ -114,5 +115,31 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
         stop()
       }
     }
+  }
+}
+
+class BundleWithoutCloneTypeProblem extends ChiselPropSpec {
+  property("Bundles should not freak out if you forget cloneType") {
+    intercept[GetReferenceException] {
+      val a = new Bundle {
+        val b = UInt(4.W)
+      }
+
+      runTester(
+        new BasicTester {
+          val m = Module(new Module {
+            val d = Wire(new Bundle {
+              val e = a // forgot cloneType
+            })
+            val io = IO(new Bundle {
+              val c = Output(a.cloneType)
+            })
+            io.c := d.e
+            d.e.b := 0.U
+            stop()
+          })
+        }
+      )
+    }.getMessage should include("Cannot emit ports for Bundle with fields e, perhaps you forgot a cloneType")
   }
 }


### PR DESCRIPTION
**Related issue**: #765 #908 
**Type of change**: other enhancement
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation

**Release Notes**
I incorporated Paul's changes from #908.

Here, `Field` is a method and does not live in the companion object; this is because it must modify state to allow the check that _all_ fields are wrapped in `Field` if any is. I am not a huge fan of the capital-letter method, but there are many ways to get around that if it's worth changing. One alternative would be adding a mutable `isBundleField` member to `Data` that is set to `false` in the default constructor and changed to `true` during a `Field` call.
