### PR TITLE
Avoid procedural wire assignment in test resource

### DIFF
--- a/src/test/resources/chisel3/VerilogVendingMachine.v
+++ b/src/test/resources/chisel3/VerilogVendingMachine.v
@@ -10,35 +10,38 @@ module VerilogVendingMachine(
 );
   parameter sIdle = 3'd0, s5 = 3'd1, s10 = 3'd2, s15 = 3'd3, sOk = 3'd4;
   reg [2:0] state;
-  wire [2:0] next_state;
 
   assign dispense = (state == sOk) ? 1'd1 : 1'd0;
 
-  always @(*) begin
-    case (state)
-      sIdle: if (nickel) next_state <= s5;
-             else if (dime) next_state <= s10;
-             else next_state <= state;
-      s5: if (nickel) next_state <= s10;
-             else if (dime) next_state <= s15;
-             else next_state <= state;
-      s10: if (nickel) next_state <= s15;
-             else if (dime) next_state <= sOk;
-             else next_state <= state;
-      s15: if (nickel) next_state <= sOk;
-             else if (dime) next_state <= sOk;
-             else next_state <= state;
-      sOk: next_state <= sIdle;
-    endcase
-  end
-
-  // Go to next state
   always @(posedge clock) begin
     if (reset) begin
       state <= sIdle;
     end else begin
-      state <= next_state;
+      case (state)
+      sIdle: begin
+        if (nickel) state <= s5;
+        else if (dime) state <= s10;
+        else state <= state;
+      end
+      s5: begin
+        if (nickel) state <= s10;
+        else if (dime) state <= s15;
+        else state <= state;
+      end
+      s10: begin
+        if (nickel) state <= s15;
+        else if (dime) state <= sOk;
+        else state <= state;
+      end
+      s15: begin
+        if (nickel) state <= sOk;
+        else if (dime) state <= sOk;
+        else state <= state;
+      end
+      sOk: begin
+        state <= sIdle;
+      end
+      endcase
     end
   end
 endmodule
-


### PR DESCRIPTION
Running the tests with Verilator 4.008 (which Ubuntu apparently updated for me) will fail with a `PROCASSWIRE` error due to an old Verilog test resource using this. Apparently the Verilog standard disallows procedural wire assignments and Verilator decided to hard align with this. This has odd implications as it effectively means that the `always @ *` construct is effectively disabled. It's weird, but whatever.

See: https://www.veripool.org/news/246-Verilator-Verilator-4-008-Released

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

This is a test-only fix, so no release notes.