### PR TITLE
Add user-friendly DecoupledIn, DecoupledOut objects

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -104,6 +104,20 @@ object Decoupled
   }
 }
 
+
+/** Decoupled Output from the point of view of a module - drives (outputs) valid and bits, inputs ready.
+  * @param gen The type of data to enqueue
+  */
+object DecoupledOut {
+  def apply[T<:Data](gen: T): DecoupledIO[T] = Decoupled(gen)
+}
+/** Decoupled Input from the point of view of a module - drives (outputs) ready, inputs valid and bits.
+  * @param gen The type of data to dequeue
+  */
+object DecoupledIn {
+  def apply[T<:Data](gen: T): DecoupledIO[T] = Flipped(Decoupled(gen))
+}
+
 /** A concrete subclass of ReadyValidIO that promises to not change
   * the value of 'bits' after a cycle where 'valid' is high and 'ready' is low.
   * Additionally, once 'valid' is raised it will never be lowered until after


### PR DESCRIPTION
**Type of change**:  other enhancement

**Impact**:  API addition (no impact on existing code) 

**Development Phase**:   implementation

**Release Notes**
- `DecoupledIO` being a producer by default is error-prone.
- `Flipped` construct should not to be required to be understood by average users
- `EnqIO` and `DeqIO` companion objects do not make sense in from a generic point of view 

I hence suggest the introduction of 2 companion objects: `DecoupledIn` and `DecoupledOut`

Currently we need the following syntax:
```scala
class MyModule(WIDTH: Int) extends Module {
    val flow = new Bundle {
      val data       = UInt(WIDTH.W)
      // ...
    }
    val io = IO(new Bundle {
      val in  = Flipped(Decoupled(flow))
      val out = Decoupled(flow)
      // ...
    })
   // ...
}
```

With this PR, hardware designers will have a clearer syntax :

```scala
class MyModule(WIDTH: Int) extends Module {
    val flow = new Bundle {
      val data       = UInt(WIDTH.W)
      // ...
    }
    val io = IO(new Bundle {
      val in  = DecoupledIn(flow)
      val out = DecoupledOut(flow)
      // ...
    })
   // ...
}
```