### PR TITLE
LFSR/PRNG Asynchronous Safety, Use Vec[Bool] to store internal state

### DIFF
--- a/src/main/scala/chisel3/util/random/FibonacciLFSR.scala
+++ b/src/main/scala/chisel3/util/random/FibonacciLFSR.scala
@@ -47,7 +47,7 @@ class FibonacciLFSR(
   step: Int = 1,
   updateSeed: Boolean = false) extends PRNG(width, seed, step, updateSeed) with LFSR {
 
-  def delta(s: UInt): UInt = s(width-2,0) ## taps.map{ case i => s(i - 1) }.reduce(reduction)
+  def delta(s: Seq[Bool]): Seq[Bool] = taps.map{ case i => s(i - 1) }.reduce(reduction) +: s.dropRight(1)
 
 }
 

--- a/src/main/scala/chisel3/util/random/GaloisLFSR.scala
+++ b/src/main/scala/chisel3/util/random/GaloisLFSR.scala
@@ -45,18 +45,14 @@ class GaloisLFSR(
   step: Int = 1,
   updateSeed: Boolean = false) extends PRNG(width, seed, step, updateSeed) with LFSR {
 
-  def delta(s: UInt): UInt = {
-    val in = s.asBools
-    val first = in.head
-    val out = Wire(Vec(s.getWidth, Bool()))
-    out
-      .zip(in.tail :+ first)
+  def delta(s: Seq[Bool]): Seq[Bool] = {
+    val first = s.head
+    (s.tail :+ first)
       .zipWithIndex
-      .foreach {
-        case ((l, r), i) if taps(i + 1) && (i + 1 != out.size) => l := reduction(r, first)
-        case ((l, r), _)                                       => l := r
+      .map {
+        case (a, i) if taps(i + 1) && (i + 1 != s.size) => reduction(a, first)
+        case (a, _)                                     => a
       }
-    out.asUInt
   }
 
 }

--- a/src/main/scala/chisel3/util/random/LFSR.scala
+++ b/src/main/scala/chisel3/util/random/LFSR.scala
@@ -55,8 +55,8 @@ trait LFSR extends PRNG {
       }
     case None =>
       reduction match {
-        case XOR  => when (reset.toBool) { state := state(width-1, 1) ## 1.U }
-        case XNOR => when (reset.toBool) { state := state(width-1, 1) ## 0.U }
+        case XOR  => when (reset.toBool) { state(0) := 1.U }
+        case XNOR => when (reset.toBool) { state(0) := 0.U }
       }
   }
 

--- a/src/test/scala/chiselTests/LFSR16.scala
+++ b/src/test/scala/chiselTests/LFSR16.scala
@@ -51,10 +51,15 @@ class LFSRMaxPeriod(gen: => UInt) extends BasicTester {
   val seed = withReset(!started) { RegInit(rv) }
 
   val (_, wrap) = Counter(started, math.pow(2.0, rv.getWidth).toInt - 1)
+
   when (rv === seed && started) {
     chisel3.assert(wrap)
     stop()
   }
+
+  val last = RegNext(rv)
+  chisel3.assert(rv =/= last, "LFSR last value (0b%b) was equal to current value (0b%b)", rv, last)
+
 }
 
 /** Check that the output of the new LFSR is the same asthe old LFSR */

--- a/src/test/scala/chiselTests/util/random/LFSRSpec.scala
+++ b/src/test/scala/chiselTests/util/random/LFSRSpec.scala
@@ -12,7 +12,7 @@ import chiselTests.{ChiselFlatSpec, LFSRDistribution, LFSRMaxPeriod}
 import math.pow
 
 class FooLFSR(val reduction: LFSRReduce, seed: Option[BigInt]) extends PRNG(4, seed) with LFSR {
-  def delta(s: UInt): UInt = s
+  def delta(s: Seq[Bool]): Seq[Bool] = s
 }
 
 /** This tests that after reset an LFSR is not locked up. This manually sets the seed of the LFSR at run-time to the
@@ -30,20 +30,18 @@ class LFSRResetTester(gen: => LFSR, lockUpValue: BigInt) extends BasicTester {
 
   val (count, done) = Counter(true.B, 5)
 
-  printf("%d: 0b%b\n", count, lfsr.io.out)
-
   lfsr.io.seed.valid := count === 1.U
-  lfsr.io.seed.bits := lockUpValue.U
+  lfsr.io.seed.bits := lockUpValue.U(lfsr.width.W).asBools
   lfsr.io.increment := true.B
 
   when (count === 2.U) {
-    assert(lfsr.io.out === lockUpValue.U, "LFSR is NOT locked up, but should be!")
+    assert(lfsr.io.out.asUInt === lockUpValue.U, "LFSR is NOT locked up, but should be!")
   }
 
   lfsr.reset := count === 3.U
 
   when (count === 4.U) {
-    assert(lfsr.io.out =/= lockUpValue.U, "LFSR is locked up, but should not be after reset!")
+    assert(lfsr.io.out.asUInt =/= lockUpValue.U, "LFSR is locked up, but should not be after reset!")
   }
 
   when (done) {

--- a/src/test/scala/chiselTests/util/random/PRNGSpec.scala
+++ b/src/test/scala/chiselTests/util/random/PRNGSpec.scala
@@ -12,7 +12,7 @@ import chiselTests.ChiselFlatSpec
 class CyclePRNG(width: Int, seed: Option[BigInt], step: Int, updateSeed: Boolean)
     extends PRNG(width, seed, step, updateSeed) {
 
-  def delta(s: UInt): UInt = s ## s(width - 1)
+  def delta(s: Seq[Bool]): Seq[Bool] = s.last +: s.dropRight(1)
 
 }
 
@@ -49,10 +49,10 @@ class PRNGUpdateSeedTest(updateSeed: Boolean, seed: BigInt, expected: BigInt) ex
 
   a.io.increment := true.B
   a.io.seed.valid := count === 2.U
-  a.io.seed.bits := seed.U
+  a.io.seed.bits := seed.U(a.width.W).asBools
 
   when (count === 3.U) {
-    assert(a.io.out === expected.U, "Output didn't match!")
+    assert(a.io.out.asUInt === expected.U, "Output didn't match!")
   }
 
   when (done) {


### PR DESCRIPTION
Changes the internal state of PRNG to use Vec[Bool] instead of UInt.
This fixes an @aswaterman identified future problem with asynchronous
reset.

A register with an asynchronous reset can only be reset to a literal.
Previously, an LFSR would store state as a UInt. If it was not
parameterized with a seed it should have its least significant bit
reset to something to avoid locking up. It's ideal to not reset the
full UInt (better test coverage, decreased reset fanout). However,
it's difficult to only reset one bit of a UInt. Conversely, it's
trivial to reset one bit of a Vec[Bool]. This also moves PRNG/LFSR
closer to a canonical representation of their internal state, i.e.,
it's natural to think of generalizing Vec[Bool] to arbitrary finite
fields (Vec[A <: Field]) whereas UInt is tightly coupled to GF2.

The specific change for async reset can be seen here:
  - https://github.com/freechipsproject/chisel3/pull/1092/files#diff-b971a8f4b4adb579f0d85c8060d2fc7eL58

Minor updates:

- Updates/fixes to some scaladoc
- Add assertion to period test to make sure LFSR is changing

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Use Vec[Bool] for internal LFSR/PRNG state