### PR TITLE
Fix Queue.io.count when entries=1

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -252,7 +252,7 @@ class Queue[T <: Data](gen: T,
 
   private val ptr_diff = enq_ptr.value - deq_ptr.value
   if (isPow2(entries)) {
-    io.count := Cat(maybe_full && ptr_match, ptr_diff)
+    io.count := Mux(maybe_full && ptr_match, entries.U, 0.U) | ptr_diff
   } else {
     io.count := Mux(ptr_match,
                     Mux(maybe_full,


### PR DESCRIPTION
Previously, io.count would report 2 when it should've reported 1.

**Related issue**: https://github.com/freechipsproject/chisel3/issues/917

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Queues with depth 1 now correctly report how many entries are present.