### PR TITLE
Chisel Stage

### DIFF
--- a/src/main/scala/chisel3/ChiselExecutionOptions.scala
+++ b/src/main/scala/chisel3/ChiselExecutionOptions.scala
@@ -2,7 +2,9 @@
 
 package chisel3
 
-import firrtl.{ExecutionOptionsManager, ComposableOptions}
+import chisel3.stage.{NoRunFirrtlCompilerAnnotation, PrintFullStackTraceAnnotation}
+
+import firrtl.{AnnotationSeq, ExecutionOptionsManager, ComposableOptions}
 
 //TODO: provide support for running firrtl as separate process, could alternatively be controlled by external driver
 //TODO: provide option for not saving chirrtl file, instead calling firrtl with in memory chirrtl
@@ -16,7 +18,13 @@ case class ChiselExecutionOptions(
                                    runFirrtlCompiler: Boolean = true,
                                    printFullStackTrace: Boolean = false
                                    // var runFirrtlAsProcess: Boolean = false
-                                 ) extends ComposableOptions
+                                 ) extends ComposableOptions {
+
+  def toAnnotations: AnnotationSeq =
+    (if (!runFirrtlCompiler) { Seq(NoRunFirrtlCompilerAnnotation) } else { Seq() }) ++
+      (if (printFullStackTrace) { Some(PrintFullStackTraceAnnotation) } else { None })
+
+}
 
 trait HasChiselExecutionOptions {
   self: ExecutionOptionsManager =>

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -5,6 +5,8 @@ package chisel3
 import chisel3.internal.ErrorLog
 import chisel3.internal.firrtl.Converter
 import chisel3.experimental.{RawModule, RunFirrtlTransform}
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, ChiselStage, ChiselExecutionResultView}
+import chisel3.stage.phases.DriverCompatibility
 
 import java.io._
 import net.jcazevedo.moultingyaml._
@@ -12,6 +14,8 @@ import net.jcazevedo.moultingyaml._
 import internal.firrtl._
 import firrtl._
 import firrtl.annotations.{Annotation, JsonProtocol}
+import firrtl.options.Phase
+import firrtl.options.Viewer.view
 import firrtl.util.{ BackendCompilationUtilities => FirrtlBackendCompilationUtilities }
 
 import _root_.firrtl.annotations.AnnotationYamlProtocol._
@@ -181,8 +185,22 @@ object Driver extends BackendCompilationUtilities {
   def execute(
       optionsManager: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions,
       dut: () => RawModule): ChiselExecutionResult = {
-    val circuitOpt = try {
-      Some(elaborate(dut))
+
+    val annos = ChiselGeneratorAnnotation(dut) +:
+      (optionsManager.chiselOptions.toAnnotations ++
+         optionsManager.firrtlOptions.toAnnotations ++
+         optionsManager.commonOptions.toAnnotations)
+
+    val phases: Seq[Phase] = Seq(
+      DriverCompatibility.AddImplicitOutputFile,
+      DriverCompatibility.AddImplicitOutputAnnotationFile,
+      firrtl.stage.phases.DriverCompatibility.AddImplicitOutputFile,
+      firrtl.stage.phases.DriverCompatibility.AddImplicitEmitter,
+      ChiselStage
+    )
+
+    val annosx = try {
+      phases.foldLeft(annos)( (a, p) => p.transform(a) )
     } catch {
       case ce: ChiselException =>
         val stackTrace = if (!optionsManager.chiselOptions.printFullStackTrace) {
@@ -193,60 +211,10 @@ object Driver extends BackendCompilationUtilities {
           sw.toString
         }
         Predef.augmentString(stackTrace).lines.foreach(line => println(s"${ErrorLog.errTag} $line"))
-        None
+        annos
     }
 
-    circuitOpt.map { circuit =>
-      // this little hack let's us set the topName with the circuit name if it has not been set from args
-      optionsManager.setTopNameIfNotSet(circuit.name)
-
-      val firrtlOptions = optionsManager.firrtlOptions
-      val chiselOptions = optionsManager.chiselOptions
-
-      val firrtlCircuit = Converter.convert(circuit)
-
-      // Still emit to leave an artifact (and because this always has been the behavior)
-      val firrtlString = Driver.emit(circuit)
-      val firrtlFileName = firrtlOptions.getInputFileName(optionsManager)
-      val firrtlFile = new File(firrtlFileName)
-
-      val w = new FileWriter(firrtlFile)
-      w.write(firrtlString)
-      w.close()
-
-      // Emit the annotations because it has always been the behavior
-      val annotationFile = new File(optionsManager.getBuildFileName("anno.json"))
-      val af = new FileWriter(annotationFile)
-      val firrtlAnnos = circuit.annotations.map(_.toFirrtl)
-      af.write(JsonProtocol.serialize(firrtlAnnos))
-      af.close()
-
-      /** Find the set of transform classes associated with annotations then
-        * instantiate an instance of each transform
-        * @note Annotations targeting firrtl.Transform will not result in any
-        *   transform being instantiated
-        */
-      val transforms = circuit.annotations
-                         .collect { case anno: RunFirrtlTransform => anno.transformClass }
-                         .distinct
-                         .filterNot(_ == classOf[firrtl.Transform])
-                         .map { transformClass: Class[_ <: Transform] =>
-                           transformClass.newInstance()
-                         }
-      /* This passes the firrtl source and annotations directly to firrtl */
-      optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
-        firrtlCircuit = Some(firrtlCircuit),
-        annotations = optionsManager.firrtlOptions.annotations ++ firrtlAnnos,
-        customTransforms = optionsManager.firrtlOptions.customTransforms ++ transforms.toList)
-
-      val firrtlExecutionResult = if(chiselOptions.runFirrtlCompiler) {
-        Some(firrtl.Driver.execute(optionsManager))
-      }
-      else {
-        None
-      }
-      ChiselExecutionSuccess(Some(circuit), firrtlString, firrtlExecutionResult)
-    }.getOrElse(ChiselExecutionFailure("could not elaborate circuit"))
+    view[ChiselExecutionResult](annosx)
   }
 
   /**

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -1,0 +1,107 @@
+// See LICENSE for license details.
+
+package chisel3.stage
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.options.{HasScoptOptions, OptionsException, Unserializable}
+
+import chisel3.{ChiselException, Module}
+import chisel3.experimental.RawModule
+import chisel3.internal.Builder
+import chisel3.internal.firrtl.Circuit
+
+import scopt.OptionParser
+
+/** Mixin that indicates that this is an [[firrtl.annotations.Annotation Annotation]] used to generate a
+  * [[ChiselOptions]] view.
+  */
+sealed trait ChiselOption extends Unserializable { this: Annotation => }
+
+/** Disable the execution of the FIRRTL compiler by Chisel
+  */
+case object NoRunFirrtlCompilerAnnotation extends NoTargetAnnotation with ChiselOption with HasScoptOptions {
+
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
+    .opt[Unit]("no-run-firrtl")
+    .abbr("chnrf")
+    .action( (x, c) => NoRunFirrtlCompilerAnnotation +: c )
+    .unbounded()
+    .text("Stop after chisel emits chirrtl file")
+
+}
+
+/** On an exception, this will cause the full stack trace to be printed as opposed to a pruned stack trace.
+  */
+case object PrintFullStackTraceAnnotation extends NoTargetAnnotation with ChiselOption with HasScoptOptions {
+
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
+    .opt[Unit]("full-stacktrace")
+    .action( (x, c) => PrintFullStackTraceAnnotation +: c )
+    .unbounded()
+    .text("Do not trim stack trace")
+
+}
+
+/** An [[firrtl.annotations.Annotation Annotation]] storing a function that returns a Chisel module
+  * @param gen a generator function
+  */
+case class ChiselGeneratorAnnotation(gen: () => RawModule) extends NoTargetAnnotation with Unserializable {
+
+  /** Run elaboration on the Chisel module generator function stored by this [[firrtl.annotations.Annotation Annotation]]
+    */
+  def elaborate: ChiselCircuitAnnotation = try {
+    ChiselCircuitAnnotation(Builder.build(Module(gen())))
+  } catch {
+    case e @ (_: OptionsException | _: ChiselException) => throw e
+    case e: Throwable =>
+      throw new OptionsException(s"Exception thrown when elaborating ChiselGeneratorAnnotation", e)
+  }
+
+}
+
+object ChiselGeneratorAnnotation extends HasScoptOptions {
+
+  /** Construct a [[ChiselGeneratorAnnotation]] with a generator function that will try to construct a Chisel Module from
+    * using that Module's name. The Module must both exist in the class path and not take parameters.
+    * @param name a module name
+    * @throws firrtl.options.OptionsException if the module name is not found or if no parameterless constructor for
+    * that Module is found
+    */
+  def apply(name: String): ChiselGeneratorAnnotation = {
+    val gen = () => try {
+      Class.forName(name).asInstanceOf[Class[_ <: RawModule]].newInstance()
+    } catch {
+      case e: ClassNotFoundException =>
+        throw new OptionsException(s"Unable to locate module '$name'! (Did you misspell it?)", e)
+      case e: InstantiationException =>
+        throw new OptionsException(s"Unable to create instance of module '$name'! (Does this class take parameters?)", e)
+    }
+    ChiselGeneratorAnnotation(gen)
+  }
+
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
+    .opt[String]("module")
+    .action{ (x, c) => ChiselGeneratorAnnotation(x) +: c }
+    .unbounded()
+    .text("The name of a Chisel module (in the classpath) to elaborate")
+
+}
+
+/** Stores a Chisel [[chisel3.internal.firrtl.Circuit Circuit]]
+  * @param circuit a Chisel Circuit
+  */
+case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption
+
+case class ChiselOutputFileAnnotation(file: String) extends NoTargetAnnotation with ChiselOption
+
+object ChiselOutputFileAnnotation extends HasScoptOptions {
+
+  def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
+    .opt[String]("chisel-output-file")
+    .valueName("FILE")
+    .action( (x, c) => ChiselOutputFileAnnotation(x) +: c )
+    .unbounded()
+    .text("sets an output file name for the Chisel-generated FIRRTL circuit")
+
+}

--- a/src/main/scala/chisel3/stage/ChiselCli.scala
+++ b/src/main/scala/chisel3/stage/ChiselCli.scala
@@ -1,0 +1,12 @@
+// See LICENSE for license details.
+
+package chisel3.stage
+
+import firrtl.options.Shell
+
+trait ChiselCli { this: Shell =>
+  parser.note("Chisel Front End Options")
+  Seq( NoRunFirrtlCompilerAnnotation,
+       PrintFullStackTraceAnnotation )
+    .map(_.addOptions(parser))
+}

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package chisel3.stage
+
+import chisel3.internal.firrtl.Circuit
+
+class ChiselOptions private [stage] (
+  val runFirrtlCompiler:   Boolean         = true,
+  val printFullStackTrace: Boolean         = false,
+  val outputFile:          Option[String]  = None,
+  val chiselCircuit:       Option[Circuit] = None) {
+
+  private [stage] def copy(
+    runFirrtlCompiler:   Boolean         = runFirrtlCompiler,
+    printFullStackTrace: Boolean         = printFullStackTrace,
+    outputFile:          Option[String]  = outputFile,
+    chiselCircuit:       Option[Circuit] = chiselCircuit ): ChiselOptions = {
+
+    new ChiselOptions(
+      runFirrtlCompiler   = runFirrtlCompiler,
+      printFullStackTrace = printFullStackTrace,
+      outputFile          = outputFile,
+      chiselCircuit       = chiselCircuit )
+
+  }
+
+}

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -1,0 +1,34 @@
+// See LICENSE for license details.
+
+package chisel3.stage
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Phase, Shell, Stage}
+import firrtl.options.Viewer.view
+import firrtl.stage.{FirrtlCli, FirrtlStage}
+
+import logger.{Logger, LoggerCli}
+
+object ChiselStage extends Stage {
+  val shell: Shell = new Shell("chisel") with LoggerCli with ChiselCli with FirrtlCli
+
+  private val phases: Seq[Phase] = Seq(
+    chisel3.stage.phases.Checks,
+    chisel3.stage.phases.Elaborate,
+    chisel3.stage.phases.AddImplicitOutputFile,
+    chisel3.stage.phases.AddImplicitOutputAnnotationFile,
+    chisel3.stage.phases.Emitter,
+    chisel3.stage.phases.Convert
+  )
+
+  def run(annotations: AnnotationSeq): AnnotationSeq = Logger.makeScope(annotations) {
+    val cOpts = view[ChiselOptions](annotations)
+
+    /* @todo: Should this be wrapped in a try/catch? */
+    (phases ++
+       (if (cOpts.runFirrtlCompiler) { Some(FirrtlStage) }
+        else                         { Seq.empty         }))
+      .foldLeft(annotations)( (a, f) => f.transform(a) )
+  }
+
+}

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -1,0 +1,83 @@
+// See LICENSE for license details.
+
+package chisel3
+
+import firrtl._
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.OptionsView
+import firrtl.options.Viewer
+import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlOptions}
+
+import chisel3.internal.firrtl.Circuit
+import chisel3.stage.ChiselOptions
+import chisel3.stage.phases.{Convert, Emitter}
+
+package object stage {
+
+  implicit object ChiselOptionsView extends OptionsView[ChiselOptions] {
+
+    def view(options: AnnotationSeq): ChiselOptions = options
+      .collect { case a: ChiselOption => a }
+      .foldLeft(new ChiselOptions()){ (c, x) =>
+        x match {
+          case _: NoRunFirrtlCompilerAnnotation.type => c.copy(runFirrtlCompiler = false)
+          case _: PrintFullStackTraceAnnotation.type => c.copy(printFullStackTrace = true)
+          case ChiselOutputFileAnnotation(f)         => c.copy(outputFile = Some(f))
+          case ChiselCircuitAnnotation(a)            => c.copy(chiselCircuit = Some(a))
+        }
+      }
+
+  }
+
+  /** Construct a view of a [[firrtl.FirrtlExecutionResult FirrtlExecutionResult]]. This is not supposed to be used except
+    * to enable the Driver compatibility layer.
+    *
+    * This is a straight copy-paste of the equivalent FIRRTL implicit object. This is intentional as this object should
+    * not be made public.
+    */
+  private [chisel3] implicit object FirrtlExecutionResultView extends OptionsView[FirrtlExecutionResult] {
+
+    def view(options: AnnotationSeq): FirrtlExecutionResult = {
+      val fopts = Viewer.view[FirrtlOptions](options)
+      val emittedRes = options.collect{ case a: EmittedAnnotation[_] => a.value.value }.mkString("\n")
+
+      options.collectFirst{ case a: FirrtlCircuitAnnotation => a.circuit } match {
+        case None => FirrtlExecutionFailure("No circuit found in AnnotationSeq!")
+        case Some(a) => FirrtlExecutionSuccess(
+          emitType = fopts.compiler.getClass.getSimpleName,
+          emitted = emittedRes,
+          circuitState = CircuitState(
+            circuit = a,
+            form = fopts.compiler.outputForm,
+            annotations = firrtl.stage.phases.Strip.transform(options),
+            renames = None
+          ))
+      }
+    }
+  }
+
+  private [chisel3] implicit object ChiselExecutionResultView extends OptionsView[ChiselExecutionResult] {
+
+    def view(options: AnnotationSeq): ChiselExecutionResult = {
+      var chiselCircuit: Option[Circuit] = None
+      var chirrtlCircuit: Option[String] = None
+      options.foreach {
+        case DeletedAnnotation(Convert.name, ChiselCircuitAnnotation(a)) => chiselCircuit = Some(a)
+        case DeletedAnnotation(Emitter.name, EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit(_, a, _))) =>
+          chirrtlCircuit = Some(a)
+        case _ =>
+      }
+
+      val fResult = Viewer.view[FirrtlExecutionResult](options)
+
+      (chiselCircuit, chirrtlCircuit) match {
+        case (None, _)          => ChiselExecutionFailure("Failed to elaborate Chisel circuit")
+        case (Some(_), None)    => ChiselExecutionFailure("Failed to convert Chisel circuit to FIRRTL")
+        case (Some(a), Some(b)) => ChiselExecutionSuccess( Some(a), b, Some(fResult))
+      }
+
+    }
+
+  }
+
+}

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.{OutputAnnotationFileAnnotation, Phase, StageOptions}
+import firrtl.options.Viewer.view
+
+import chisel3.stage.ChiselCircuitAnnotation
+
+/** Adds an [[firrtl.options.OutputAnnotationFileAnnotation OutputAnnotationFileAnnotation]] if one does not exist. This
+  * replicates old behavior where an output annotation file was always written.
+  */
+object AddImplicitOutputAnnotationFile extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
+    .collectFirst{ case a: OutputAnnotationFileAnnotation => annotations }
+    .getOrElse{
+
+      val x: Option[AnnotationSeq] = annotations
+        .collectFirst{ case a: ChiselCircuitAnnotation =>
+          OutputAnnotationFileAnnotation(a.circuit.name) +: annotations }
+
+      x.getOrElse(annotations)
+    }
+
+}

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.Phase
+
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselOutputFileAnnotation}
+
+/** Add a output file for a Chisel circuit, derived from the top module in the ciruict, if no
+  * [[ChiselOutputFileAnnotation]] already exists.
+  */
+object AddImplicitOutputFile extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq =
+    annotations.collectFirst{ case _: ChiselOutputFileAnnotation  => annotations }.getOrElse{
+
+      val x: Option[AnnotationSeq] = annotations
+        .collectFirst{ case a: ChiselCircuitAnnotation =>
+          ChiselOutputFileAnnotation(a.circuit.name) +: annotations }
+
+      x.getOrElse(annotations)
+    }
+
+}

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -1,0 +1,46 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import chisel3.stage.{ChiselOutputFileAnnotation, NoRunFirrtlCompilerAnnotation, PrintFullStackTraceAnnotation}
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.Annotation
+import firrtl.options.{OptionsException, Phase}
+
+object Checks extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val noF, st, outF = collection.mutable.ListBuffer[Annotation]()
+    annotations.foreach {
+      case a: NoRunFirrtlCompilerAnnotation.type => a +=: noF
+      case a: PrintFullStackTraceAnnotation.type => a +=: st
+      case a: ChiselOutputFileAnnotation         => a +=: outF
+      case _ =>
+    }
+
+    if (noF.size > 1) {
+      throw new OptionsException(
+        s"""|At most one NoRunFirrtlCompilerAnnotation can be specified, but found '${noF.size}'. Did you duplicate:
+            |    - option or annotation: -chnrf, --no-run-firrtl, NoRunFirrtlCompilerAnnotation
+            |""".stripMargin)
+    }
+
+    if (st.size > 1) {
+      throw new OptionsException(
+        s"""|At most one PrintFullStackTraceAnnotation can be specified, but found '${noF.size}'. Did you duplicate:
+            |    - option or annotation: --full-stacktrace, PrintFullStackTraceAnnotation
+            |""".stripMargin)
+    }
+
+    if (outF.size > 1) {
+      throw new OptionsException(
+        s"""|At most one Chisel output file can be specified but found '${outF.size}'. Did you duplicate:
+            |    - option or annotation: --chisel-output-file, ChiselOutputFileAnnotation
+            |""".stripMargin)
+    }
+
+    annotations
+  }
+
+}

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -1,0 +1,34 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import chisel3.experimental.RunFirrtlTransform
+import chisel3.internal.firrtl.Converter
+import chisel3.stage.ChiselCircuitAnnotation
+
+import firrtl.{AnnotationSeq, Transform}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.Phase
+import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
+
+object Convert extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
+    case a: ChiselCircuitAnnotation =>
+      /* Convert this Chisel Circuit to a FIRRTL Circuit */
+      Seq( DeletedAnnotation(name, a), FirrtlCircuitAnnotation(Converter.convert(a.circuit)) ) ++
+        /* Convert all Chisel Annotations to FIRRTL Annotations */
+        (a.circuit
+           .annotations
+           .map(_.toFirrtl)) ++
+        /* Add requested FIRRTL Transforms for any Chisel Annotations which mixed in RunFirrtlTransform */
+        (a.circuit
+           .annotations
+           .collect { case b: RunFirrtlTransform => b.transformClass }
+           .distinct
+           .filterNot(_ == classOf[firrtl.Transform])
+           .map { c: Class[_ <: Transform] => RunFirrtlTransformAnnotation(c.newInstance()) })
+    case a => Seq(a)
+  }
+
+}

--- a/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
@@ -1,0 +1,78 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.{OutputAnnotationFileAnnotation, Phase}
+import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
+
+import chisel3.stage.ChiselOutputFileAnnotation
+
+/** This provides components of a compatibility wrapper around Chisel's deprecated [[chisel.Driver Driver]].
+  *
+  * Primarily, this object includes [[firrtl.options.Phase Phase]]s that generate [[firrtl.annotation.Annotation
+  * Annotation]]s derived from the deprecated [[firrtl.options.phases.DriverCompatibility.TopNameAnnotation
+  * TopNameAnnotation]].
+  */
+object DriverCompatibility {
+
+  /** Indicates that an [[AnnotationSeq]] was run through a transform included in this compatibility layer */
+  private [phases] case object ChiselDriverCompatibilityAnnotation extends NoTargetAnnotation
+
+  /** Adds a [[ChiselOutputFileAnnotation]] derived from a [[TopNameAnnotation]] if no [[ChiselOutputFileAnnotation]]
+    * already exists. If no [[TopNameAnnotation]] exists, then no [[OutputFileAnnotation]] is added. ''This is not a
+    * replacement for [[chisel3.stage.phases.AddImplicitOutputFile AddImplicitOutputFile]] as this only adds an output
+    * file based on a discovered top name and not on a discovered elaborated circuit.'' Consequently, this will provide
+    * the correct behavior before a circuit has been elaborated.
+    * @note the output suffix is unspecified and will be set by [[chisel3.stage.phases.EmitCircuit EmitCircuit]]
+    */
+  private [chisel3] object AddImplicitOutputFile extends Phase {
+
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+      val hasOutputFile = annotations
+        .collectFirst{ case a: ChiselOutputFileAnnotation => a }
+        .isDefined
+      lazy val top = annotations.collectFirst{ case TopNameAnnotation(a) => a }
+
+      val annotationsx: AnnotationSeq =
+        if (!hasOutputFile && top.isDefined) {
+          ChiselOutputFileAnnotation(top.get) +: annotations
+        } else {
+          annotations
+        }
+
+      ChiselDriverCompatibilityAnnotation +: annotationsx
+    }
+
+  }
+
+  /** If a [[firrtl.options.OutputAnnotationFileAnnotation OutputAnnotationFileAnnotation]] does not exist, this adds one
+    * derived from a [[TopNameAnnotation]]. ''This is not a replacement for
+    * [[chisel3.stage.phases.AddImplicitOutputAnnotationFile AddImplicitOutputAnnotationFile]] as this only adds an
+    * output annotation file based on a discovered top name.'' Consequently, this will provide the correct behavior
+    * before a circuit has been elaborated.
+    * @note the output suffix is unspecified and will be set by [[firrtl.options.phases.WriteOutputAnnotations
+    * WriteOutputAnnotations]]
+    */
+  private [chisel3] object AddImplicitOutputAnnotationFile extends Phase {
+
+    def transform(annotations: AnnotationSeq): AnnotationSeq = {
+
+      val annotationsx: AnnotationSeq = annotations
+        .collectFirst{ case a: OutputAnnotationFileAnnotation => annotations }
+        .getOrElse{
+          val top = annotations.collectFirst{ case TopNameAnnotation(top) => top}
+
+          if (top.isDefined) {
+            OutputAnnotationFileAnnotation(top.get) +: annotations
+          } else {
+            annotations
+          }
+        }
+
+      ChiselDriverCompatibilityAnnotation +: annotationsx
+    }
+  }
+
+}

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -1,0 +1,41 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import java.io.{PrintWriter, StringWriter}
+
+import chisel3.{ChiselException, Module}
+import chisel3.internal.ErrorLog
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselCircuitAnnotation, ChiselOptions}
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.{OptionsException, Phase}
+import firrtl.options.Viewer.view
+
+object Elaborate extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
+    case a: ChiselGeneratorAnnotation =>
+      try {
+        Seq( DeletedAnnotation(name, a), a.elaborate )
+      } catch {
+        /* todo: How should OptionsExceptions be handled? */
+        case e: OptionsException => throw e
+        /* todo: What should this return? Should this delete the annotation? */
+        case e: ChiselException =>
+          val copts = view[ChiselOptions](annotations)
+          val stackTrace = if (!copts.printFullStackTrace) {
+            e.chiselStackTrace
+          } else {
+            val s = new StringWriter
+            e.printStackTrace(new PrintWriter(s))
+            s.toString
+          }
+          Predef.augmentString(stackTrace).lines.foreach(line => println(s"${ErrorLog.errTag} $line"))
+          Seq(DeletedAnnotation(name, a))
+      }
+    case a => Seq(a)
+  }
+
+}

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -1,0 +1,45 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import firrtl.{AnnotationSeq, EmittedFirrtlCircuit, EmittedFirrtlCircuitAnnotation}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.{Phase, StageOptions}
+import firrtl.options.Viewer.view
+
+import chisel3.internal.firrtl.{Emitter => OldEmitter}
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselOptions}
+
+import java.io.{File, FileWriter}
+
+/** Emit a [[chisel3.stage.ChiselCircuitAnnotation ChiselCircuitAnnotation]] to a file if a
+  * [[chisel3.stage.ChiselCircuitAnnotation ChiselCircuitAnnotation]] is present. A deleted
+  * [[firrtl.EmittedFirrtlCircuitAnnotation EmittedFirrtlCircuitAnnotation]] is added.
+  *
+  * @todo This should be switched to support correct emission of multiple circuits to multiple files. The API should
+  * likely mirror how the [[firrtl.stage.phases.Compiler phases.Compiler]] parses annotations into "global" annotations
+  * and left-associative per-ciruict annotations.
+  * @todo The use of the deleted [[firrtl.EmittedFirrtlCircuitAnnotation EmittedFirrtlCircuitAnnotation]] is a kludge to
+  * provide some breadcrumbs such that the emitter CHIRRTL can be provided back to the old Driver. This should be
+  * removed or a better solution developed.
+  */
+object Emitter extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val copts = view[ChiselOptions](annotations)
+    val sopts = view[StageOptions](annotations)
+
+    annotations.flatMap {
+      case a: ChiselCircuitAnnotation if copts.outputFile.isDefined =>
+        val file = new File(sopts.getBuildFileName(copts.outputFile.get, Some(".fir")))
+        val emitted = OldEmitter.emit(a.circuit)
+        val w = new FileWriter(file)
+        w.write(emitted)
+        w.close()
+        val anno = EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit(a.circuit.name, emitted, ".fir"))
+        Seq(DeletedAnnotation(name, anno), a)
+      case a => Seq(a)
+    }
+  }
+
+}

--- a/src/test/scala/chisel3/stage/phases/DriverCompatibilitySpec.scala
+++ b/src/test/scala/chisel3/stage/phases/DriverCompatibilitySpec.scala
@@ -1,0 +1,51 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3.stage.ChiselOutputFileAnnotation
+
+import firrtl.options.{OutputAnnotationFileAnnotation, StageOptions}
+import firrtl.options.Viewer.view
+import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
+
+class DriverCompatibilitySpec extends FlatSpec with Matchers {
+
+  behavior of DriverCompatibility.AddImplicitOutputFile.name
+
+  it should "do nothing if a ChiselOutputFileAnnotation is present" in {
+    val annotations = Seq(
+      ChiselOutputFileAnnotation("Foo"),
+      TopNameAnnotation("Bar") )
+    val expected = DriverCompatibility.ChiselDriverCompatibilityAnnotation +: annotations
+    DriverCompatibility.AddImplicitOutputFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "add a ChiselOutputFileAnnotation derived from a TopNameAnnotation" in {
+    val annotations = Seq( TopNameAnnotation("Bar") )
+    val expected = Seq(
+      DriverCompatibility.ChiselDriverCompatibilityAnnotation,
+      ChiselOutputFileAnnotation("Bar") ) ++ annotations
+    DriverCompatibility.AddImplicitOutputFile.transform(annotations).toSeq should be (expected)
+  }
+
+  behavior of DriverCompatibility.AddImplicitOutputAnnotationFile.name
+
+  it should "do nothing if an OutputAnnotationFileAnnotation is present" in {
+    val annotations = Seq(
+      OutputAnnotationFileAnnotation("Foo"),
+      TopNameAnnotation("Bar") )
+    val expected = DriverCompatibility.ChiselDriverCompatibilityAnnotation +: annotations
+    DriverCompatibility.AddImplicitOutputAnnotationFile.transform(annotations).toSeq should be (expected)
+  }
+
+  it should "add an OutputAnnotationFileAnnotation derived from a TopNameAnnotation" in {
+    val annotations = Seq( TopNameAnnotation("Bar") )
+    val expected = Seq(
+      DriverCompatibility.ChiselDriverCompatibilityAnnotation,
+      OutputAnnotationFileAnnotation("Bar") ) ++ annotations
+    DriverCompatibility.AddImplicitOutputAnnotationFile.transform(annotations).toSeq should be (expected)
+  }
+
+}

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -28,6 +28,7 @@ class DriverSpec extends FreeSpec with Matchers {
           val exts = List("anno.json", "fir", "v")
           for (ext <- exts) {
             val dummyOutput = new File(targetDir, "DummyModule" + "." + ext)
+            info(s"${dummyOutput.toString} exists")
             dummyOutput.exists() should be(true)
             dummyOutput.delete()
           }
@@ -44,6 +45,7 @@ class DriverSpec extends FreeSpec with Matchers {
           val exts = List("anno.json", "fir", "v")
           for (ext <- exts) {
             val dummyOutput = new File(targetDir, "dm" + "." + ext)
+            info(s"${dummyOutput.toString} exists")
             dummyOutput.exists() should be(true)
             dummyOutput.delete()
           }
@@ -53,14 +55,21 @@ class DriverSpec extends FreeSpec with Matchers {
       }
 
     }
+
     "execute returns a chisel execution result" in {
       val targetDir = "test_run_dir"
       val args = Array("--compiler", "low", "--target-dir", targetDir)
+
+      info("Driver returned a ChiselExecutionSuccess")
       val result = Driver.execute(args, () => new DummyModule)
       result shouldBe a[ChiselExecutionSuccess]
+
+      info("emitted circuit included 'circuit DummyModule'")
       val successResult = result.asInstanceOf[ChiselExecutionSuccess]
       successResult.emitted should include ("circuit DummyModule")
+
       val dummyOutput = new File(targetDir, "DummyModule.lo.fir")
+      info(s"${dummyOutput.toString} exists")
       dummyOutput.exists() should be(true)
       dummyOutput.delete()
     }

--- a/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
@@ -1,0 +1,65 @@
+// See LICENSE for license details.
+
+package chiselTests.stage
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3._
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation}
+import chisel3.experimental.RawModule
+
+import firrtl.options.OptionsException
+
+class ChiselAnnotationsSpecFoo extends RawModule {
+  val in = IO(Input(Bool()))
+  val out = IO(Output(Bool()))
+  out := ~in
+}
+
+class ChiselAnnotationsSpecBaz(name: String) extends ChiselAnnotationsSpecFoo {
+  override val desiredName = name
+}
+
+class ChiselAnnotationsSpecQux extends ChiselAnnotationsSpecFoo {
+  /* This printf requires an implicit clock and reset, but RawModule has none. This will thereby fail elaboration. */
+  printf("hello")
+}
+
+class ChiselAnnotation
+
+class ChiselAnnotationsSpec extends FlatSpec with Matchers {
+
+  behavior of "ChiselGeneratorAnnotation elaboration"
+
+  it should "elaborate to a ChiselCircuitAnnotation" in {
+    val annotation = ChiselGeneratorAnnotation(() => new ChiselAnnotationsSpecFoo)
+    annotation.elaborate shouldBe a [ChiselCircuitAnnotation]
+  }
+
+  it should "throw an exception if elaboration fails" in {
+    val annotation = ChiselGeneratorAnnotation(() => new ChiselAnnotationsSpecQux)
+    intercept [ChiselException] { annotation.elaborate }
+  }
+
+  behavior of "ChiselGeneratorAnnotation when stringly constructing from Module names"
+
+  it should "elaborate from a String" in {
+    val annotation = ChiselGeneratorAnnotation("chiselTests.stage.ChiselAnnotationsSpecFoo")
+    annotation.elaborate shouldBe a [ChiselCircuitAnnotation]
+  }
+
+  it should "throw an exception if elaboration from a String refers to nonexistant class" in {
+    val bar = "chiselTests.stage.ChiselAnnotationsSpecBar"
+    val annotation = ChiselGeneratorAnnotation(bar)
+    intercept [OptionsException] { annotation.elaborate }
+      .getMessage should startWith (s"Unable to locate module '$bar'")
+  }
+
+  it should "throw an exception if elaboration from a String refers to an anonymous class" in {
+    val baz = "chiselTests.stage.ChiselAnnotationsSpecBaz"
+    val annotation = ChiselGeneratorAnnotation(baz)
+    intercept [OptionsException] { annotation.elaborate }
+      .getMessage should startWith (s"Unable to create instance of module '$baz'")
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/ChiselOptionsViewSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselOptionsViewSpec.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package chiselTests.stage
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import firrtl.options.Viewer.view
+
+import chisel3.stage._
+import chisel3.internal.firrtl.Circuit
+
+class ChiselOptionsViewSpec extends FlatSpec with Matchers {
+
+  behavior of ChiselOptionsView.getClass.getName
+
+  it should "construct a view from an AnnotationSeq" in {
+    val bar = Circuit("bar", Seq.empty, Seq.empty)
+    val annotations = Seq(
+      NoRunFirrtlCompilerAnnotation,
+      PrintFullStackTraceAnnotation,
+      ChiselOutputFileAnnotation("foo"),
+      ChiselCircuitAnnotation(bar)
+    )
+    val out = view[ChiselOptions](annotations)
+
+    info("runFirrtlCompiler was set to false")
+    out.runFirrtlCompiler should be (false)
+
+    info("printFullStackTrace was set to true")
+    out.printFullStackTrace should be (true)
+
+    info("outputFile was set to 'foo'")
+    out.outputFile should be (Some("foo"))
+
+    info("chiselCircuit was set to circuit 'bar'")
+    out.chiselCircuit should be (Some(bar))
+
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/AddImplicitOutputAnnotationFileSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/AddImplicitOutputAnnotationFileSpec.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3.experimental.RawModule
+import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.stage.phases.{AddImplicitOutputAnnotationFile, Elaborate}
+
+import firrtl.AnnotationSeq
+import firrtl.options.OutputAnnotationFileAnnotation
+
+class AddImplicitOutputAnnotationFileSpec extends FlatSpec with Matchers {
+
+  class Foo extends RawModule { override val desiredName = "Foo" }
+
+  behavior of AddImplicitOutputAnnotationFile.name
+
+  it should "not override an existing OutputAnnotationFileAnnotation" in {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      OutputAnnotationFileAnnotation("Bar") )
+
+    Seq( Elaborate, AddImplicitOutputAnnotationFile )
+      .foldLeft(annotations)((a, p) => p.transform(a))
+      .collect{ case a: OutputAnnotationFileAnnotation => a.file }
+      .toSeq should be (Seq("Bar"))
+  }
+
+  it should "generate an OutputAnnotationFileAnnotation from a ChiselCircuitAnnotation" in {
+    val annotations: AnnotationSeq = Seq( ChiselGeneratorAnnotation(() => new Foo) )
+
+    Seq( Elaborate, AddImplicitOutputAnnotationFile )
+      .foldLeft(annotations)((a, p) => p.transform(a))
+      .collect{ case a: OutputAnnotationFileAnnotation => a.file }
+      .toSeq should be (Seq("Foo"))
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/AddImplicitOutputFileSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/AddImplicitOutputFileSpec.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3.experimental.RawModule
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselOutputFileAnnotation}
+import chisel3.stage.phases.{AddImplicitOutputFile, Elaborate}
+
+import firrtl.AnnotationSeq
+import firrtl.options.{StageOptions, TargetDirAnnotation}
+import firrtl.options.Viewer.view
+
+class AddImplicitOutputFileSpec extends FlatSpec with Matchers {
+
+  class Foo extends RawModule { override val desiredName = "Foo" }
+
+  behavior of AddImplicitOutputFile.name
+
+  it should "not override an existing ChiselOutputFileAnnotation" in {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      ChiselOutputFileAnnotation("Bar") )
+
+    Seq( Elaborate, AddImplicitOutputFile )
+      .foldLeft(annotations)((a, p) => p.transform(a))
+      .collect{ case a: ChiselOutputFileAnnotation => a.file }
+      .toSeq should be (Seq("Bar"))
+  }
+
+  it should "generate a ChiselOutputFileAnnotation from a ChiselCircuitAnnotation" in {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      TargetDirAnnotation("test_run_dir") )
+
+    Seq( Elaborate, AddImplicitOutputFile )
+      .foldLeft(annotations)((a, p) => p.transform(a))
+      .collect{ case a: ChiselOutputFileAnnotation => a.file }
+      .toSeq should be (Seq("Foo"))
+  }
+
+  it should "do nothing to an empty annotation sequence" in {
+    AddImplicitOutputFile.transform(AnnotationSeq(Seq.empty)).toSeq should be (empty)
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/ChecksSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/ChecksSpec.scala
@@ -1,0 +1,41 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3.stage.{ChiselOutputFileAnnotation, NoRunFirrtlCompilerAnnotation, PrintFullStackTraceAnnotation}
+import chisel3.stage.phases.Checks
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.{OptionsException, Phase}
+
+class ChecksSpec extends FlatSpec with Matchers {
+
+  def checkExceptionMessage(phase: Phase, annotations: AnnotationSeq, messageStart: String): Unit =
+    intercept[OptionsException]{ phase.transform(annotations) }.getMessage should startWith(messageStart)
+
+  behavior of Checks.name
+
+  it should "do nothing on sane annotation sequences" in {
+    val a = Seq(NoRunFirrtlCompilerAnnotation, PrintFullStackTraceAnnotation)
+    Checks.transform(a).toSeq should be (a)
+  }
+
+  it should "throw an OptionsException if more than one NoRunFirrtlCompilerAnnotation is specified" in {
+    val a = Seq(NoRunFirrtlCompilerAnnotation, NoRunFirrtlCompilerAnnotation)
+    checkExceptionMessage(Checks, a, "At most one NoRunFirrtlCompilerAnnotation")
+  }
+
+  it should "throw an OptionsException if more than one PrintFullStackTraceAnnotation is specified" in {
+    val a = Seq(PrintFullStackTraceAnnotation, PrintFullStackTraceAnnotation)
+    checkExceptionMessage(Checks, a, "At most one PrintFullStackTraceAnnotation")
+  }
+
+  it should "throw an OptionsException if more than one ChiselOutputFileAnnotation is specified" in {
+    val a = Seq(ChiselOutputFileAnnotation("foo"), ChiselOutputFileAnnotation("bar"))
+    checkExceptionMessage(Checks, a, "At most one Chisel output file")
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
@@ -1,0 +1,59 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3._
+import chisel3.experimental.{ChiselAnnotation, RawModule, RunFirrtlTransform}
+import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.stage.phases.{Convert, Elaborate}
+
+import firrtl.{AnnotationSeq, CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.annotations.{Annotation, NoTargetAnnotation}
+import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
+
+class ConvertSpecFirrtlTransform extends Transform {
+  def inputForm: CircuitForm = UnknownForm
+  def outputForm: CircuitForm = UnknownForm
+  def execute(state: CircuitState): CircuitState = state
+}
+
+case class ConvertSpecFirrtlAnnotation(name: String) extends NoTargetAnnotation
+
+case class ConvertSpecChiselAnnotation(name: String) extends ChiselAnnotation with RunFirrtlTransform {
+  def toFirrtl: Annotation = ConvertSpecFirrtlAnnotation(name)
+  def transformClass: Class[_ <: Transform] = classOf[ConvertSpecFirrtlTransform]
+}
+
+class ConvertSpecFoo extends RawModule {
+  override val desiredName: String = "foo"
+
+  val in = IO(Input(Bool()))
+  val out = IO(Output(Bool()))
+
+  experimental.annotate(new ConvertSpecChiselAnnotation("bar"))
+}
+
+class ConvertSpec extends FlatSpec with Matchers {
+
+  behavior of Convert.name
+
+  it should "convert a Chisel Circuit to a FIRRTL Circuit" in {
+    val annos: AnnotationSeq = Seq(ChiselGeneratorAnnotation(() => new ConvertSpecFoo))
+
+    val annosx = Seq(Elaborate, Convert)
+      .foldLeft(annos)( (a, p) => p.transform(a) )
+
+    info("FIRRTL circuit generated")
+    annosx.collect{ case a: FirrtlCircuitAnnotation => a.circuit.main }.toSeq should be (Seq("foo"))
+
+    info("FIRRTL annotations generated")
+    annosx.collect{ case a: ConvertSpecFirrtlAnnotation => a.name }.toSeq should be (Seq("bar"))
+
+    info("FIRRTL transform annotations generated")
+    annosx.collect{ case a: RunFirrtlTransformAnnotation => a.transform.getClass}
+      .toSeq should be (Seq(classOf[ConvertSpecFirrtlTransform]))
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/ElaborateSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/ElaborateSpec.scala
@@ -1,0 +1,44 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3._
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation}
+import chisel3.stage.phases.Elaborate
+
+import firrtl.annotations.DeletedAnnotation
+
+class ElaborateSpec extends FlatSpec with Matchers {
+
+  class Foo extends Module {
+    override def desiredName: String = "Foo"
+    val io = IO(
+      new Bundle {
+        val in = Input(Bool())
+        val out = Output(Bool())
+      })
+
+    io.out := ~io.in
+  }
+
+  class Bar extends Foo {
+    override def desiredName: String = "Bar"
+  }
+
+  behavior of Elaborate.name
+
+  it should "expand ChiselGeneratorAnnotations into ChiselCircuitAnnotations and delete originals" in {
+    val annotations = Seq( ChiselGeneratorAnnotation(() => new Foo),
+                           ChiselGeneratorAnnotation(() => new Bar) )
+    val out = Elaborate.transform(annotations)
+
+    info("original annotations deleted")
+    out.collect{ case DeletedAnnotation(_, a: ChiselGeneratorAnnotation) => a } should be (annotations)
+
+    info("circuits created with the expected names")
+    out.collect{ case a: ChiselCircuitAnnotation => a.circuit.name } should be (Seq("Foo", "Bar"))
+  }
+
+}

--- a/src/test/scala/chiselTests/stage/phases/EmitterSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/EmitterSpec.scala
@@ -1,0 +1,58 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import chisel3.experimental.RawModule
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, ChiselOutputFileAnnotation}
+import chisel3.stage.phases.{Convert, Elaborate, Emitter}
+
+import firrtl.{AnnotationSeq, EmittedFirrtlCircuitAnnotation}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.options.TargetDirAnnotation
+
+import java.io.File
+
+class EmitterSpec extends FlatSpec with Matchers {
+
+  class FooModule extends RawModule { override val desiredName = "Foo" }
+  class BarModule extends RawModule { override val desiredName = "Bar" }
+
+  behavior of Emitter.getClass.getName
+
+  it should "do nothing if no ChiselOutputFileAnnotations are present" in {
+    val dir = new File("test_run_dir/EmitterSpec")
+    val annotations = Elaborate.transform(Seq( TargetDirAnnotation(dir.toString),
+                                               ChiselGeneratorAnnotation(() => new FooModule) ))
+    val annotationsx = Emitter.transform(annotations)
+
+    val Seq(fooFile, barFile) = Seq("Foo.fir", "Bar.fir").map(f => new File(dir + "/" + f))
+
+    info(s"$fooFile does not exist")
+    fooFile should not (exist)
+
+    info("annotations are unmodified")
+    annotationsx.toSeq should be (annotations.toSeq)
+  }
+
+  it should "emit a ChiselCircuitAnnotation to a specific file" in {
+    val dir = new File("test_run_dir/EmitterSpec")
+    val circuit = Elaborate
+      .transform(Seq(ChiselGeneratorAnnotation(() => new BarModule)))
+      .collectFirst{ case a: ChiselCircuitAnnotation => a}
+      .get
+    val annotations = Emitter.transform(Seq( TargetDirAnnotation(dir.toString),
+                                             circuit,
+                                             ChiselOutputFileAnnotation("Baz") ))
+
+    val bazFile = new File(dir + "/Baz.fir")
+
+    info(s"$bazFile exists")
+    bazFile should (exist)
+
+    info("a deleted EmittedFirrtlCircuitAnnotation should be generated")
+    annotations.collect{ case a @ DeletedAnnotation(_, _: EmittedFirrtlCircuitAnnotation) => a }.size should be (1)
+  }
+
+}


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

This PR provides a reimplementation of the Chisel Driver as a `Stage`. The Chisel Driver is converted to a compatibility wrapper around the FIRRTL Stage that freechipsproject/firrtl#920 provides. This PR is split up into separate commits that shows the order in which the porting was done and a rough guide for how this can be done for other repositories:

1. Add expected annotations
2. Write the CLI
3. Add the `xOptions` class (which is not a case class)
4. Write an options view to construct your `xOptions`
5. Add methods to existing `ExecutionOptions` to reconstruct an `AnnotationSeq`
6. Write all new phases to reimplement Driver functionality
7. Write any necessary compatibility layer and/or re-use existing compatibility layers
8. Write the new `Stage`
9. Replace old Driver logic with new phases

Anecdotally, this process is non-linear. I did this by incrementally porting the old Driver in pieces and moving whatever functionality I could into it when I had it. Git's `--squash` and `--fixup` help a lot for keeping the history sane when you do rebase. Additionally, writing tests as you go is tedious, but likely necessary.

__Most of the porting difficulty is (1) deciding, without constraints, what you want the new stage to do and (2) writing the compatibility layer that interfaces this with the old Driver.__ 

There are several temptations here that I think should be avoided:

- Opting to have the old Driver call an old, already ported, sub-Driver (e.g., have `chisel3.Driver` call `firrtl.Driver`). This causes the old Driver and the new Stage to use different code paths. While not insurmountable, this would seem to introduce the potential for subtle bugs between the two versions.
- For the same reasons as above, no functionality should differ between the old Driver and the new stage excepting compatibility layer phases and a view to an execution result.

Most of difficulty in not yielding to these temptations is dealing with situations where the old Driver does not do things in a linear, pipe-like order. E.g., the old Chisel Driver would do elaboration and then continually refer back to the elaborated Chisel circuit. The stage doesn't need to do this as it's moving directly towards a CHIRRTL circuit or to run the FIRRTL compiler. However, the compatibility wrapper has to reconstruct what happened. This PR gets around this, kludgily, by viewing deleted annotations. This isn't really advised, but for a compatibility layer it's passable.

Depends on:
  - https://github.com/freechipsproject/firrtl/pull/920.

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Adds ChiselStage, a the Chisel Driver as a firrtl.options.Stage
- The original Chisel Driver is converted to a compatibility layer around ChiselStage