### PR TITLE
Miscellaneous Scaladoc Cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,18 @@ lazy val chisel = (project in file(".")).
       "-diagrams-max-classes", "25",
       "-doc-version", version.value,
       "-doc-title", name.value,
-      "-doc-root-content", baseDirectory.value+"/root-doc.txt"
+      "-doc-root-content", baseDirectory.value+"/root-doc.txt",
+      "-sourcepath", (baseDirectory in ThisBuild).value.toString,
+      "-doc-source-url",
+      {
+        val branch =
+          if (version.value.endsWith("-SNAPSHOT")) {
+            "master"
+          } else {
+            s"v${version.value}"
+          }
+        s"https://github.com/freechipsproject/chisel3/tree/$branch/€{FILE_PATH}.scala"
+      }
     ),
     // Include macro classes, resources, and sources main JAR since we don't create subproject JARs.
     mappings in (Compile, packageBin) ++= (mappings in (coreMacros, Compile, packageBin)).value,

--- a/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Annotation.scala
@@ -5,7 +5,6 @@ package chisel3.core
 import scala.language.existentials
 
 import chisel3.internal.{Builder, InstanceId}
-import chisel3.core.ImplicitModule
 import firrtl.Transform
 import firrtl.annotations.{Annotation, CircuitName, ComponentName, ModuleName}
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
@@ -30,9 +29,10 @@ object ChiselAnnotation {
     }
 }
 
-/** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this
-  * Annotation is present during a run of [[chisel3.Driver.execute]]. Automatic Transform
-  * instantiation is *not* supported when the Circuit and Annotations are serialized before invoking
+/** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this Annotation is present
+  * during a run of
+  * [[Driver$.execute(args:Array[String],dut:()=>chisel3\.experimental\.RawModule)* Driver.execute]].
+  * Automatic Transform instantiation is *not* supported when the Circuit and Annotations are serialized before invoking
   * FIRRTL.
   */
 // TODO There should be a FIRRTL API for this instead
@@ -99,7 +99,7 @@ object dontTouch { // scalastyle:ignore object.name
   *        val b = Input(UInt(32.W))
   *        val out = Output(UInt(32.W))
   *      })
-  *      override def desiredName = s"adder_$myNname"
+  *      override def desiredName = "adder_" + myNname
   *      io.out := io.a + io.b
   *    })
   *    doNotDedup(m)

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -1285,7 +1285,7 @@ sealed class Bool() extends UInt(1.W) with Reset {
     *
     * @param that a hardware $coll
     * @return the lgocial or of this $coll and `that`
-    * @note this is equivalent to [[Bool.|]]
+    * @note this is equivalent to [[Bool!.|(that:chisel3\.core\.Bool)* Bool.|)]]
     * @group Logical
     */
   def || (that: Bool): Bool = macro SourceInfoTransform.thatArg
@@ -1297,7 +1297,7 @@ sealed class Bool() extends UInt(1.W) with Reset {
     *
     * @param that a hardware $coll
     * @return the lgocial and of this $coll and `that`
-    * @note this is equivalent to [[Bool.&]]
+    * @note this is equivalent to [[Bool!.&(that:chisel3\.core\.Bool)* Bool.&]]
     * @group Logical
     */
   def && (that: Bool): Bool = macro SourceInfoTransform.thatArg

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -567,9 +567,8 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
 }
 
 trait WireFactory {
-  /** @usecase def apply[T <: Data](t: T): T
-    *   Construct a [[Wire]] from a type template
-    *   @param t The template from which to construct this wire
+  /** Construct a [[Wire]] from a type template
+    * @param t The template from which to construct this wire
     */
   def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     if (compileOptions.declaredTypeMustBeUnbound) {
@@ -681,29 +680,25 @@ object WireDefault {
     x
   }
 
-  /** @usecase def apply[T <: Data](t: T, init: DontCare.type): T
-    *   Construct a [[Wire]] with a type template and a [[DontCare]] default
-    *   @param t The type template used to construct this [[Wire]]
-    *   @param init The default connection to this [[Wire]], can only be [[DontCare]]
-    *   @note This is really just a specialized form of `apply[T <: Data](t: T, init: T): T` with [[DontCare]]
-    *   as `init`
+  /** Construct a [[Wire]] with a type template and a [[DontCare]] default
+    * @param t The type template used to construct this [[Wire]]
+    * @param init The default connection to this [[Wire]], can only be [[DontCare]]
+    * @note This is really just a specialized form of `apply[T <: Data](t: T, init: T): T` with [[DontCare]] as `init`
     */
   def apply[T <: Data](t: T, init: DontCare.type)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = { // scalastyle:ignore line.size.limit
     applyImpl(t, init)
   }
 
-  /** @usecase def apply[T <: Data](t: T, init: T): T
-    *   Construct a [[Wire]] with a type template and a default connection
-    *   @param t The type template used to construct this [[Wire]]
-    *   @param init The hardware value that will serve as the default value
+  /** Construct a [[Wire]] with a type template and a default connection
+    * @param t The type template used to construct this [[Wire]]
+    * @param init The hardware value that will serve as the default value
     */
   def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     applyImpl(t, init)
   }
 
-  /** @usecase def apply[T <: Data](init: T): T
-    *   Construct a [[Wire]] with a default connection
-    *   @param init The hardware value that will serve as a type template and default value
+  /** Construct a [[Wire]] with a default connection
+    * @param init The hardware value that will serve as a type template and default value
     */
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (init match {

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -498,7 +498,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
     case Some(BundleLitBinding(litMap)) => None  // this API does not support Bundle literals
     case _ => None
   }
- 
+
   def isLit(): Boolean = litArg.isDefined
 
   /**
@@ -680,7 +680,7 @@ object WireDefault {
     x
   }
 
-  /** Construct a [[Wire]] with a type template and a [[DontCare]] default
+  /** Construct a [[Wire]] with a type template and a [[chisel3.DontCare]] default
     * @param t The type template used to construct this [[Wire]]
     * @param init The default connection to this [[Wire]], can only be [[DontCare]]
     * @note This is really just a specialized form of `apply[T <: Data](t: T, init: T): T` with [[DontCare]] as `init`
@@ -740,4 +740,3 @@ private[chisel3] object DontCare extends Element {
   // DontCare's only match themselves.
   private[core] def typeEquivalent(that: chisel3.core.Data): Boolean = that == DontCare
 }
-

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -30,10 +30,9 @@ import chisel3.internal.sourceinfo.{SourceInfo}
   *
   */
 object Reg {
-  /** @usecase def apply[T <: Data](t: T): T
-    *   Construct a [[Reg]] from a type template with no initialization value (reset is ignored).
-    *   Value will not change unless the [[Reg]] is given a connection.
-    *   @param t The template from which to construct this wire
+  /** Construct a [[Reg]] from a type template with no initialization value (reset is ignored).
+    * Value will not change unless the [[Reg]] is given a connection.
+    * @param t The template from which to construct this wire
     */
   def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     if (compileOptions.declaredTypeMustBeUnbound) {
@@ -143,10 +142,9 @@ object RegNext {
   * }}}
   */
 object RegInit {
-  /** @usecase def apply[T <: Data](t: T, init: T): T
-    *   Construct a [[Reg]] from a type template initialized to the specified value on reset
-    *   @param t The type template used to construct this [[Reg]]
-    *   @param init The value the [[Reg]] is initialized to on reset
+  /** Construct a [[Reg]] from a type template initialized to the specified value on reset
+    * @param t The type template used to construct this [[Reg]]
+    * @param init The value the [[Reg]] is initialized to on reset
     */
   def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     if (compileOptions.declaredTypeMustBeUnbound) {
@@ -162,9 +160,8 @@ object RegInit {
     reg
   }
 
-  /** @usecase def apply[T <: Data](init: T): T
-    *   Construct a [[Reg]] initialized on reset to the specified value.
-    *   @param init Initial value that serves as a type template and reset value
+  /** Construct a [[Reg]] initialized on reset to the specified value.
+    * @param init Initial value that serves as a type template and reset value
     */
   def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (init match {

--- a/coreMacros/src/main/scala/chisel3/SourceInfoDoc.scala
+++ b/coreMacros/src/main/scala/chisel3/SourceInfoDoc.scala
@@ -15,27 +15,23 @@ package chisel3
   *   <br>
   *
   *   The equivalent public-facing methods do not have the `do_` prefix or have the same name. Use and look at the
-  *   documentation for those. If you want left shift, use `<<`, not `do_<<`. If you want comversion to a [[Seq]] of
-  *   [[Bool]]s look at the `asBools` above, not the one below. Users can safely ignore every method in this group!
-  *   <br>
-  *   <br>
+  *   documentation for those. If you want left shift, use `<<`, not `do_<<`. If you want conversion to a
+  *   [[scala.collection.Seq Seq]] of [[Bool]]s look at the `asBools` above, not the one below. Users can safely ignore
+  *   every method in this group! <br> <br>
   *
   *   🐉🐉🐉 '''Here be dragons...''' 🐉🐉🐉
   *   <br>
   *   <br>
   *
-  *   These `do_X` methods are used to enable both implicit passing of [[SourceInfo]] and
-  *   [[chisel3.core.CompileOptions]] while also supporting chained apply methods. In effect all "normal" methods that
-  *   you, as a user, will use in your designs, are converted to their "hidden", `do_*`, via macro transformations.
-  *   Without using macros here, only one of the above wanted behaviors is allowed (implicit passing and chained
-  *   applies)---the compiler interprets a chained apply as an explicit 'implicit' argument and will throw type errors.
-  *   <br>
-  *   <br>
+  *   These `do_X` methods are used to enable both implicit passing of SourceInfo and [[chisel3.core.CompileOptions]]
+  *   while also supporting chained apply methods. In effect all "normal" methods that you, as a user, will use in your
+  *   designs, are converted to their "hidden", `do_*`, via macro transformations. Without using macros here, only one
+  *   of the above wanted behaviors is allowed (implicit passing and chained applies)---the compiler interprets a
+  *   chained apply as an explicit 'implicit' argument and will throw type errors. <br> <br>
   *
-  *   The "normal", public-facing methods then take no [[SourceInfo]]. However, a macro transforms this public-facing
-  *   method into a call to an internal, hidden `do_*` that takes an explicit [[SourceInfo]] by inserting an
-  *   `implicitly[SourceInfo]` as the explicit argument.
-  * </p>
+  *   The "normal", public-facing methods then take no SourceInfo. However, a macro transforms this public-facing method
+  *   into a call to an internal, hidden `do_*` that takes an explicit SourceInfo by inserting an
+  *   `implicitly[SourceInfo]` as the explicit argument. </p>
   *
   * @groupprio SourceInfoTransformMacro 1001
   */

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -151,7 +151,7 @@ object Driver extends BackendCompilationUtilities {
     * Emit the annotations of a circuit
     *
     * @param ir The circuit containing annotations to be emitted
-    * @param optName An optional filename (will use s"${ir.name}.json" otherwise)
+    * @param optName An optional filename (will use s"\${ir.name}.json" otherwise)
     */
   def dumpAnnotations(ir: Circuit, optName: Option[File]): File = {
     val f = optName.getOrElse(new File(ir.name + ".anno.json"))

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -61,7 +61,7 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   * }}}
   *
   * In addition to adding the `valid` bit, a [[Valid.fire]] method is also added that returns the `valid` bit. This
-  * provides a similarly named interface to [[DecoupledIO.fire]].
+  * provides a similarly named interface to [[DecoupledIO]]'s fire.
   *
   * @see [[Decoupled$ DecoupledIO Factory]]
   * @see [[Irrevocable$ IrrevocableIO Factory]]

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -18,7 +18,7 @@ import chisel3.internal.Namespace
 class BoringUtilsException(message: String) extends Exception(message)
 
 /** Utilities for generating synthesizable cross module references that "bore" through the hierarchy. The underlying
-  * cross module connects are handled by FIRRTL's Wiring Transform ([[firrtl.passes.wiring.WiringTransform]]).
+  * cross module connects are handled by FIRRTL's Wiring Transform.
   *
   * Consider the following exmple where you want to connect a component in one module to a component in another. Module
   * `Constant` has a wire tied to `42` and `Expect` will assert unless connected to `42`:

--- a/src/main/scala/chisel3/util/experimental/Inline.scala
+++ b/src/main/scala/chisel3/util/experimental/Inline.scala
@@ -28,8 +28,8 @@ import firrtl.annotations.{CircuitName, ModuleName, ComponentName, Annotation}
   * class Bar extends Module with Internals with HasSub
   * /* The resulting instances will be:
   *  - Top
-  *  - Top.x$sub
-  *  - Top.y$sub
+  *  - Top.x\$sub
+  *  - Top.y\$sub
   *  - Top.z
   *  - Top.z.sub */
   * class Top extends Module with Internals {


### PR DESCRIPTION
This is a smattering of improvements to Scaladoc:

1. This modifies `build.sbt` to include links to the GitHub sources in each generated Scaladoc page. This will use `master` for any `*-SNAPSHOT` and `v$version` for any versioned release.
2. `@usecase` is deprecated in Scala 2.13.x. This removes the six uses of `@usecase`. See: https://github.com/scala/scala/pull/7462
3. This cleans up `loadMemoryFromFile` by moving its documentation to the object as opposed to the `apply` method. Miscellaneous fixes are applied related to grammar, captialization, and addition of an outbound link to the associated tests.
4. All warnings stemming from Scaladoc generation are cleared. This was primarily related to fixing bad links.

Note: to fix ambigous method calls (e.g., which `Driver.execute` do you mean in the documentation?) you need to use [some rather interesting syntax](https://github.com/freechipsproject/chisel3/compare/cleanup-scaladoc?expand=1#diff-af2878daa0a229be50b75d1e496196bcR34) that isn't documented.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Add GitHub source links to Scaladoc
- Fix missing links in Scaladoc