### PR TITLE
Turn off strong enum annotations

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/StrongEnum.scala
@@ -32,7 +32,7 @@ object EnumAnnotations {
 import EnumAnnotations._
 
 
-abstract class EnumType(private val factory: EnumFactory, selfAnnotating: Boolean = true) extends Element {
+abstract class EnumType(private val factory: EnumFactory, selfAnnotating: Boolean = false) extends Element {
   override def cloneType: this.type = factory().asInstanceOf[this.type]
 
   private[core] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -376,6 +376,7 @@ class StrongEnumAnnotationSpec extends FreeSpec with Matchers {
   import chisel3.experimental.EnumAnnotations._
   import firrtl.annotations.ComponentName
 
+  /*
   "Test that strong enums annotate themselves appropriately" in {
 
     def test() = {
@@ -427,4 +428,5 @@ class StrongEnumAnnotationSpec extends FreeSpec with Matchers {
     test()
     test()
   }
+  */
 }


### PR DESCRIPTION
Enum annotations don't work properly with dynamically indexed values in `Vec`s. This PR temporarily turns them off so that an elegant solution can be found.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: freechipsproject/firrtl#922, #915

<!-- choose one -->
**Type of change**: temporary work-around

<!-- choose one -->
**Impact**: API modification (for annotations)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->