### PR TITLE
Fix LoadMemoryTransform for Instance Annotations

### DIFF
--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -36,7 +36,8 @@ case class ChiselLoadMemoryAnnotation[T <: Data](
   def transformClass: Class[LoadMemoryTransform] = classOf[LoadMemoryTransform]
 
   def toFirrtl: LoadMemoryAnnotation = {
-    LoadMemoryAnnotation(target.toNamed.asInstanceOf[ComponentName], fileName, hexOrBinary)
+    val tx = target.toNamed.asInstanceOf[ComponentName]
+    LoadMemoryAnnotation(tx, fileName, hexOrBinary, Some(tx.name))
   }
 }
 


### PR DESCRIPTION
Quickfix for LoadMemoryTransform that gets this to work with Instance
Annotations. The new Instance Annotations caused a corner case where a
LoadMemoryAnnotation would be duplicated (via update/renaming) and the
resulting annotation would differ from the original in only their
originalMemoryNameOpt field. This corrects that by having the
ChiselLoadMemoryAnnotation also emit the originalMemoryNameOpt field where
it did not previously.

First part of a fix for freechipsproject/firrtl#922.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
