### PR TITLE
Make Vec cloneType keep directions of elements

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -240,7 +240,7 @@ sealed class Vec[T <: Data] private[core] (gen: => T, val length: Int)
   def apply(idx: Int): T = self(idx)
 
   override def cloneType: this.type = {
-    new Vec(gen.cloneType, length).asInstanceOf[this.type]
+    new Vec(gen.cloneTypeFull, length).asInstanceOf[this.type]
   }
 
   override def getElements: Seq[Data] =

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -2,11 +2,9 @@
 
 package chiselTests
 
-import chisel3._
 import org.scalatest._
-import org.scalatest.matchers._
-import org.scalatest.prop._
-import chisel3.testers.BasicTester
+import chisel3._
+import chisel3.util.Decoupled
 
 class DirectionedBundle extends Bundle {
   val in = Input(UInt(32.W))
@@ -61,5 +59,78 @@ class DirectionSpec extends ChiselPropSpec with Matchers {
 
   property("Top-level forced outputs should be assignable") {
     elaborate(new TopDirectionOutput)
+  }
+
+  import chisel3.experimental.{MultiIOModule, DataMirror, Direction}
+  import chisel3.core.SpecifiedDirection
+
+  property("Directions should be preserved through cloning and binding of Bundles") {
+    elaborate(new MultiIOModule {
+      class MyBundle extends Bundle {
+        val foo = Input(UInt(8.W))
+        val bar = Output(UInt(8.W))
+      }
+      class MyOuterBundle extends Bundle {
+        val fizz = new MyBundle
+        val buzz = Flipped(new MyBundle)
+      }
+      val a = new MyOuterBundle
+      val b = IO(a)
+      val specifiedDirs = Seq(
+        a.fizz.foo -> SpecifiedDirection.Input,
+        a.fizz.bar -> SpecifiedDirection.Output,
+        a.fizz -> SpecifiedDirection.Unspecified,
+        a.buzz.foo -> SpecifiedDirection.Input,
+        a.buzz.bar -> SpecifiedDirection.Output,
+        a.buzz -> SpecifiedDirection.Flip
+      )
+      val actualDirs = Seq(
+        b.fizz.foo -> Direction.Input,
+        b.fizz.bar -> Direction.Output,
+        b.fizz -> Direction.Bidirectional(Direction.Default),
+        b.buzz.foo -> Direction.Output,
+        b.buzz.bar -> Direction.Input,
+        b.buzz -> Direction.Bidirectional(Direction.Flipped)
+      )
+      for ((data, dir) <- specifiedDirs) {
+        DataMirror.specifiedDirectionOf(data) shouldBe (dir)
+      }
+      for ((data, dir) <- actualDirs) {
+        DataMirror.directionOf(data) shouldBe (dir)
+      }
+    }.asInstanceOf[MultiIOModule]) // The cast works around weird reflection behavior (bug?)
+  }
+
+  property("Directions should be preserved through cloning and binding of Vecs") {
+    elaborate(new MultiIOModule {
+      val a = Vec(1, Input(UInt(8.W)))
+      val b = Vec(1, a)
+      val c = Vec(1, Flipped(a))
+      val io0 = IO(b)
+      val io1 = IO(c)
+      val specifiedDirs = Seq(
+        a(0) -> SpecifiedDirection.Input,
+        b(0)(0) -> SpecifiedDirection.Input,
+        a -> SpecifiedDirection.Unspecified,
+        b -> SpecifiedDirection.Unspecified,
+        c(0) -> SpecifiedDirection.Flip,
+        c(0)(0) -> SpecifiedDirection.Input,
+        c -> SpecifiedDirection.Unspecified
+      )
+      val actualDirs = Seq(
+        io0(0)(0) -> Direction.Input,
+        io0(0) -> Direction.Input,
+        io0 -> Direction.Input,
+        io1(0)(0) -> Direction.Output,
+        io1(0) -> Direction.Output,
+        io1 -> Direction.Output
+      )
+      for ((data, dir) <- specifiedDirs) {
+        DataMirror.specifiedDirectionOf(data) shouldBe (dir)
+      }
+      for ((data, dir) <- actualDirs) {
+        DataMirror.directionOf(data) shouldBe (dir)
+      }
+    }.asInstanceOf[MultiIOModule]) // The cast works around weird reflection behavior (bug?)
   }
 }


### PR DESCRIPTION
Fixes #893

The added tests test way more than just this fix, I just decided to test several (working) similar things with them

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Fix bug where Chisel might lose the direction of elements of Vecs
