### PR TITLE
Add explicit Sonatype resolvers so SNAPSHOTs can be found remotely.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
 
 lazy val commonSettings = Seq (
+  resolvers ++= Seq(
+    Resolver.sonatypeRepo("snapshots"),
+    Resolver.sonatypeRepo("releases")
+  ),
   organization := "edu.berkeley.cs",
   version := "3.2-SNAPSHOT",
   git.remoteRepo := "git@github.com:freechipsproject/chisel3.git",


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
**NOTE**: A `publishLocal` should replace the downloaded `.ivy2/cache/...` version with a pointer to the `.ivy2/local/...` version. To force re-fetching of the Sonatype repository version, you should delete both `.ivy2/{cache,local}/...` versions.
