### PR TITLE
Boring utils dedup fix

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -177,7 +177,7 @@ object BoringUtils {
     val annotations =
       Seq(new ChiselAnnotation with RunFirrtlTransform {
             def toFirrtl = SinkAnnotation(component.toNamed, name)
-            def transformClass = classOf[WiringTransform] })
+            def transformClass = classOf[WiringTransform] }) ++ maybeDedup
     annotations.map(annotate(_))
   }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix BoringUtils.addSinks bug where sinks would still be
  deduplicated even if the user or BoringUtils.bore requested
  that they not be
- Correct BoringUtils.{addSinks, addSources} parameter name from
  dedup to disableDedup
