### PR TITLE
Generate better names for Pipe via TransitName

### DIFF
--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -8,7 +8,6 @@ package chisel3.util
 import chisel3._
 import chisel3.core.CompileOptions
 import chisel3.experimental.DataMirror
-import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 
 /** A [[Bundle]] that adds a `valid` bit to some data. This indicates that the user expects a "valid" interface between
   * a producer and a consumer. Here, the producer asserts the `valid` bit when data on the `bits` line contains valid
@@ -109,7 +108,6 @@ object Pipe {
     * @param latency the number of pipeline stages
     * @return $returnType
     */
-  @chiselName
   def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int)(implicit compileOptions: CompileOptions): Valid[T] = {
     require(latency >= 0, "Pipe latency must be greater than or equal to zero!")
     if (latency == 0) {
@@ -120,7 +118,10 @@ object Pipe {
     } else {
       val v = RegNext(enqValid, false.B)
       val b = RegEnable(enqBits, enqValid)
-      apply(v, b, latency-1)(compileOptions)
+      val out = apply(v, b, latency-1)(compileOptions)
+
+      TransitName.withSuffix("Pipe_valid")(out, v)
+      TransitName.withSuffix("Pipe_bits")(out, b)
     }
   }
 


### PR DESCRIPTION
This switches to using `TransitName` for name generation inside the `Pipe` factory. This then uses the suffix of `Pipe_valid` and Pipe`_bits` for the delayed versions of signals. I'm open to an alternative naming convention if there are any suggetsions. Oddly, from what I can tell, `chiselName` wasn't helping with naming before.

```scala
class Foo extends MultiIOModule {
  val in = IO(Input(Valid(UInt(2.W))))
  val bar = Pipe(in, 2)
}
```

Before:
```
circuit PipeSpecFoo1 :
  module PipeSpecFoo1 :
    input clock : Clock
    input reset : UInt<1>
    input in : { valid : UInt<1>, bits : UInt<2>}
  
    reg _T : UInt<1>, clock with :
      reset => (reset, UInt<1>("h0")) @[Valid.scala 121:22]
    _T <= in.valid @[Valid.scala 121:22]
    reg _T_1 : UInt<2>, clock with :
      reset => (UInt<1>("h0"), _T_1) @[Reg.scala 11:16]
    when in.valid : @[Reg.scala 12:19]
      _T_1 <= in.bits @[Reg.scala 12:23]
    reg _T_2 : UInt<1>, clock with :
      reset => (reset, UInt<1>("h0")) @[Valid.scala 121:22]
    _T_2 <= _T @[Valid.scala 121:22]
    reg _T_3 : UInt<2>, clock with :
      reset => (UInt<1>("h0"), _T_3) @[Reg.scala 11:16]
    when _T : @[Reg.scala 12:19]
      _T_3 <= _T_1 @[Reg.scala 12:23]
    wire bar : { valid : UInt<1>, bits : UInt<2>} @[Valid.scala 116:21]
    bar.valid <= _T_2 @[Valid.scala 117:17]
    bar.bits <= _T_3 @[Valid.scala 118:16]
```

This PR:
```
circuit PipeSpecFoo1 :
  module PipeSpecFoo1 :
    input clock : Clock
    input reset : UInt<1>
    input in : { valid : UInt<1>, bits : UInt<2>}
  
    reg barPipe_valid : UInt<1>, clock with :
      reset => (reset, UInt<1>("h0")) @[Valid.scala 119:22]
    barPipe_valid <= in.valid @[Valid.scala 119:22]
    reg barPipe_bits : UInt<2>, clock with :
      reset => (UInt<1>("h0"), barPipe_bits) @[Reg.scala 11:16]
    when in.valid : @[Reg.scala 12:19]
      barPipe_bits <= in.bits @[Reg.scala 12:23]
    reg barPipe_valid_1 : UInt<1>, clock with :
      reset => (reset, UInt<1>("h0")) @[Valid.scala 119:22]
    barPipe_valid_1 <= barPipe_valid @[Valid.scala 119:22]
    reg barPipe_bits_1 : UInt<2>, clock with :
      reset => (UInt<1>("h0"), barPipe_bits_1) @[Reg.scala 11:16]
    when barPipe_valid : @[Reg.scala 12:19]
      barPipe_bits_1 <= barPipe_bits @[Reg.scala 12:23]
    wire bar : { valid : UInt<1>, bits : UInt<2>} @[Valid.scala 114:21]
    bar.valid <= barPipe_valid_1 @[Valid.scala 115:17]
    bar.bits <= barPipe_bits_1 @[Valid.scala 116:16]
```

This is currently targeting based against #1023 as it's an easy follow-on after that gets merged.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification (generated FIRRTL changes)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Generate better names Pipe registers