### PR TITLE
Make core.DontCare private to chisel3

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -670,9 +670,10 @@ object WireDefault {
 /** RHS (source) for Invalidate API.
   * Causes connection logic to emit a DefInvalid when connected to an output port (or wire).
   */
-object DontCare extends Element {
+private[chisel3] object DontCare extends Element {
   // This object should be initialized before we execute any user code that refers to it,
   //  otherwise this "Chisel" object will end up on the UserModule's id list.
+  // We make it private to chisel3 so it has to be accessed through the package object.
 
   private[chisel3] override val width: Width = UnknownWidth()
 


### PR DESCRIPTION
Force clients to access `DontCare` through the chisel3 package to ensure it's created as a chisel3 object and not a client object.

**Related issue**: #1053

**Type of change**: bug report

**Impact**: API modification

**Development Phase**:  implementation

**Release Notes**
`chisel3.core.DontCare` should have been private to `chisel3` to prevent client code from referencing it directly and creating the object. This corrects that short-coming.
