### PR TITLE
Improve quality of code generation for UInt.-%

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -738,10 +738,10 @@ sealed class UInt private[core] (width: Width) extends Bits(width) with Num[UInt
     (this +& that).tail(1)
   /** @group SourceInfoTransformMacro */
   def do_-& (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
-    binop(sourceInfo, SInt((this.width max that.width) + 1), SubOp, that).asUInt
+    (this subtractAsSInt that).asUInt
   /** @group SourceInfoTransformMacro */
   def do_-% (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
-    (this -& that).tail(1)
+    (this subtractAsSInt that).tail(1)
 
   /** Bitwise and operator
     *
@@ -913,6 +913,9 @@ sealed class UInt private[core] (width: Width) extends Bits(width) with Num[UInt
       compileOptions: CompileOptions): Unit = {
     this := that.asUInt
   }
+
+  private def subtractAsSInt(that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt =
+    binop(sourceInfo, SInt((this.width max that.width) + 1), SubOp, that)
 }
 
 // This is currently a factory because both Bits and UInt inherit it.


### PR DESCRIPTION
Emit it as

    tail(sub(x, y), 1)

rather than

    tail(asUInt(sub(x, y)), 1)

This is semantically equivalent, but gets rid of a bunch of Firrtl text.  It also gets rid of a bunch of Verilog, because Firrtl is capable of  pattern-matching the new expression into SubWrap.  The effect is that  we now get

    wire [4:0] in;
    wire [4:0] res;
    assign res = 5'h0 - in;

instead of

    wire [4:0] in;
    wire [5:0] _T_40;
    wire [5:0] _T_41;
    wire [4:0] res;
    assign _T_40 = 5'h0 - in;
    assign _T_41 = $unsigned(_T_40);
    assign res = _T_41[4:0];

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Improved code generation for modular UInt subtraction.