### PR TITLE
Allow naming annotation to work outside builder context

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -358,7 +358,7 @@ object DynamicNamingStack {
     }
   }
 
-  def popReturnContext[T <: Any](prefix_ref: T, until: internal.naming.NamingContextInterface): T = {
+  def popReturnContext[T <: Any](prefixRef: T, until: internal.naming.NamingContextInterface): T = {
     until match {
       case internal.naming.DummyNamer =>
         require(Builder.namingStackOption.isEmpty,
@@ -366,8 +366,8 @@ object DynamicNamingStack {
       case context: internal.naming.NamingContext =>
         require(Builder.namingStackOption.isDefined,
           "Builder context must remain stable throughout a chiselName-annotated function invocation")
-        Builder.namingStackOption.get.popContext(prefix_ref, context)
+        Builder.namingStackOption.get.popContext(prefixRef, context)
     }
-    prefix_ref
+    prefixRef
   }
 }

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -351,14 +351,14 @@ private[chisel3] object Builder {
   * objects.
   */
 object DynamicNamingStack {
-  def push_context(): internal.naming.NamingContextInterface = {
+  def pushContext(): internal.naming.NamingContextInterface = {
     Builder.namingStackOption match {
-      case Some(namingStack) => namingStack.push_context()
+      case Some(namingStack) => namingStack.pushContext()
       case None => internal.naming.DummyNamer
     }
   }
 
-  def pop_return_context[T <: Any](prefix_ref: T, until: internal.naming.NamingContextInterface): T = {
+  def popReturnContext[T <: Any](prefix_ref: T, until: internal.naming.NamingContextInterface): T = {
     until match {
       case internal.naming.DummyNamer =>
         require(Builder.namingStackOption.isEmpty,
@@ -366,7 +366,7 @@ object DynamicNamingStack {
       case context: internal.naming.NamingContext =>
         require(Builder.namingStackOption.isDefined,
           "Builder context must remain stable throughout a chiselName-annotated function invocation")
-        Builder.namingStackOption.get.pop_return_context(prefix_ref, context)
+        Builder.namingStackOption.get.popContext(prefix_ref, context)
     }
     prefix_ref
   }

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -362,10 +362,10 @@ object DynamicNamingStack {
     until match {
       case internal.naming.DummyNamer =>
         require(Builder.namingStackOption.isEmpty,
-          "Builder context must remain stable throughout a chiselName invocation")
+          "Builder context must remain stable throughout a chiselName-annotated function invocation")
       case context: internal.naming.NamingContext =>
         require(Builder.namingStackOption.isDefined,
-          "Builder context must remain stable throughout a chiselName invocation")
+          "Builder context must remain stable throughout a chiselName-annotated function invocation")
         Builder.namingStackOption.get.pop_return_context(prefix_ref, context)
     }
     prefix_ref

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -203,7 +203,7 @@ private[chisel3] object Builder {
     val dummy = core.DontCare
   }
 
-  def namingStackOption: Option[internal.naming.NamingStack]= dynamicContextVar.value.map(_.namingStack)
+  def namingStackOption: Option[internal.naming.NamingStack] = dynamicContextVar.value.map(_.namingStack)
 
   def idGen: IdGen = chiselContext.value.idGen
 

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -4,7 +4,6 @@ package chisel3.internal
 
 import scala.util.DynamicVariable
 import scala.collection.mutable.{ArrayBuffer, HashMap}
-
 import chisel3._
 import core._
 import firrtl._
@@ -204,6 +203,8 @@ private[chisel3] object Builder {
     val dummy = core.DontCare
   }
 
+  def namingStackOption: Option[internal.naming.NamingStack]= dynamicContextVar.value.map(_.namingStack)
+
   def idGen: IdGen = chiselContext.value.idGen
 
   def globalNamespace: Namespace = dynamicContext.globalNamespace
@@ -344,10 +345,29 @@ private[chisel3] object Builder {
   initializeSingletons()
 }
 
-/** Allows public access to the naming stack in Builder / DynamicContext.
+/** Allows public access to the naming stack in Builder / DynamicContext, and handles invocations
+  * outside a Builder context.
   * Necessary because naming macros expand in user code and don't have access into private[chisel3]
   * objects.
   */
 object DynamicNamingStack {
-  def apply(): internal.naming.NamingStack = Builder.namingStack
+  def push_context(): internal.naming.NamingContextInterface = {
+    Builder.namingStackOption match {
+      case Some(namingStack) => namingStack.push_context()
+      case None => internal.naming.DummyNamer
+    }
+  }
+
+  def pop_return_context[T <: Any](prefix_ref: T, until: internal.naming.NamingContextInterface): T = {
+    until match {
+      case internal.naming.DummyNamer =>
+        require(Builder.namingStackOption.isEmpty,
+          "Builder context must remain stable throughout a chiselName invocation")
+      case context: internal.naming.NamingContext =>
+        require(Builder.namingStackOption.isDefined,
+          "Builder context must remain stable throughout a chiselName invocation")
+        Builder.namingStackOption.get.pop_return_context(prefix_ref, context)
+    }
+    prefix_ref
+  }
 }

--- a/chiselFrontend/src/main/scala/chisel3/internal/Namer.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Namer.scala
@@ -80,10 +80,7 @@ class NamingContext extends NamingContextInterface {
   def addDescendant(ref: Any, descendant: NamingContext) {
     ref match {
       case ref: AnyRef =>
-        if (!descendants.containsKey(ref)) {
-          descendants.put(ref, ListBuffer[NamingContext]())
-        }
-        descendants.get(ref) += descendant
+        descendants.getOrElseUpdate(ref, ListBuffer[NamingContext]()) += descendant
       case _ => anonymousDescendants += descendant
     }
   }
@@ -143,11 +140,11 @@ class NamingStack {
     *
     * Will assert out if the context being popped isn't the topmost on the stack.
     */
-  def popContext[T <: Any](prefix_ref: T, until: NamingContext): Unit = {
+  def popContext[T <: Any](prefixRef: T, until: NamingContext): Unit = {
     assert(namingStack.top == until)
     namingStack.pop()
     if (!namingStack.isEmpty) {
-      namingStack.top.addDescendant(prefix_ref, until)
+      namingStack.top.addDescendant(prefixRef, until)
     }
   }
 }

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
@@ -53,7 +53,7 @@ class NamingTransforms(val c: Context) {
   import c.universe._
   import Flag._
 
-  val globalNamingStack = q"_root_.chisel3.internal.DynamicNamingStack()"
+  val globalNamingStack = q"_root_.chisel3.internal.DynamicNamingStack"
 
   /** Base transformer that provides the val name transform.
     * Should not be instantiated, since by default this will recurse everywhere and break the
@@ -125,7 +125,7 @@ class NamingTransforms(val c: Context) {
     val $contextVar = $globalNamingStack.push_context()
     ..$transformedBody
     $contextVar.name_prefix("")
-    $globalNamingStack.pop_context($contextVar)
+    $globalNamingStack.pop_return_context((), $contextVar)
     """
   }
 

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/NamingAnnotations.scala
@@ -51,7 +51,6 @@ class DebugTransforms(val c: Context) {
 object NamingTransforms
 class NamingTransforms(val c: Context) {
   import c.universe._
-  import Flag._
 
   val globalNamingStack = q"_root_.chisel3.internal.DynamicNamingStack"
 
@@ -107,7 +106,7 @@ class NamingTransforms(val c: Context) {
   class MethodTransformer(val contextVar: TermName) extends ValNameTransformer {
     override def transform(tree: Tree): Tree = tree match {
       // TODO: better error messages when returning nothing
-      case q"return $expr" => q"return $globalNamingStack.pop_return_context($expr, $contextVar)"
+      case q"return $expr" => q"return $globalNamingStack.popReturnContext($expr, $contextVar)"
       // Do not recurse into methods
       case q"$mods def $tname[..$tparams](...$paramss): $tpt = $expr" => tree
       case other => super.transform(other)
@@ -122,10 +121,10 @@ class NamingTransforms(val c: Context) {
     val transformedBody = (new ModuleTransformer(contextVar)).transformTrees(stats)
 
     q"""
-    val $contextVar = $globalNamingStack.push_context()
+    val $contextVar = $globalNamingStack.pushContext()
     ..$transformedBody
-    $contextVar.name_prefix("")
-    $globalNamingStack.pop_return_context((), $contextVar)
+    $contextVar.namePrefix("")
+    $globalNamingStack.popReturnContext((), $contextVar)
     """
   }
 
@@ -137,8 +136,8 @@ class NamingTransforms(val c: Context) {
     val transformedBody = (new MethodTransformer(contextVar)).transform(expr)
 
     q"""{
-      val $contextVar = $globalNamingStack.push_context()
-      $globalNamingStack.pop_return_context($transformedBody, $contextVar)
+      val $contextVar = $globalNamingStack.pushContext()
+      $globalNamingStack.popReturnContext($transformedBody, $contextVar)
     }
     """
   }

--- a/src/test/scala/chiselTests/NamingAnnotationTest.scala
+++ b/src/test/scala/chiselTests/NamingAnnotationTest.scala
@@ -154,6 +154,11 @@ object NonNamedHelper {
     val myVal = NamedFunction()
     myVal
   }
+
+  @chiselName
+  def NonBuilderFunction(): Int = { // scalastyle:ignore method.name
+    1 + 1
+  }
 }
 
 @chiselName
@@ -214,5 +219,9 @@ class NamingAnnotationSpec extends ChiselPropSpec {
 
   property("NonNamedFunction should elaborate") {
     elaborate { new NonNamedFunction }
+  }
+
+  property("NonBuilderFunction should run outside a Builder context") {
+    NonNamedHelper.NonBuilderFunction() should be (2)
   }
 }


### PR DESCRIPTION
Exactly as the title says. If there is no Builder context upon entering a naming annotated function, all the naming calls become nops. It does check that the Builder context remained stable at function entry and exit.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #1046

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
