### PR TITLE
Detect bundle aliasing

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -12,6 +12,8 @@ import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo._
 import chisel3.SourceInfoDoc
 
+class AliasedAggregateFieldException(message: String) extends ChiselException(message)
+
 /** An abstract class for data types that solely consist of (are an aggregate
   * of) other Data objects.
   */
@@ -20,6 +22,10 @@ sealed abstract class Aggregate extends Data {
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
+    val duplicates = getElements.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
+    if (!duplicates.isEmpty) {
+      throw new AliasedAggregateFieldException(s"Aggregate $this contains aliased fields $duplicates")
+    }
     for (child <- getElements) {
       child.bind(ChildBinding(this), resolvedDirection)
     }
@@ -591,15 +597,13 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     */
   final lazy val elements: ListMap[String, Data] = {
     val nameMap = LinkedHashMap[String, Data]()
-    val seen = HashSet[Data]()
     for (m <- getPublicFields(classOf[Bundle])) {
       getBundleField(m) match {
         case Some(d: Data) =>
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
-          } else if (!seen(d)) {
+          } else {
             nameMap(m.getName) = d
-            seen += d
           }
         case None =>
           if (!ignoreSeq) {

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -115,4 +115,17 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
       }
     }
   }
+
+  "Bundles" should "not have aliased fields" in {
+    (the[ChiselException] thrownBy {
+      elaborate { new Module {
+        val io = IO(Output(new Bundle {
+          val a = UInt(8.W)
+          val b = a
+        }))
+        io.a := 0.U
+        io.b := 1.U
+      } }
+    }).getMessage should include("aliased fields")
+  }
 }


### PR DESCRIPTION
From #1047, there was the idea to check if fields aliasing within a Bundle would be problematic. I thought it would be caught by a rebinding error, but apparently it's not - because aliased fields are explicitly ignored in the Bundle field detection logic, the binding logic only finds one field, and binds it without a problem. However, all accesses still point to the aliased element (which IS bound), so you don't get a binding error on access either.

Because there was explicit ignore logic (which I'm not sure about the motivation behind, or how intentional it was) this could be more contentious than the autoclonetype referential equality PR, so it's being separated out for its own discussion.

This does not appear to affect chisel3 regressions, so if there was some intentional reason behind this, it's not a test case. I also traced through the git blame, and `seen` appears to have been introduced (also without explanation) in https://github.com/freechipsproject/chisel3/commit/6f3bc0551ec89e397d2972d7a664915c63e19a06

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1047

<!-- choose one -->
**Type of change**: ???

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
