### PR TITLE
Fix width inferencing issue

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -429,9 +429,9 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
    */
   def litValue(): BigInt = litOption.get
 
-  /** Returns the width, in bits, if currently known.
-    * @throws java.util.NoSuchElementException if the width is not known. */
-  final def getWidth: Int = width.get
+  /** Returns the width, in bits, if currently known. */
+  final def getWidth: Int =
+    if (isWidthKnown) width.get else throwException(s"Width of $this is unknown!")
   /** Returns whether the width is currently known. */
   final def isWidthKnown: Boolean = width.known
   /** Returns Some(width) if the width is known, else None. */

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -534,9 +534,10 @@ object Wire extends WireFactory
   * specified.
   *
   * ==Single Argument==
-  * The single argument form is for specifying the type and default value with a single argument.
-  *
-  * There are 3 cases of width inference for single argument `WireInit`:
+  * The single argument form uses the argument to specify both the type and default connection. For
+  * non-literal [[Bits]], the width of the [[Wire]] will be inferred. For literal [[Bits]] and all
+  * non-Bits arguments, the type will be copied from the argument. See the following examples for
+  * more details:
   *
   * 1. Literal [[Bits]] initializer: width will be set to match
   * {{{

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -507,8 +507,8 @@ object Wire extends WireFactory
 object WireInit {
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (init match {
-      // For e.g. Wire(init=0.U(k.W)), fix the Reg's width to k
-      case init: Bits if init.litIsForcedWidth == Some(false) => init.cloneTypeWidth(Width())
+      // If init is a literal without forced width OR any non-literal, let width be inferred
+      case init: Bits if !init.litIsForcedWidth.getOrElse(false) => init.cloneTypeWidth(Width())
       case _ => init.cloneTypeFull
     }).asInstanceOf[T]
     apply(model, init)

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -70,8 +70,8 @@ object RegInit {
     */
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (init match {
-      // For e.g. Reg(init=UInt(0, k)), fix the Reg's width to k
-      case init: Bits if init.litIsForcedWidth == Some(false) => init.cloneTypeWidth(Width())
+      // If init is a literal without forced width OR any non-literal, let width be inferred
+      case init: Bits if !init.litIsForcedWidth.getOrElse(false) => init.cloneTypeWidth(Width())
       case init => init.cloneTypeFull
     }).asInstanceOf[T]
     RegInit(model, init)

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -92,7 +92,10 @@ object RegNext {
   * specified.
   *
   * ==Single Argument==
-  * The single argument form is for specifying the type and default value with a single argument.
+  * The single argument form uses the argument to specify both the type and reset value. For
+  * non-literal [[Bits]], the width of the [[Reg]] will be inferred. For literal [[Bits]] and all
+  * non-Bits arguments, the type will be copied from the argument. See the following examples for
+  * more details:
   *
   * There are 3 cases of type inference for single argument `RegInit`:
   *

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -97,8 +97,6 @@ object RegNext {
   * non-Bits arguments, the type will be copied from the argument. See the following examples for
   * more details:
   *
-  * There are 3 cases of type inference for single argument `RegInit`:
-  *
   * 1. Literal [[Bits]] initializer: width will be set to match
   * {{{
   * val r1 = RegInit(1.U) // width will be inferred to be 1

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -31,6 +31,33 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
   }
   def elaborate(t: => RawModule): Unit = Driver.elaborate(() => t)
 
+  def assertKnownWidth(expected: Int)(gen: => Data): Unit = {
+    assertTesterPasses(new BasicTester {
+      val x = gen
+      assert(x.getWidth === expected)
+      // Sanity check that firrtl doesn't change the width
+      x := 0.U.asTypeOf(chiselTypeOf(x))
+      val (_, done) = chisel3.util.Counter(true.B, 2)
+      when (done) {
+        chisel3.assert(~(x.asUInt) === -1.S(expected.W).asUInt)
+        stop()
+      }
+    })
+  }
+
+  def assertInferredWidth(expected: Int)(gen: => Data): Unit = {
+    assertTesterPasses(new BasicTester {
+      val x = gen
+      assert(!x.isWidthKnown, s"Asserting that width should be inferred yet width is known to Chisel!")
+      x := 0.U.asTypeOf(chiselTypeOf(x))
+      val (_, done) = chisel3.util.Counter(true.B, 2)
+      when (done) {
+        chisel3.assert(~(x.asUInt) === -1.S(expected.W).asUInt)
+        stop()
+      }
+    })
+  }
+
   /** Given a generator, return the Firrtl that it generates.
     *
     * @param t Module generator
@@ -63,7 +90,59 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
 }
 
 /** Spec base class for BDD-style testers. */
-class ChiselFlatSpec extends FlatSpec with ChiselRunners with Matchers
+abstract class ChiselFlatSpec extends FlatSpec with ChiselRunners with Matchers
+
+class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
+  import org.scalatest.exceptions.TestFailedException
+  // Who tests the testers?
+  "assertKnownWidth" should "error when the expected width is wrong" in {
+    a [TestFailedException] shouldBe thrownBy {
+      assertKnownWidth(7) {
+        Wire(UInt(8.W))
+      }
+    }
+  }
+
+  it should "error when the width is unknown" in {
+    a [ChiselException] shouldBe thrownBy {
+      assertKnownWidth(7) {
+        Wire(UInt())
+      }
+    }
+  }
+
+  it should "work if the width is correct" in {
+    assertKnownWidth(8) {
+      Wire(UInt(8.W))
+    }
+  }
+
+  "assertInferredWidth" should "error if the width is known" in {
+    a [TestFailedException] shouldBe thrownBy {
+      assertInferredWidth(8) {
+        Wire(UInt(8.W))
+      }
+    }
+  }
+
+  it should "error if the expected width is wrong" in {
+    a [TestFailedException] shouldBe thrownBy {
+      assertInferredWidth(8) {
+        val w = Wire(UInt())
+        w := 2.U(2.W)
+        w
+      }
+    }
+  }
+
+  it should "pass if the width is correct" in {
+    assertInferredWidth(4) {
+      val w = Wire(UInt())
+      w := 2.U(4.W)
+      w
+    }
+  }
+}
 
 /** Spec base class for property-based testers. */
 class ChiselPropSpec extends PropSpec with ChiselRunners with PropertyChecks with Matchers {

--- a/src/test/scala/chiselTests/WidthSpec.scala
+++ b/src/test/scala/chiselTests/WidthSpec.scala
@@ -14,4 +14,99 @@ class WidthSpec extends ChiselFlatSpec {
     1.U.getWidth should be (1)
     1.S.getWidth should be (2)
   }
+
+  behavior of "WireInit (Single Argument)"
+
+  it should "set width if passed a literal with forced width" in {
+    assertKnownWidth(4) {
+      WireInit(3.U(4.W))
+    }
+  }
+
+  it should "NOT set width if passed a literal without a forced width" in {
+    assertInferredWidth(4) {
+      val w = WireInit(3.U)
+      w := 3.U(4.W)
+      w
+    }
+  }
+
+  it should "NOT set width if passed a non-literal" in {
+    assertInferredWidth(4) {
+      val w = WireInit(3.U(4.W))
+      WireInit(w)
+    }
+  }
+
+  behavior of "WireInit (Double Argument)"
+
+  it should "set the width if the template type has a set width" in {
+    assertKnownWidth(4) {
+      WireInit(UInt(4.W), 0.U)
+    }
+    assertKnownWidth(4) {
+      WireInit(UInt(4.W), 0.U(2.W))
+    }
+  }
+
+  it should "infer the width if the template type has no width" in {
+    val templates = Seq(
+      () => 0.U, () => 0.U(2.W), () => WireInit(0.U), () => WireInit(0.U(2.W))
+    )
+    for (gen <- templates) {
+      assertInferredWidth(4) {
+        val w = WireInit(UInt(), gen())
+        w := 0.U(4.W)
+        w
+      }
+    }
+  }
+
+  behavior of "RegInit (Single Argument)"
+
+  it should "set width if passed a literal with forced width" in {
+    assertKnownWidth(4) {
+      RegInit(3.U(4.W))
+    }
+  }
+
+  it should "NOT set width if passed a literal without a forced width" in {
+    assertInferredWidth(4) {
+      val w = RegInit(3.U)
+      w := 3.U(4.W)
+      w
+    }
+  }
+
+  it should "NOT set width if passed a non-literal" in {
+    assertInferredWidth(4) {
+      val w = WireInit(3.U(4.W))
+      RegInit(w)
+    }
+  }
+
+  behavior of "RegInit (Double Argument)"
+
+  it should "set the width if the template type has a set width" in {
+    assertKnownWidth(4) {
+      RegInit(UInt(4.W), 0.U)
+    }
+    assertKnownWidth(4) {
+      RegInit(UInt(4.W), 0.U(2.W))
+    }
+  }
+
+  it should "infer the width if the template type has no width" in {
+    val templates = Seq(
+      () => 0.U, () => 0.U(2.W), () => WireInit(0.U), () => WireInit(0.U(2.W))
+    )
+    for (gen <- templates) {
+      assertInferredWidth(4) {
+        val w = RegInit(UInt(), gen())
+        w := 0.U(4.W)
+        w
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
As part of the Bundle literals framework PR, (https://github.com/freechipsproject/chisel3/pull/820) it appears a minor code refactor accidentally changed the width inference semantics of `WireInit` and `RegInit`.

For example
```scala
val wire1 = Wire(UInt(8.W))
val wire2 = WireInit(wire1)
```

prior to #820, wire2 would have it's width inferred. After #820, wire2 gets its width set to 8.

This PR restores the previous behavior and adds some tests that pass prior to #820, fail on current master, and pass on this branch

I noticed this issue while trying to bump Chisel because it changed the functionality of the output FIRRTL ever so slightly but enough to make simulations fail.

Future work is to make similar tests that show and check the width inferencing semantics for other constructors (eg. `RegNext`, `RegEnable`), as well as for aggregates (rather than just `UInt`).

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report & fix
<!-- choose one -->
**Impact**: Undo API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Restore use of width inference to set width of RegInit and WireInit when initialized with a non-literal Bits
