### PR TITLE
ECC Utils

### DIFF
--- a/src/main/scala/chisel3/util/Ecc.scala
+++ b/src/main/scala/chisel3/util/Ecc.scala
@@ -1,0 +1,48 @@
+// See LICENSE for license details.
+
+package chisel3Base.examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.internal.firrtl.Width
+
+trait Ecc {
+  def n: Int
+  def k: Int
+  require(n > k)
+  def encode(x: UInt): UInt
+  def decode(y: UInt): UInt
+  def error(y: UInt): Bool
+}
+
+class EccEncodeIO[T <: Data](gen: T, n: Int, k: Int) extends Bundle {
+  val in = Input(gen.chiselCloneType)
+  val out = Output(UInt((gen.getWidth + (n - k)).W))
+
+  override def cloneType = new EccEncodeIO(gen, n, k).asInstanceOf[this.type]
+}
+
+class EccDecodeIO[T <: Data](gen: T, n: Int, k: Int) extends Bundle {
+  val in = Input(UInt((gen.getWidth + (n - k)).W))
+  val out = Output(gen.chiselCloneType)
+  val err = Output(Bool())
+
+  override def cloneType = new EccDecodeIO(gen, n, k).asInstanceOf[this.type]
+}
+
+abstract class EccEncode[T <: Data](gen: T) extends Module {
+  this: Ecc =>
+
+  lazy val io = IO(new EccEncodeIO[T](gen, this.n, this.k))
+
+  io.out := this.encode(io.in.asUInt)
+}
+
+abstract class EccDecode[T <: Data](gen: T) extends Module {
+  this: Ecc =>
+
+  val io = IO(new EccDecodeIO[T](gen, this.n, this.k))
+
+  io.out := gen.chiselCloneType.fromBits(this.decode(io.in))
+  io.err := this.error(io.in)
+}

--- a/src/main/scala/chisel3/util/EccLinear.scala
+++ b/src/main/scala/chisel3/util/EccLinear.scala
@@ -1,0 +1,118 @@
+// See LICENSE for license details.
+
+package chisel3Base.examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+
+object HammingMatrices {
+  // Identity Matrix
+  private def I(n: Int) = {
+    val x = Array.fill(n)(Array.fill(n)(0))
+    0 until n map (i => x(i)(i) = 1)
+    x
+  }
+
+  // Generating Matrix
+  def G(n: Int, k: Int): Seq[UInt] = { (n, k) match {
+    case (7, 4) => Seq(
+      "b1000".U,
+      "b0100".U,
+      "b0010".U,
+      "b0001".U,
+      "b1101".U,
+      "b1011".U,
+      "b0111".U).reverse
+    case _ => throw new Exception(s"No known generator matrix for n: $n, k: $k")
+  }}
+
+  // Parity Check Matrix
+  def H(n: Int, k: Int): Seq[UInt] = { (n, k) match {
+    case (7, 4) => Seq(
+      "b1101100".U,
+      "b1011010".U,
+      "b0111001".U).reverse
+    case _ => throw new Exception(s"No known parity check matrix for n: $n, k: $k")
+  }}
+
+  // Extraction of the data-carrying values
+  def R(n: Int, k: Int): Seq[UInt] = { (n, k) match {
+    case (7, 4) => Seq(
+      "b1000000".U,
+      "b0100000".U,
+      "b0010000".U,
+      "b0001000".U).reverse
+    case _ => throw new Exception(s"No known decode matrix for n: $n, k: $k")
+  }}
+}
+
+trait Hamming extends Ecc {
+  def encode(x: UInt): UInt = {
+    val y = Seq.fill(n)(x)
+    val g = HammingMatrices.G(n, k)
+    Vec(y zip g map { case(a, b) => (a & b).xorR}).asUInt
+  }
+
+  private def syndrome(x: UInt): UInt = {
+    val z = Seq.fill(n)(x)
+    val h = HammingMatrices.H(n, k)
+    Vec(z zip h map { case(a, b) => (a & b).xorR }).asUInt
+  }
+
+  def error(x: UInt): Bool = syndrome(x).orR
+
+  def decode(y: UInt): UInt = {
+    // [TODO] Add error correction
+    val z = Seq.fill(n)(y)
+    val r = HammingMatrices.R(n, k)
+    Vec(z zip r map { case(a, b) => (a & b).xorR }).asUInt
+  }
+}
+
+trait Hamming_7_4 extends Hamming {
+  def n: Int = 7
+  def k: Int = 4
+}
+
+object HammingEncoder {
+  def apply[A <: Data](gen: A) = Module(new EccEncode(gen) with Hamming_7_4)
+}
+
+object HammingDecoder {
+  def apply[A <: Data](gen: A) = Module(new EccDecode(gen) with Hamming_7_4)
+}
+
+class HammingCounter(n: Int) extends Module {
+  val io = IO(new Bundle{
+    val in = Input(UInt(n.W))
+    val out = Output(UInt(n.W))
+    val err = Output(Bool())
+  })
+
+  val enc = HammingEncoder(io.in)
+  val dec = HammingDecoder(io.in)
+
+  enc.io.in := io.in
+  dec.io.in := enc.io.out
+  io.out := dec.io.out
+}
+
+class HammingCounterTest extends BasicTester {
+  val n = 4
+  val dut = Module(new HammingCounter(n))
+
+  val s_INIT :: s_RUN :: s_DONE :: Nil = Enum(3)
+  val state = Reg(init = s_INIT)
+
+  when (state === s_INIT) { state := s_RUN }
+
+  val (count, done) = Counter(state === s_RUN, math.pow(2, n).toInt)
+  dut.io.in := count
+
+  assert(dut.io.in === dut.io.out)
+  assert(dut.io.err === false.B)
+
+  when (done) { state := s_DONE }
+  when (state === s_DONE) { stop }
+}

--- a/src/main/scala/chisel3/util/EccSimple.scala
+++ b/src/main/scala/chisel3/util/EccSimple.scala
@@ -1,0 +1,67 @@
+// See LICENSE for license details.
+
+package chisel3Base.examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+
+trait Parity extends Ecc {
+  // (n, k) are arbitrary here, only their relationship is important
+  def n: Int = 1
+  def k: Int = 0
+
+  def encode(x: UInt): UInt = Cat(x.asUInt, x.asUInt.xorR)
+  def decode(y: UInt): UInt = y(y.getWidth - 1, 1)
+  def error(x: UInt): Bool = encode(decode(x.asUInt))(0) =/= x(0)
+}
+
+trait TwoOutOfFive {
+  // [TODO] Implement
+}
+
+trait Repetition {
+  // [TODO] Implement
+}
+
+object ParityEncoder {
+  def apply[T <: Data](gen: T) = Module(new EccEncode(gen) with Parity)
+}
+
+object ParityDecoder {
+  def apply[T <: Data](gen: T) = Module(new EccDecode(gen) with Parity)
+}
+
+class ParityCounter(n: Int) extends Module {
+  val io = IO(new Bundle{
+    val in = Input(UInt(n.W))
+    val out = Output(UInt(n.W))
+    val err = Output(Bool())
+  })
+
+  val enc = ParityEncoder(io.in)
+  val dec = ParityDecoder(io.in)
+
+  enc.io.in := io.in
+  dec.io.in := enc.io.out
+  io.out := dec.io.out
+}
+
+class ParityCounterTest extends BasicTester {
+  val n = 4
+  val dut = Module(new ParityCounter(n))
+
+  val s_INIT :: s_RUN :: s_DONE :: Nil = Enum(3)
+  val state = Reg(init = s_INIT)
+
+  when (state === s_INIT) { state := s_RUN }
+
+  val (count, done) = Counter(state === s_RUN, math.pow(2, n).toInt)
+  dut.io.in := count
+
+  assert(dut.io.in === dut.io.out)
+  assert(dut.io.err === false.B)
+
+  when (done) { state := s_DONE }
+  when (state === s_DONE) { stop }
+}


### PR DESCRIPTION
WIP towards an ECC library. (This is some old code that I had which I need to revive / it's easier to just improve it and upstream.) An alternative would be to sweep in: 
  - https://github.com/freechipsproject/rocket-chip/blob/master/src/main/scala/util/ECC.scala

High level requirements:
  - Generic in terms of code
  - Optional additional parity bit
  - Provides specific implementations of a wide array of codes (or concrete realizations of all of the following are possible):
    - Hamming
    - Parity
    - n of m
    - TMR
    - Golay 
    - Hadamard 
    - Reed Solomon
    - BCH
    - Reed Muller
  - Implementation should be recognizable in terms of ECC language (generator matrix, parity check matrix, etc.)

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->