### PR TITLE
Make asTypeOf work for bundles with zero-width fields.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -70,8 +70,16 @@ sealed abstract class Aggregate extends Data {
     var i = 0
     val bits = WireDefault(UInt(this.width), that)  // handles width padding
     for (x <- flatten) {
-      x.connectFromBits(bits(i + x.getWidth - 1, i))
-      i += x.getWidth
+      val fieldWidth = x.getWidth
+      if (fieldWidth > 0) {
+        x.connectFromBits(bits(i + fieldWidth - 1, i))
+        i += fieldWidth
+      } else {
+        // There's a zero-width field in this bundle.
+        // Zero-width fields can't really be assigned to, but the frontend complains if there are uninitialized fields,
+        // so we assign it to DontCare. We can't use connectFromBits() on DontCare, so use := instead.
+        x := DontCare
+      }
     }
   }
 }

--- a/src/test/scala/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala/chiselTests/AsTypeOfTester.scala
@@ -27,6 +27,24 @@ class AsTypeOfBundleTester extends BasicTester {
   stop()
 }
 
+class AsTypeOfBundleZeroWidthTester extends BasicTester {
+  class ZeroWidthBundle extends Bundle {
+    val a = UInt(0.W)
+    val b = UInt(1.W)
+    val c = UInt(0.W)
+  }
+
+  val bun = new ZeroWidthBundle
+
+  val bunAsTypeOf = 1.U.asTypeOf(bun)
+
+  assert(bunAsTypeOf.a === 0.U)
+  assert(bunAsTypeOf.b === 1.U)
+  assert(bunAsTypeOf.c === 0.U)
+
+  stop()
+}
+
 class AsTypeOfVecTester extends BasicTester {
   val vec = ((15 << 12) + (0 << 8) + (1 << 4) + (2 << 0)).U.asTypeOf(Vec(4, SInt(4.W)))
 
@@ -101,6 +119,10 @@ class AsTypeOfSpec extends ChiselFlatSpec {
 
   it should "work with Bundles containing Bits Types" in {
     assertTesterPasses{ new AsTypeOfBundleTester }
+  }
+
+  it should "work with Bundles that have fields of zero width" in {
+    assertTesterPasses{ new AsTypeOfBundleZeroWidthTester }
   }
 
   it should "work with Vecs containing Bits Types" in {


### PR DESCRIPTION
Closes #1075.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1075 
<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
