### PR TITLE
BitPat.pase bug fixed

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -32,7 +32,7 @@ object BitPat {
         bits = (bits << 1) + (if (d == '1') 1 else 0)
       }
     }
-    (bits, mask, x.length - 1)
+    (bits, mask, x.filter(_!='_').length - 1)
   }
 
   /** Creates a [[BitPat]] literal from a string.


### PR DESCRIPTION
a bug when use ‘_’ in BitPat string got error width 
`BitPat.pase("b11000000")  = (192,255,8)`
`BitPat.pase("b1100_0000") = (192,255,9)`  got 9bit width actually 8bit

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:   implementation

