### PR TITLE
Improve chiselName to name Iterable[Data], Option[Data]

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -225,22 +225,6 @@ abstract class BaseModule extends HasId {
       }
     }
 
-    /** Recursively suggests names to supported "container" classes
-      * Arbitrary nestings of supported classes are allowed so long as the
-      * innermost element is of type HasId
-      * (Note: Map is Iterable[Tuple2[_,_]] and thus excluded)
-      */
-    def nameRecursively(prefix: String, nameMe: Any): Unit =
-      nameMe match {
-        case (id: HasId) => name(id, prefix)
-        case Some(elt) => nameRecursively(prefix, elt)
-        case (iter: Iterable[_]) if iter.hasDefiniteSize =>
-          for ((elt, i) <- iter.zipWithIndex) {
-            nameRecursively(s"${prefix}_${i}", elt)
-          }
-        case _ => // Do nothing
-      }
-
     /** Scala generates names like chisel3$util$Queue$$ram for private vals
       * This extracts the part after $$ for names like this and leaves names
       * without $$ unchanged
@@ -248,7 +232,7 @@ abstract class BaseModule extends HasId {
     def cleanName(name: String): String = name.split("""\$\$""").lastOption.getOrElse(name)
 
     for (m <- getPublicFields(rootClass)) {
-      nameRecursively(cleanName(m.getName), m.invoke(this))
+      Builder.nameRecursively(cleanName(m.getName), m.invoke(this), name)
     }
 
     names

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -294,6 +294,21 @@ private[chisel3] object Builder {
     lastStack
   }
 
+  /** Recursively suggests names to supported "container" classes
+    * Arbitrary nestings of supported classes are allowed so long as the
+    * innermost element is of type HasId
+    * (Note: Map is Iterable[Tuple2[_,_]] and thus excluded)
+    */
+  def nameRecursively(prefix: String, nameMe: Any, namer: (HasId, String) => Unit): Unit = nameMe match {
+    case (id: HasId) => namer(id, prefix)
+    case Some(elt) => nameRecursively(prefix, elt, namer)
+    case (iter: Iterable[_]) if iter.hasDefiniteSize =>
+      for ((elt, i) <- iter.zipWithIndex) {
+        nameRecursively(s"${prefix}_${i}", elt, namer)
+      }
+    case _ => // Do nothing
+  }
+
   def errors: ErrorLog = dynamicContext.errors
   def error(m: => String): Unit = if (dynamicContextVar.value.isDefined) errors.error(m)
   def warning(m: => String): Unit = if (dynamicContextVar.value.isDefined) errors.warning(m)

--- a/chiselFrontend/src/main/scala/chisel3/internal/Namer.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Namer.scala
@@ -84,10 +84,7 @@ class NamingContext {
     closed = true
     for ((ref, suffix) <- items) {
       // First name the top-level object
-      ref match {
-        case nameable: chisel3.internal.HasId => nameable.suggestName(prefix + suffix)
-        case _ =>
-      }
+      chisel3.internal.Builder.nameRecursively(prefix + suffix, ref, (id, name) => id.suggestName(name))
 
       // Then recurse into descendant contexts
       if (descendants.containsKey(ref)) {

--- a/src/test/scala/chiselTests/NamingAnnotationTest.scala
+++ b/src/test/scala/chiselTests/NamingAnnotationTest.scala
@@ -67,6 +67,11 @@ class NamedModule extends NamedModuleTester {
     val myA = expectName(1.U + myNested, "test_myA")
     val myB = expectName(myA +& 2.U, "test_myB")
     val myC = expectName(myB +& 3.U, "test_myC")
+
+    val myD = Seq(myC +& 1.U, myC +& 2.U)
+    for ((d, i) <- myD.zipWithIndex)
+      expectName(d, s"test_myD_$i")
+
     myC +& 4.U  // named at enclosing scope
   }
 


### PR DESCRIPTION
I noticed that chiselName wasn't naming some things that reflective naming does name.  This is because chiselName only looks for HasId, whereas reflective naming will dig through Options and Iterables to look for a HasId.  This PR changes chiselName to use the same algorithm as reflective naming.

**Type of change**: other enhancement

**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
