### PR TITLE
IO(Analog) fix for RawModule

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -1776,6 +1776,13 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
     val targetTopBinding = target match {
       case target: TopBinding => target
       case ChildBinding(parent) => parent.topBinding
+      case x: SampleElementBinding[x] => x.parent.topBinding
+      // TODO: CKDUR: I don't know what I'm doing here, but seems to be relatable to Data.scala:320.
+      // Citing here for convenience:
+      // TODO: technically, it's bound, but it's more of a ghost binding and None is probably the most appropriate
+      // Note: sample elements should not be user-accessible, so there's not really a good reason to access its
+      // top binding. However, we can't make this assert out right not because a larger refactoring is needed.
+      // See https://github.com/freechipsproject/chisel3/pull/946
     }
 
     // Analog counts as different directions based on binding context

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -1776,13 +1776,8 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
     val targetTopBinding = target match {
       case target: TopBinding => target
       case ChildBinding(parent) => parent.topBinding
-      case x: SampleElementBinding[x] => x.parent.topBinding
-      // TODO: CKDUR: I don't know what I'm doing here, but seems to be relatable to Data.scala:320.
-      // Citing here for convenience:
-      // TODO: technically, it's bound, but it's more of a ghost binding and None is probably the most appropriate
-      // Note: sample elements should not be user-accessible, so there's not really a good reason to access its
-      // top binding. However, we can't make this assert out right not because a larger refactoring is needed.
       // See https://github.com/freechipsproject/chisel3/pull/946
+      case x: SampleElementBinding[x] => x.parent.topBinding
     }
 
     // Analog counts as different directions based on binding context

--- a/src/test/scala/chiselTests/AnalogPortRawModuleSpec.scala
+++ b/src/test/scala/chiselTests/AnalogPortRawModuleSpec.scala
@@ -13,25 +13,25 @@ class AnalogPortRawModule(val vec_ports: Int = 4) extends RawModule {
   val s_in         = IO(Input(UInt(32.W)))
   val s_out        = IO(Output(UInt(32.W)))
   val v_analog     = IO(Vec(vec_ports, Analog(32.W)))
-  val v_in         = IO(Vec(vec_ports, Input(UInt(32.W))))
-  val v_out        = IO(Vec(vec_ports, Output(UInt(32.W))))
+  val v_in         = IO(Input(Vec(vec_ports, UInt(32.W))))
+  val v_out        = IO(Output(Vec(vec_ports, UInt(32.W))))
   
-  val sig_wr_mod = new AnalogWriterBlackBox
+  val sig_wr_mod = Module(new AnalogWriterBlackBox)
   attach(sig_wr_mod.io.bus, s_analog)
   sig_wr_mod.io.in := s_in
   
-  val sig_rd_mod = new AnalogReaderBlackBox
+  val sig_rd_mod = Module(new AnalogReaderBlackBox)
   attach(sig_rd_mod.io.bus, s_analog)
   s_out := sig_rd_mod.io.out
   
   (v_analog zip v_in).foreach{ case( ana, in ) => 
-    val vec_wr_mod = new AnalogWriterBlackBox
+    val vec_wr_mod = Module(new AnalogWriterBlackBox)
     attach(vec_wr_mod.io.bus, ana)
     vec_wr_mod.io.in := in
   }
   
   (v_analog zip v_out).foreach{ case( ana, out ) => 
-    val vec_rd_mod = new AnalogReaderBlackBox
+    val vec_rd_mod = Module(new AnalogReaderBlackBox)
     attach(vec_rd_mod.io.bus, ana)
     out := vec_rd_mod.io.out
   }

--- a/src/test/scala/chiselTests/AnalogPortRawModuleSpec.scala
+++ b/src/test/scala/chiselTests/AnalogPortRawModuleSpec.scala
@@ -1,0 +1,77 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+import chisel3.experimental.{Analog, attach, BaseModule, RawModule}
+
+// The RawModule to test
+class AnalogPortRawModule(val vec_ports: Int = 4) extends RawModule {
+  val s_analog     = IO(Analog(32.W))
+  val s_in         = IO(Input(UInt(32.W)))
+  val s_out        = IO(Output(UInt(32.W)))
+  val v_analog     = IO(Vec(vec_ports, Analog(32.W)))
+  val v_in         = IO(Vec(vec_ports, Input(UInt(32.W))))
+  val v_out        = IO(Vec(vec_ports, Output(UInt(32.W))))
+  
+  val sig_wr_mod = new AnalogWriterBlackBox
+  attach(sig_wr_mod.io.bus, s_analog)
+  sig_wr_mod.io.in := s_in
+  
+  val sig_rd_mod = new AnalogReaderBlackBox
+  attach(sig_rd_mod.io.bus, s_analog)
+  s_out := sig_rd_mod.io.out
+  
+  (v_analog zip v_in).foreach{ case( ana, in ) => 
+    val vec_wr_mod = new AnalogWriterBlackBox
+    attach(vec_wr_mod.io.bus, ana)
+    vec_wr_mod.io.in := in
+  }
+  
+  (v_analog zip v_out).foreach{ case( ana, out ) => 
+    val vec_rd_mod = new AnalogReaderBlackBox
+    attach(vec_rd_mod.io.bus, ana)
+    out := vec_rd_mod.io.out
+  }
+}
+
+// The Chisel tester (Just borrowed the AnalogTester)
+abstract class AnalogPortRawModuleTester(val vec_ports: Int = 4) extends BasicTester {
+  final val BusValue = "hdeadbeef".U
+
+  final val (cycle, done) = Counter(true.B, 2)
+  when (done) { stop() }
+
+  final val raw_module = Module(new AnalogPortRawModule(vec_ports))
+  raw_module.s_in := BusValue
+  raw_module.v_in.foreach{ case x => x := BusValue }
+
+  final def check: Unit = {
+    assert(raw_module.s_out === BusValue)
+    raw_module.v_out.foreach{ case x => assert( x === BusValue) }
+  }
+}
+
+class AnalogPortRawModuleSpec extends ChiselFlatSpec {
+  behavior of "AnalogPortRawModule"
+  
+  it should "work with 1 vector bulk connected" in {
+    assertTesterPasses(new AnalogPortRawModuleTester(1) {
+      check
+    }, Seq("/chisel3/AnalogBlackBox.v"))
+  }
+  
+  it should "work with 2 vector bulk connected" in {
+    assertTesterPasses(new AnalogPortRawModuleTester(2) {
+      check
+    }, Seq("/chisel3/AnalogBlackBox.v"))
+  }
+  
+  it should "work with 3 vector bulk connected" in {
+    assertTesterPasses(new AnalogPortRawModuleTester(3) {
+      check
+    }, Seq("/chisel3/AnalogBlackBox.v"))
+  }
+}


### PR DESCRIPTION
**Related issue**: https://github.com/freechipsproject/chisel3/pull/946

**Type of change**: bug report
**Impact**: API addition (no impact on existing code)
**Development Phase**: proposal

**Release Notes**
Inclusion of IO(Analog) for RawModule is not currently supported by the master branch of Chisel3.
An example of the implementation failure can be reviewed if you try to update the Chisel version of freedom.
See for example https://github.com/sifive/fpga-shells/blob/master/src/main/scala/shell/xilinx/ArtyShell.scala#L34

With this fix, I was able to reproduce firrtl code and verilog code similar to the generated with previous versions of Chisel, but maybe revision can be considered important here.

Thanks.