### PR TITLE
Hide awkward DecoupledIO .bits attribute from user

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -5,6 +5,8 @@
 
 package chisel3.util
 
+import scala.language.dynamics
+
 import chisel3._
 import chisel3.experimental.{DataMirror, Direction, requireIsChiselType}
 import chisel3.internal.naming._  // can't use chisel3_ version because of compile order
@@ -78,9 +80,13 @@ object ReadyValidIO {
   * of ready or valid.
   * @param gen the type of data to be wrapped in DecoupledIO
   */
-class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
-{
+class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen) with Dynamic {
   override def cloneType: this.type = new DecoupledIO(gen).asInstanceOf[this.type]
+  def selectDynamic(name: String) = {
+    this.bits match {
+      case b: Bundle => b.elements(name)
+    }
+  }
 }
 
 /** This factory adds a decoupled handshaking protocol to a data bundle. */


### PR DESCRIPTION
**Type of change**:  other enhancement

**Impact**: API addition (no impact on existing code)

**Development Phase**:  implementation

**Release Notes**

Accessing the elements of a `DecoupledIO(Bundle)` is awkward from an hardware point of view because the ready/valid and the elements of the Bundle does not stand on the same level.
```scala
class MyModule(WIDTH: Int) extends Module {
    val flow = new Bundle {
      val data       = UInt(WIDTH.W)
      // ...
    }
    val io = IO(new Bundle {
      val in  = Flipped(Decoupled(flow))
      val out = Decoupled(flow)
      // ...
    })

    when(io.in.ready){
        io.out.valid     := io.in.valid
        io.out.bits.data := io.in.bits.data
    }
    io.in.ready := io.out.ready
}
```

Hardware engineers do not care about our syntactic sugars and implementation details, they want things to be straight accessible and not being hidden behind an irrelevant `.bits` attribute.
 
This PR enables the following access:
```scala
    when(io.in.ready){
        io.out.valid := io.in.valid
        io.out.data  := io.in.data
    }
```

Note0: renaming `flow` as `bits` in an attempt to bring some *(actually misleading)* consistency is not a solution since it will break as soon as you have 2 distinct DecoupledIOs.

Note1: The match is incomplete, I think it should raise a proper (not the java mismatch) error when  `this.bits` is not a `Bundle`.

Please share your thoughts =)
