### PR TITLE
Add BigInt / Int to Bool conversion (0.B, 1.B)

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/package.scala
@@ -24,6 +24,12 @@ package chisel3 {
     * `0.asUInt(16)` (instead of `16.W`) compile without error and produce undesired results.
     */
     implicit class fromBigIntToLiteral(bigint: BigInt) {
+      /** Int to Bool conversion, allowing compact syntax like 1.B and 0.B
+       */
+      def B: Bool = {
+        require(bigint == 0 || bigint == 1)
+        Bool.Lit(if (bigint == 1) true else false)
+      }
       /** Int to UInt conversion, recommended style for constants.
         */
       def U: UInt = UInt.Lit(bigint, Width())  // scalastyle:ignore method.name

--- a/chiselFrontend/src/main/scala/chisel3/core/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/package.scala
@@ -26,9 +26,10 @@ package chisel3 {
     implicit class fromBigIntToLiteral(bigint: BigInt) {
       /** Int to Bool conversion, allowing compact syntax like 1.B and 0.B
        */
-      def B: Bool = {
-        require(bigint == 0 || bigint == 1)
-        Bool.Lit(if (bigint == 1) true else false)
+      def B: Bool = bigint match {
+        case bigint if bigint == 0 => Bool.Lit(false)
+        case bigint if bigint == 1 => Bool.Lit(true)
+        case bigint => Builder.error(s"Cannot convert $bigint to Bool, must be 0 or 1"); Bool.Lit(false)
       }
       /** Int to UInt conversion, recommended style for constants.
         */

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -32,6 +32,9 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
   "litToBoolean" should "return the literal value" in {
     assert(true.B.litToBoolean === true)
     assert(false.B.litToBoolean === false)
+
+    assert(1.B.litToBoolean === true)
+    assert(0.B.litToBoolean === false)
   }
 
   "litToDouble" should "return the literal value" in {


### PR DESCRIPTION
I think there are cases where it's cleaner to use `0.B` and `1.B` instead of `false.B` and `true.B`, especially as testers is going to use chisel literals.

(the use case is in testing interface code, where signal levels are usually specified as 0 and 1 instead of false and true)

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal, implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
