### PR TITLE
Make BaseModule.name lazy

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -180,7 +180,13 @@ abstract class BaseModule extends HasId {
   def desiredName = this.getClass.getName.split('.').last
 
   /** Legalized name of this module. */
-  final lazy val name = Builder.globalNamespace.name(desiredName)
+  final lazy val name = try {
+    Builder.globalNamespace.name(desiredName)
+  } catch {
+    case e: NullPointerException => throwException(
+      s"Error: desiredName of ${this.getClass.getName} is null. Did you evaluate 'name' before all values needed by desiredName were available?", e)
+    case t: Throwable => throw t
+  }
 
   /** Returns a FIRRTL ModuleName that references this object
     * @note Should not be called until circuit elaboration is complete

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -180,7 +180,7 @@ abstract class BaseModule extends HasId {
   def desiredName = this.getClass.getName.split('.').last
 
   /** Legalized name of this module. */
-  final val name = Builder.globalNamespace.name(desiredName)
+  final lazy val name = Builder.globalNamespace.name(desiredName)
 
   /** Returns a FIRRTL ModuleName that references this object
     * @note Should not be called until circuit elaboration is complete

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -65,7 +65,14 @@ class ModuleRewrap extends Module {
 class ModuleWrapper(gen: => Module) extends Module {
   val io = IO(new Bundle{})
   val child = Module(gen)
+  override val desiredName = s"${child.desiredName}Wrapper"
+}
+
+class NullModuleWrapper extends Module {
+  val io = IO(new Bundle{})
   override lazy val desiredName = s"${child.desiredName}Wrapper"
+  println(s"My name is ${name}")
+  val child = Module(new ModuleWire)
 }
 
 class ModuleSpec extends ChiselPropSpec {
@@ -146,5 +153,9 @@ class ModuleSpec extends ChiselPropSpec {
   }
   property("A desiredName parameterized by a submodule should work") {
     Driver.elaborate(() => new ModuleWrapper(new ModuleWire)).name should be ("ModuleWireWrapper")
+  }
+  property("A name generating a null pointer exception should provide a good error message") {
+    (the [Exception] thrownBy (Driver.elaborate(() => new NullModuleWrapper)))
+      .getMessage should include ("desiredName of chiselTests.NullModuleWrapper is null")
   }
 }

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -62,6 +62,12 @@ class ModuleRewrap extends Module {
   val inst2 = Module(inst)
 }
 
+class ModuleWrapper(gen: => Module) extends Module {
+  val io = IO(new Bundle{})
+  val child = Module(gen)
+  override lazy val desiredName = s"${child.desiredName}Wrapper"
+}
+
 class ModuleSpec extends ChiselPropSpec {
 
   property("ModuleVec should elaborate") {
@@ -137,5 +143,8 @@ class ModuleSpec extends ChiselPropSpec {
           "clock" -> m.clock, "reset" -> m.reset,
           "a" -> m.a, "b" -> m.b))
     })
+  }
+  property("A desiredName parameterized by a submodule should work") {
+    Driver.elaborate(() => new ModuleWrapper(new ModuleWire)).name should be ("ModuleWireWrapper")
   }
 }


### PR DESCRIPTION
Fixes #911 

This makes `BaseModule.name` lazy (previously eager) so that a Module's `desiredName` can be a function of some property associated with a sub-instance.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Make BaseModule.name lazy to enable better name parameterization, e.g., a module name can now be a function of a submodule name