### PR TITLE
Remove @chiselName from MixedVec

### DIFF
--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -4,7 +4,6 @@ package chisel3.util
 
 import chisel3._
 import chisel3.core.{Data, requireIsChiselType, requireIsHardware}
-import chisel3.internal.naming.chiselName
 
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -86,7 +86,6 @@ object MixedVec {
   * v(2) := 101.U(32.W)
   * }}}
   */
-@chiselName
 final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with collection.IndexedSeq[T] {
   // We want to create MixedVec only with Chisel types.
   if (compileOptions.declaredTypeMustBeUnbound) {


### PR DESCRIPTION
`@chiselName` can only be invoked by things running in a Builder context. In this case, it seemed to have inserted naming stack (unavailable outside a Builder context) pushes and pops into each function, which would cause it to assert out in a completely unhelpful way.

I also don't think `chiselName` does anything useful inside MixedVec?

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #1031

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
