### PR TITLE
Tighten inferred width for PopCount

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
@@ -37,7 +37,9 @@ private[chisel3] object SeqUtils {
   def do_count(in: Seq[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = in.size match {
     case 0 => 0.U
     case 1 => in.head
-    case n => count(in take n/2) +& count(in drop n/2)
+    case n =>
+      val sum = count(in take n/2) +& count(in drop n/2)
+      sum(BigInt(n).bitLength - 1, 0)
   }
 
   /** Returns the data value corresponding to the first true predicate.

--- a/src/test/scala/chiselTests/PopCount.scala
+++ b/src/test/scala/chiselTests/PopCount.scala
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util.PopCount
+import org.scalatest._
+import org.scalatest.prop._
+import chisel3.testers.BasicTester
+
+class PopCountTester(n: Int) extends BasicTester {
+  val x = RegInit(0.U(n.W))
+  x := x + 1.U
+  when (RegNext(x === ~0.U(n.W))) { stop() }
+
+  val result = PopCount(x.asBools)
+  val expected = x.asBools.foldLeft(0.U)(_ +& _)
+  assert(result === expected)
+}
+
+class PopCountSpec extends ChiselPropSpec {
+  property("Mul lookup table should return the correct result") {
+    forAll(smallPosInts) { (n: Int) =>  assertTesterPasses { new PopCountTester(n) } }
+  }
+}

--- a/src/test/scala/chiselTests/PopCount.scala
+++ b/src/test/scala/chiselTests/PopCount.scala
@@ -16,6 +16,8 @@ class PopCountTester(n: Int) extends BasicTester {
   val result = PopCount(x.asBools)
   val expected = x.asBools.foldLeft(0.U)(_ +& _)
   assert(result === expected)
+
+  require(result.getWidth == BigInt(n).bitLength)
 }
 
 class PopCountSpec extends ChiselPropSpec {


### PR DESCRIPTION
An artifact of SeqUtils.count's implementation strategy makes its result one bit too wide, except for the case that the number of inputs is exactly a power of two.

`count(Seq(b, c))` expands to `b +& c`, which is 2 bits wide, as you'd hope.

`count(Seq(a, b, c))` expands to `count(Seq(a)) +& count(Seq(b, c))`, which is 3 bits wide, even though only 2 bits are needed to represent the result.

A simple fix is to truncate the sum at every step.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Reduce width of PopCount output to minimal possible value.