### PR TITLE
Update recommended verilator version to 4.006

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This will walk you through installing Chisel and its dependencies:
     sudo apt-get install sbt
     ```
 1. Install Verilator.
-    We currently recommend Verilator version 3.922.
+    We currently recommend Verilator version 4.006.
     Follow these instructions to compile it from source.
 
     1. Install prerequisites (if not installed already):
@@ -62,7 +62,7 @@ This will walk you through installing Chisel and its dependencies:
     3. In the Verilator repository directory, check out a known good version:
         ```
         git pull
-        git checkout verilator_3_922
+        git checkout verilator_4_006
         ```
 
     4. In the Verilator repository directory, build and install:


### PR DESCRIPTION
**Type of change**: documentation

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Update recommended Verilator version to 4.006 in README