### PR TITLE
RawModule with no reset should be able to use withClock method.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -41,8 +41,8 @@ object Module extends SourceInfoDoc {
     val whenDepth: Int = Builder.whenDepth
 
     // Save then clear clock and reset to prevent leaking scope, must be set again in the Module
-    val clockAndReset: Option[ClockAndReset] = Builder.currentClockAndReset
-    Builder.currentClockAndReset = None
+    val clockAndReset: ClockAndReset = Builder.currentClockAndReset
+    Builder.currentClockAndReset = ClockAndReset.empty
 
     // Execute the module, this has the following side effects:
     //   - set currentModule

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -41,8 +41,9 @@ object Module extends SourceInfoDoc {
     val whenDepth: Int = Builder.whenDepth
 
     // Save then clear clock and reset to prevent leaking scope, must be set again in the Module
-    val clockAndReset: ClockAndReset = Builder.currentClockAndReset
-    Builder.currentClockAndReset = ClockAndReset.empty
+    val (saveClock, saveReset)  = (Builder.currentClock, Builder.currentReset)
+    Builder.currentClock = None
+    Builder.currentReset = None
 
     // Execute the module, this has the following side effects:
     //   - set currentModule
@@ -59,9 +60,10 @@ object Module extends SourceInfoDoc {
                      "This is probably due to rewrapping a Module instance with Module()." +
                      sourceInfo.makeMessage(" See " + _))
     }
-    Builder.currentModule = parent // Back to parent!
+    Builder.currentModule = parent     // Back to parent!
     Builder.whenDepth = whenDepth
-    Builder.currentClockAndReset = clockAndReset // Back to clock and reset scope
+    Builder.currentClock = saveClock   // Back to clock and reset scope
+    Builder.currentReset = saveReset
 
     val component = module.generateComponent()
     Builder.components += component

--- a/chiselFrontend/src/main/scala/chisel3/core/MultiClock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/MultiClock.scala
@@ -59,7 +59,7 @@ object withReset {  // scalastyle:ignore object.name
   def apply[T](reset: Reset)(block: => T): T = {
     // Save parentScope
     val parentReset = Builder.currentReset
-    Builder.currentReset = Builder.currentReset
+    Builder.currentReset = Some(reset)
     val res = block // execute block
     // Return to old scope
     Builder.currentReset = parentReset

--- a/chiselFrontend/src/main/scala/chisel3/core/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/RawModule.scala
@@ -146,7 +146,7 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
   val reset: Reset = IO(Input(Bool()))
 
   // Setup ClockAndReset
-  Builder.currentClockAndReset = Some(ClockAndReset(clock, reset))
+  Builder.currentClockAndReset = ClockAndReset(clock, reset)
 
   private[core] override def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo

--- a/chiselFrontend/src/main/scala/chisel3/core/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/RawModule.scala
@@ -146,7 +146,8 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
   val reset: Reset = IO(Input(Bool()))
 
   // Setup ClockAndReset
-  Builder.currentClockAndReset = ClockAndReset(clock, reset)
+  Builder.currentClock = Some(clock)
+  Builder.currentReset = Some(reset)
 
   private[core] override def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -2,21 +2,34 @@
 
 package chiselTests
 
-import org.scalatest._
-import org.scalatest.prop._
-
 import chisel3._
+import chisel3.experimental.RawModule
 import chisel3.testers.BasicTester
-import chisel3.util._
 
 class ClockAsUIntTester extends BasicTester {
   assert(true.B.asClock.asUInt === 1.U)
   stop()
 }
 
+class WithClockAndNoReset extends RawModule {
+  val clock1 = IO(Input(Clock()))
+  val clock2 = IO(Input(Clock()))
+  val in = IO(Input(Bool()))
+  val out = IO(Output(Bool()))
+  val a = withClock(clock2) {
+    RegNext(in)
+  }
+  out := a
+}
+
 
 class ClockSpec extends ChiselPropSpec {
   property("Bool.asClock.asUInt should pass a signal through unaltered") {
     assertTesterPasses { new ClockAsUIntTester }
+  }
+
+  property("Should be able to use withClock in a module with no reset") {
+    val circuit = Driver.emit { () => new WithClockAndNoReset }
+    circuit.contains("reg a : UInt<1>, clock2") should be (true)
   }
 }


### PR DESCRIPTION
## Motivation
Fixes bug identified in Issue #1041 

## Description
A user defining defining a `Module` with a clock and no reset cannot use the 
`withClock(clock) { val r = RegNext(...) }`. Attempting to do so will generate an exception saying
there is no reset even though no reset is required.

## Details
- refactor ClockAndReset
  - now has `clockOpt: Option[Clock]` and `resetOpt: Option[Reset]` constructor params
  - convenience methods clock and reset tries to deref the option
  - ClockAndReset.empty is factory method for (None, None)
- In Builder
  - forcedClock does not check resetOpt now
  - forcedReset does not check clockOpt now
- withClock no longer looks at resetOpt
- withReset no longer looks at clockOpt
- Module starts with empty ClockAndReset

## Impact
Internal API change.
