### PR TITLE
Added support to extract bit in reverse order

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -219,7 +219,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     // This preserves old behavior while a more more consistent API is under debate
     // See https://github.com/freechipsproject/chisel3/issues/867
     litOption.map { value =>
-      if x > y ((value >> y) & ((BigInt(1) << w) - 1)).asUInt(w.W)
+      if (x > y) ((value >> y) & ((BigInt(1) << w) - 1)).asUInt(w.W)
       else Array.range(0,w).zipWithIndex.map{case (bit, i) => {
         val trimmedValue = value >> x
         if(i < (w+1)/2) (trimmedValue << ((w-1)-(i*2)) & (BigInt(1) << (w-1-i))).asUInt(w.W)

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -107,7 +107,10 @@ class UIntLitExtractTester extends BasicTester {
   assert("b101010".U(6.W)(3) === true.B)
   assert("b101010".U(6.W)(100) === false.B)
   assert("b101010".U(6.W)(3, 0) === "b1010".U)
+  assert("b101010".U(6.W)(0, 3) === "b0101".U)
+  assert("b111100".U(6.W)(1, 4) === "b0111".U)
   assert("b101010".U(6.W)(9, 0) === "b0000101010".U)
+  assert("b101010".U(6.W)(0, 9) === "b0101010000".U)
   stop()
 }
 


### PR DESCRIPTION

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
You can extract bits from given number in reverse order
e.g. num(2,5)
-->
