### PR TITLE
asBools, asBool, and chained apply on asBools

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
@@ -53,7 +53,7 @@ object assert { // scalastyle:ignore object.name
 
   def apply_impl_do(cond: Bool, line: String, message: Option[String], data: Bits*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) {
     val escLine = line.replaceAll("%", "%%")
-    when (!(cond || Module.reset.toBool)) {
+    when (!(cond || Module.reset.asBool)) {
       val fmt = message match {
         case Some(msg) =>
           s"Assertion failed: $msg\n    at $escLine\n"
@@ -80,7 +80,7 @@ object assert { // scalastyle:ignore object.name
 object stop { // scalastyle:ignore object.name
   /** Terminate execution with a failure code. */
   def apply(code: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
-    when (!Module.reset.toBool) {
+    when (!Module.reset.asBool) {
       pushCommand(Stop(sourceInfo, Builder.forcedClock.ref, code))
     }
   }

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -82,6 +82,15 @@ private[chisel3] sealed trait ToBoolable extends Element {
     *
     * @note The width must be known and equal to 1
     */
+  final def asBool(): Bool = macro SourceInfoWhiteboxTransform.noArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool
+
+  /** Casts this $coll to a [[Bool]]
+    *
+    * @note The width must be known and equal to 1
+    */
   final def toBool(): Bool = macro SourceInfoWhiteboxTransform.noArg
 
   /** @group SourceInfoTransformMacro */
@@ -420,12 +429,16 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     do_asUInt
   }
 
-  final def do_toBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
+  final def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     width match {
       case KnownWidth(1) => this(0)
-      case _ => throwException(s"can't covert UInt<$width> to Bool")
+      case _ => throwException(s"can't covert ${this.getClass.getSimpleName}$width to Bool")
     }
   }
+
+  @chiselRuntimeDeprecated
+  @deprecated("Use asBool instead", "3.2")
+  final def do_toBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = do_asBool
 
   /** Concatenation operator
     *

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -364,7 +364,15 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   final def toBools(): Seq[Bool] = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
-  def do_toBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
+  @chiselRuntimeDeprecated
+  @deprecated("Use asBools instead", "3.2")
+  def do_toBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] = do_asBools
+
+  /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
+  final def asBools(): Seq[Bool] = macro SourceInfoTransform.noArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_asBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
     Seq.tabulate(this.getWidth)(i => this(i))
 
   /** Reinterpret this $coll as a [[SInt]]

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -364,7 +364,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   final def toBools(): Seq[Bool] = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
-  def toBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
+  def do_toBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
     Seq.tabulate(this.getWidth)(i => this(i))
 
   /** Reinterpret this $coll as a [[SInt]]

--- a/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
@@ -86,7 +86,7 @@ object printf { // scalastyle:ignore object.name
     * @param pable [[Printable]] to print
     */
   def apply(pable: Printable)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
-    when (!Module.reset.toBool) {
+    when (!Module.reset.asBool) {
       printfWithoutReset(pable)
     }
   }

--- a/coreMacros/src/main/scala/chisel3/SourceInfoDoc.scala
+++ b/coreMacros/src/main/scala/chisel3/SourceInfoDoc.scala
@@ -16,7 +16,7 @@ package chisel3
   *
   *   The equivalent public-facing methods do not have the `do_` prefix or have the same name. Use and look at the
   *   documentation for those. If you want left shift, use `<<`, not `do_<<`. If you want comversion to a [[Seq]] of
-  *   [[Bool]]s look at the `toBools` above, not the one below. Users can safely ignore every method in this group!
+  *   [[Bool]]s look at the `asBools` above, not the one below. Users can safely ignore every method in this group!
   *   <br>
   *   <br>
   *

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -250,7 +250,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   val Mux = chisel3.core.Mux
   type Reset = chisel3.core.Reset
 
-  implicit def resetToBool(reset: Reset): Bool = reset.toBool
+  implicit def resetToBool(reset: Reset): Bool = reset.asBool
 
   import chisel3.core.Param
   abstract class BlackBox(params: Map[String, Param] = Map.empty[String, Param]) extends chisel3.core.BlackBox(params) {

--- a/src/main/scala/chisel3/testers/BasicTester.scala
+++ b/src/main/scala/chisel3/testers/BasicTester.scala
@@ -25,7 +25,7 @@ class BasicTester extends Module() {
     */
   def stop()(implicit sourceInfo: SourceInfo) {
     // TODO: rewrite this using library-style SourceInfo passing.
-    when (!reset.toBool) {
+    when (!reset.asBool) {
       pushCommand(Stop(sourceInfo, clock.ref, 0))
     }
   }

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -24,7 +24,7 @@ object FillInterleaved {
     *
     * Output data-equivalent to in(size(in)-1) (n times) ## ... ## in(1) (n times) ## in(0) (n times)
     */
-  def apply(n: Int, in: UInt): UInt = apply(n, in.toBools)
+  def apply(n: Int, in: UInt): UInt = apply(n, in.asBools)
 
   /** Creates n repetitions of each bit of x in order.
     *

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -69,7 +69,7 @@ object Fill {
       case 0 => UInt(0.W)
       case 1 => x
       case _ if x.isWidthKnown && x.getWidth == 1 =>
-        Mux(x.toBool, ((BigInt(1) << n) - 1).asUInt(n.W), 0.U(n.W))
+        Mux(x.asBool, ((BigInt(1) << n) - 1).asUInt(n.W), 0.U(n.W))
       case _ =>
         val nBits = log2Ceil(n + 1)
         val p2 = Array.ofDim[UInt](nBits)

--- a/src/main/scala/chisel3/util/ImplicitConversions.scala
+++ b/src/main/scala/chisel3/util/ImplicitConversions.scala
@@ -13,5 +13,5 @@ object ImplicitConversions {
   // The explicit fromIntToLiteral resolves an ambiguous conversion between fromIntToLiteral and
   // UInt.asUInt.
   implicit def intToUInt(x: Int): UInt = chisel3.core.fromIntToLiteral(x).asUInt
-  implicit def booleanToBool(x: Boolean): Bool = x.asBool
+  implicit def booleanToBool(x: Boolean): Bool = x.B
 }

--- a/src/main/scala/chisel3/util/OneHot.scala
+++ b/src/main/scala/chisel3/util/OneHot.scala
@@ -36,7 +36,7 @@ object OHToUInt {
   */
 object PriorityEncoder {
   def apply(in: Seq[Bool]): UInt = PriorityMux(in, (0 until in.size).map(_.asUInt))
-  def apply(in: Bits): UInt = apply(in.toBools)
+  def apply(in: Bits): UInt = apply(in.asBools)
 }
 
 /** Returns the one hot encoding of the input UInt.

--- a/src/test/scala/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala/chiselTests/AsTypeOfTester.scala
@@ -51,7 +51,7 @@ class AsTypeOfTruncationTester extends BasicTester {
 }
 
 class ResetAsTypeOfBoolTester extends BasicTester {
-  assert(reset.asTypeOf(Bool()) === reset.toBool)
+  assert(reset.asTypeOf(Bool()) === reset.asBool)
   stop()
 }
 

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -10,7 +10,7 @@ import chisel3.util._
 class FailingAssertTester() extends BasicTester {
   assert(false.B)
   // Wait to come out of reset
-  val (_, done) = Counter(!reset.toBool, 4)
+  val (_, done) = Counter(!reset.asBool, 4)
   when (done) {
     stop()
   }
@@ -19,7 +19,7 @@ class FailingAssertTester() extends BasicTester {
 class SucceedingAssertTester() extends BasicTester {
   assert(true.B)
   // Wait to come out of reset
-  val (_, done) = Counter(!reset.toBool, 4)
+  val (_, done) = Counter(!reset.asBool, 4)
   when (done) {
     stop()
   }
@@ -38,7 +38,7 @@ class PipelinedResetTester extends BasicTester {
 
   module.reset := RegNext(RegNext(RegNext(reset)))
 
-  val (_, done) = Counter(!reset.toBool, 4)
+  val (_, done) = Counter(!reset.asBool, 4)
   when (done) {
     stop()
   }

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -55,7 +55,7 @@ class MultiClockSubModuleTest extends BasicTester {
 /** Test withReset changing the reset of a Reg */
 class WithResetTest extends BasicTester {
   val reset2 = WireInit(false.B)
-  val reg = withReset(reset2 || reset.toBool) { RegInit(0.U(8.W)) }
+  val reg = withReset(reset2 || reset.asBool) { RegInit(0.U(8.W)) }
   reg := reg + 1.U
 
   val (cycle, done) = Counter(true.B, 10)

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -139,5 +139,15 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers {
   property("Bit extraction on literals should work for all non-negative indices") {
     assertTesterPasses(new UIntLitExtractTester)
   }
+
+  property("toBools should support chained apply") {
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(8.W))
+        val out = Output(Bool())
+      })
+      io.out := io.in.toBools()(2)
+    })
+  }
 }
 

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -80,7 +80,7 @@ class GoodBoolConversion extends Module {
     val u = Input(UInt(1.W))
     val b = Output(Bool())
   })
-  io.b := io.u.toBool
+  io.b := io.u.asBool
 }
 
 class BadBoolConversion extends Module {
@@ -88,7 +88,7 @@ class BadBoolConversion extends Module {
     val u = Input(UInt(5.W))
     val b = Output(Bool())
   })
-  io.b := io.u.toBool
+  io.b := io.u.asBool
 }
 
 class NegativeShift(t: => Bits) extends Module {

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -140,13 +140,13 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers {
     assertTesterPasses(new UIntLitExtractTester)
   }
 
-  property("toBools should support chained apply") {
+  property("asBools should support chained apply") {
     elaborate(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))
         val out = Output(Bool())
       })
-      io.out := io.in.toBools()(2)
+      io.out := io.in.asBools()(2)
     })
   }
 }

--- a/src/test/scala/cookbook/UInt2VecOfBool.scala
+++ b/src/test/scala/cookbook/UInt2VecOfBool.scala
@@ -6,13 +6,13 @@ import chisel3._
 
 /* ### How do I create a Vec of Bools from a UInt?
  *
- * Use the builtin function [[chisel3.core.Bits.toBools]] to create a Scala Seq of Bool,
+ * Use the builtin function [[chisel3.core.Bits.asBools]] to create a Scala Seq of Bool,
  * then wrap the resulting Seq in Vec(...)
  */
 class UInt2VecOfBool extends CookbookTester(1) {
   // Example
   val uint = 0xc.U
-  val vec = VecInit(uint.toBools)
+  val vec = VecInit(uint.asBools)
   printf(p"$vec") // Vec(0, 0, 1, 1)
 
   // Test

--- a/src/test/scala/examples/VendingMachineGenerator.scala
+++ b/src/test/scala/examples/VendingMachineGenerator.scala
@@ -93,7 +93,7 @@ class ParameterizedVendingMachineTester(
   val (idx, done) = Counter(true.B, testLength + 1)
   when (done) { stop(); stop() } // Two stops for Verilator
 
-  dut.io.inputs := inputVec(idx).toBools
+  dut.io.inputs := inputVec(idx).asBools
   assert(dut.io.dispense === expectedVec(idx))
 }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
* toBools -> asBools (toBools deprecated)
* toBool -> asBool (toBool deprecated)
* Fix chaining of apply after `.asBools`

