### PR TITLE
Add back Int forms of Mem do_apply methods

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -45,6 +45,10 @@ object Mem {
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
     mem
   }
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Mem[T] =
+    do_apply(BigInt(size), t)(sourceInfo, compileOptions)
 }
 
 sealed abstract class MemBase[T <: Data](t: T, val length: BigInt) extends HasId with NamedComponent with SourceInfoDoc {
@@ -65,6 +69,10 @@ sealed abstract class MemBase[T <: Data](t: T, val length: BigInt) extends HasId
     require(idx >= 0 && idx < length)
     apply(idx.asUInt)
   }
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply(idx: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+    do_apply(BigInt(idx))(sourceInfo, compileOptions)
 
   /** Creates a read/write accessor into the memory with dynamic addressing.
     * See the class documentation of the memory for more detailed information.
@@ -175,6 +183,10 @@ object SyncReadMem {
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size))
     mem
   }
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply[T <: Data](size: Int, t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] =
+    do_apply(BigInt(size), t)(sourceInfo, compileOptions)
 }
 
 /** A sequential/synchronous-read, sequential/synchronous-write memory.

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -93,4 +93,16 @@ class MemorySpec extends ChiselPropSpec {
     val cmem = compile(new HugeCMemTester(size))
     cmem should include (s"reg /* sparse */ [7:0] mem [0:$addrWidth'd${size-1}];")
   }
+
+  property("Implicit conversions with Mem indices should work") {
+    """
+    |import chisel3._
+    |import chisel3.util.ImplicitConversions._
+    |class MyModule extends Module {
+    |  val io = IO(new Bundle {})
+    |  val mem = Mem(32, UInt(8.W))
+    |  mem(0) := 0.U
+    |}
+    |""".stripMargin should compile
+  }
 }


### PR DESCRIPTION
This is necessary to support code that imports an implicit conversion from Int to UInt

I thought they were unnecessary in #1076 but I was wrong.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API ~addition~ restoration (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
