### PR TITLE
Fix build error due to scala bug #11125

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -192,7 +192,7 @@ object Driver extends BackendCompilationUtilities {
           ce.printStackTrace(new PrintWriter(sw))
           sw.toString
         }
-        stackTrace.lines.foreach(line => println(s"${ErrorLog.errTag} $line"))
+        Predef.augmentString(stackTrace).lines.foreach(line => println(s"${ErrorLog.errTag} $line"))
         None
     }
 


### PR DESCRIPTION
JDK 11 `java.lang.String#lines` conflicts with Scala `StringOps#lines`.
This has been fixed in scalac 2.12.8 but projects using 2.11 in their
cross-build need the `Predef.augmentString` patch.

[Scala bug & fix reference](https://github.com/scala/bug/issues/11125)