### PR TITLE
RFC: Add Rocket Chip-style clonemodule as CloneAndGetIO to experimental

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -134,7 +134,7 @@ object BaseModule {
     if (!compileOptions.explicitInvalidate) {
       pushCommand(DefInvalid(sourceInfo, clonePorts.ref))
     }
-    if (proto.isInstanceOf[ImplicitModule]) {
+    if (proto.isInstanceOf[MultiIOModule]) {
       clonePorts("clock") := Module.clock
       clonePorts("reset") := Module.reset
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -2,6 +2,7 @@
 
 package chisel3.core
 
+import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.collection.JavaConversions._
 import scala.language.experimental.macros
@@ -112,6 +113,32 @@ object IO {
     }
     module.bindIoInPlace(iodefClone)
     iodefClone
+  }
+}
+
+object BaseModule {
+  private[chisel3] class ClonePorts (elts: Data*)(implicit compileOptions: CompileOptions) extends Record {
+    val elements = ListMap(elts.map(d => d.instanceName -> d.cloneTypeFull): _*)
+    def apply(field: String) = elements(field)
+    override def cloneType = (new ClonePorts(elts: _*)).asInstanceOf[this.type]
+  }
+
+  private[chisel3] def cloneIORecord(proto: BaseModule)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): ClonePorts = {
+    require(proto.isClosed, "Can't clone a module before module close")
+    val clonePorts = new ClonePorts(proto.getModulePorts: _*)
+    clonePorts.bind(WireBinding(Builder.forcedUserModule))
+    val cloneInstance = new DefInstance(sourceInfo, proto, proto._component.get.ports) {
+      override def name = clonePorts.getRef.name
+    }
+    pushCommand(cloneInstance)
+    if (!compileOptions.explicitInvalidate) {
+      pushCommand(DefInvalid(sourceInfo, clonePorts.ref))
+    }
+    if (proto.isInstanceOf[ImplicitModule]) {
+      clonePorts("clock") := Module.clock
+      clonePorts("reset") := Module.reset
+    }
+    clonePorts
   }
 }
 

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -436,6 +436,28 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
     val IO = chisel3.core.IO
 
+    // Rocket Chip-style clonemodule
+
+    /** A record containing the results of CloneModuleAsRecord
+      * The apply method is retrieves the element with the supplied name.
+      */
+    type ClonePorts = chisel3.core.BaseModule.ClonePorts
+
+    object CloneModuleAsRecord {
+      /** Clones an existing module and returns a record of all its top-level ports.
+        * Each element of the record is named with a string matching the
+        * corresponding port's name and shares the port's type.
+        * @example {{{
+        * val q1 = Module(new Queue(UInt(32.W), 2))
+        * val q2_io = CloneModuleAsRecord(q1)("io").asInstanceOf[q1.io.type]
+        * q2_io.enq <> q1.io.deq
+        * }}}
+        */
+      def apply(proto: BaseModule)(implicit sourceInfo: chisel3.internal.sourceinfo.SourceInfo, compileOptions: chisel3.core.CompileOptions): ClonePorts = {
+        chisel3.core.BaseModule.cloneIORecord(proto)
+      }
+    }
+
     // Implicit conversions for BlackBox Parameters
     implicit def fromIntToIntParam(x: Int): IntParam = IntParam(BigInt(x))
     implicit def fromLongToIntParam(x: Long): IntParam = IntParam(BigInt(x))

--- a/src/test/scala/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala/chiselTests/CloneModuleSpec.scala
@@ -1,0 +1,91 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util.{Queue, EnqIO, DeqIO, QueueIO, log2Ceil}
+import chisel3.experimental.{CloneModuleAsRecord, MultiIOModule, withClockAndReset}
+import chisel3.testers.BasicTester
+import org.scalatest._
+import org.scalatest.prop._
+
+class MultiIOQueue[T <: Data](gen: T, val entries: Int) extends MultiIOModule {
+  val clk = IO(Input(Clock()))
+  val rst = IO(Input(Bool()))
+  val enq = IO(Flipped(EnqIO(gen)))
+  val deq = IO(Flipped(DeqIO(gen)))
+  val count = IO(Output(UInt(log2Ceil(entries + 1).W)))
+  val impl = withClockAndReset(clk, rst) { Module(new Queue(gen, entries)) }
+  impl.io.enq <> enq
+  deq <> impl.io.deq
+  count := impl.io.count
+}
+
+class QueueClone(multiIO: Boolean = false) extends Module {
+  val io = IO(new QueueIO(UInt(32.W), 4))
+  if (multiIO) {
+    val q1 = Module(new MultiIOQueue(UInt(32.W), 2))
+    val q2_io = CloneModuleAsRecord(q1)
+    q1.clk := clock
+    q1.rst := reset
+    q1.enq <> io.enq
+    q2_io("clk").asInstanceOf[Clock] := clock
+    q2_io("rst").asInstanceOf[Bool] := reset
+    q2_io("enq").asInstanceOf[q1.enq.type] <> q1.deq
+    io.deq <> q2_io("deq").asInstanceOf[q1.deq.type]
+    io.count := q1.count + q2_io("count").asInstanceOf[q1.count.type]
+  } else {
+    val q1 = Module(new Queue(UInt(32.W), 2))
+    val q2_io = CloneModuleAsRecord(q1)
+    q1.io.enq <> io.enq
+    val q2_io_bundle = q2_io("io").asInstanceOf[q1.io.type]
+    q2_io_bundle.enq <> q1.io.deq
+    io.deq <> q2_io_bundle.deq
+    io.count := q1.io.count + q2_io_bundle.count
+  }
+}
+
+class QueueCloneTester(x: Int, multiIO: Boolean = false) extends BasicTester {
+  val dut = Module(new QueueClone(multiIO))
+  val start = RegNext(dut.io.enq.fire, true.B)
+  val accept = RegNext(dut.io.deq.valid, false.B)
+  dut.io.enq.bits := x.U
+  dut.io.enq.valid := start
+  dut.io.deq.ready := accept
+  when (dut.io.deq.fire) {
+    assert(dut.io.deq.bits === x.U)
+    stop()
+  }
+}
+
+class CloneModuleSpec extends ChiselPropSpec {
+
+  val xVals = Table(
+    ("x"),  // First tuple defines column names
+    (42),   // Subsequent tuples define the data
+    (63),
+    (99))
+
+  property("QueueCloneTester should return the correct result") {
+    forAll (xVals) { (x: Int) =>
+      assertTesterPasses{ new QueueCloneTester(x) }
+    }
+  }
+
+  property("QueueClone's cloned queues should share the same module") {
+    val c = Driver.toFirrtl(Driver.elaborate(() => new QueueClone))
+    assert(c.modules.length == 2)
+  }
+
+  property("Clone of MultiIOModule should simulate correctly") {
+    forAll (xVals) { (x: Int) =>
+      assertTesterPasses{ new QueueCloneTester(x, multiIO=true) }
+    }
+  }
+
+  property("Clones of MultiIOModules should share the same module") {
+    val c = Driver.toFirrtl(Driver.elaborate(() => new QueueClone(multiIO=true)))
+    assert(c.modules.length == 3)
+  }
+
+}


### PR DESCRIPTION
**Related issue**: #618 
**Type of change**:  feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: proposal &&  implementation

**EXAMPLE USAGE**

```
val q1 = Module(new Queue(...))
val q2_io = CloneAndGetIO(q1)("io").asInstanceOf[q1.io.type]
q2_io.enq <> q1.io.deq
```

**Release Notes**:
This is a port of Rocket Chip's `CloneModule` functionality (which returns a `Record`) as `chisel3.experimental.CloneAndGetIO`. This simplifies the implementation drastically, as it can live inside chisel3. The idea here is that there may be some desire to have this live alongside a full `CloneModule` implementation that returns a `Module`, as the API for using the `Record`-returning version is much simpler for basic use cases.

**Pros**: it makes the simple use cases simple. Also, I am almost positive that anything returning something more module-like would have also have large, non-overlapping caveats associated with its use, which incentivizes having both variants.
**Cons**: it might be confusing to have both `CloneAndGetIO` and another version of `CloneModule` that returns a `Module`. Also, more API features means more to support ad infinitum.
