### PR TITLE
Change == to reference equality (eq) in Data print

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -314,7 +314,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
     case Some(MemoryPortBinding(enclosure)) => s"(MemPort in ${enclosure.desiredName})"
     case Some(PortBinding(enclosure)) if !enclosure.isClosed => s"(IO in unelaborated ${enclosure.desiredName})"
     case Some(PortBinding(enclosure)) if enclosure.isClosed =>
-      DataMirror.fullModulePorts(enclosure).find(_._2 == this) match {
+      DataMirror.fullModulePorts(enclosure).find(_._2 eq this) match {
         case Some((name, _)) => s"(IO $name in ${enclosure.desiredName})"
         case None => s"(IO (unknown) in ${enclosure.desiredName})"
       }


### PR DESCRIPTION
As the title says, changes the logic to check for reference equality, which is really what is meant anyways.

The partial root cause of the bug is that printing the Circuit includes printing all the Ports, which invokes the new code that tries to detect if a Data is a Port of a Module. This calls equals (through ==) on the MixedVec object, but it's not the overloaded equals as defined in MixedVec.scala (at least by a println() trace), nor does it appear to invoke Data.equals either. So I've really no clue what MixedVec.equals is doing (other than not the right thing - and for some reason trying to invoke the DynamicNamingStack), but this prevents the wrong equals from being called in the first place.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Resolves #1027

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
