### PR TITLE
Ducky readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Chisel is powered by [FIRRTL (Flexible Intermediate Representation for RTL)](htt
 
 Consider an FIR filter that implements a convolution operation, as depicted in this block diagram:
 
-<img src="doc/images/fir_filter.svg?sanitize=true" width="200" />
-
-<!-- ![FIR FILTER DIAGRAM 3](doc/images/fir_filter.svg?sanitize=true | width=100) -->
+<img src="doc/images/fir_filter.svg?sanitize=true" width="512" />
 
 While Chisel provides similar base primitives as synthesizable Verilog, and *could* be used as such:
 
@@ -109,8 +107,7 @@ These simulation-based verification tools are available for Chisel:
 - [**Gitter**](https://gitter.im/freechipsproject/chisel3), where you can ask questions or discuss anything Chisel
 - [**Website**](https://chisel.eecs.berkeley.edu)
 
-
-- If you are migrating from Chisel2, see [the migration guide on the wiki](https://github.com/ucb-bar/chisel3/wiki/Chisel3-vs-Chisel2).
+If you are migrating from Chisel2, see [the migration guide on the wiki](https://github.com/ucb-bar/chisel3/wiki/Chisel3-vs-Chisel2).
 
 ### Data Types Overview
 These are the base data types for defining circuit wires (abstract types which may not be instantiated are greyed out):

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,72 @@
+# Chisel Local Setup
+Instructions for setting up your environment to run Chisel locally.
+
+For a minimal setup, you only need to install [SBT (the Scala Build Tool)](http://www.scala-sbt.org), which will automatically fetch the appropriate version of Scala and Chisel based on on your project configuration.
+
+[Verilator](https://www.veripool.org/wiki/verilator) is optional, only if you need to run the Chisel3 regression suite, or simulate your Verilog designs.
+Note that both [PeekPokeTester](https://github.com/freechipsproject/chisel-testers) and [testers2](https://github.com/ucb-bar/chisel-testers2) both support using [treadle](https://github.com/freechipsproject/treadle) (a FIRRTL simulator written in Scala) as the simulation engine, which requires no additional installation steps.
+
+## Ubuntu Linux	
+
+1.  Install Java	
+    ```	
+    sudo apt-get install default-jdk	
+    ```
+   	
+1.  [Install sbt](http://www.scala-sbt.org/release/docs/Installing-sbt-on-Linux.html),	
+    which isn't available by default in the system package manager:	
+    ```	
+    echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list	
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823	
+    sudo apt-get update	
+    sudo apt-get install sbt	
+    ```
+    
+1.  Install Verilator.	
+    We currently recommend Verilator version 4.006.	
+    Follow these instructions to compile it from source.	
+
+    1.  Install prerequisites (if not installed already):	
+        ```	
+        sudo apt-get install git make autoconf g++ flex bison	
+        ```
+
+    2.  Clone the Verilator repository:	
+        ```	
+        git clone http://git.veripool.org/git/verilator	
+        ```
+
+    3.  In the Verilator repository directory, check out a known good version:	
+        ```	
+        git pull	
+        git checkout verilator_4_006	
+        ```
+
+    4.  In the Verilator repository directory, build and install:	
+        ```	
+        unset VERILATOR_ROOT # For bash, unsetenv for csh	
+        autoconf # Create ./configure script	
+        ./configure	
+        make	
+        sudo make install	
+        ```
+
+## Arch Linux
+1.  Install Verilator and SBT
+    ```
+    yaourt -S sbt verilator
+    ```
+ 
+## Windows
+1.  [Download and install sbt for Windows](https://www.scala-sbt.org/download.html).
+
+Verilator does not appear to have native Windows support.
+However, Verilator works in [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) or in other Linux-compatible environments like Cygwin.
+
+There are no issues with generating Verilog from Chisel, which can be pushed to FPGA or ASIC tools.
+
+## Mac OS X
+1.  Install Verilator and SBT
+    ```
+    brew install sbt verilator
+    ```


### PR DESCRIPTION
Note this will be merged onto the branch for #1106, not master.

This is by no means the way it has to be, but just my take on what I think the README should look like, with the goal of addressing as wide an audience as possible. Bikeshedding (and it probably does need a few copyediting passes) and discussion is welcome!

Main changes:
- The overview / introduction text is more focused from a user's point of view: what does Chisel provide them, instead of what Chisel is.
- The code examples are written with the Verilog-analogue first, and generators second. The idea is to provide something familiar (but still better, hopefully) while the writing style should keep readers reading onto the second example which shows the generator approach and usage.
  - Note: it would be nice to have an alternative for `tabulate` and the `reduce`. `sum()` doesn't appear to work on Vec, though can that be fixed?
  - We might also want to include a more functional version of FIR somewhere, probably behind a link to not clutter the main page - as a "if you're dabbling in a functional style, Chisel will make you feel right at home" but without confusing the heck out of those coming from Verilog
- Added a short blurb for everything on the documentation section, so readers have an idea of what each resource might be useful for
- Streamlined the section on verification
  - I removed the reference to the builtin tester (hardware testing hardware), because it doesn't appear to be something that we use or are pushing. If I'm wrong, we can add it back, but I'd like to have something to link to that's not scaladoc or a .scala file. Otherwise, it's just clutter, and the main reason it's used is the Chisel regression suite.
- Added the setup section in a separate file. We don't need per-OS instructions cluttering the main page, but it does need to be *somewhere*, because I don't expect that new users will know that the right answer is simply "go fetch sbt"
- Other stylistic cleanup