### PR TITLE
Use Verilator 4.016

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
           at: /home/chisel
 
       # Set environment
-      - run: echo 'export PATH="/opt/verilator/verilator_4_006/bin:/opt/yosys/bin:$PATH"' >> $BASH_ENV
+      - run: echo 'export PATH="/opt/verilator/verilator_4_016/bin:/opt/yosys/bin:$PATH"' >> $BASH_ENV
 
       # The -DminimalResources flag causes sbt to run tests sequentially,
       #  so we could actually use "sbt +test" to run all the crossVersioned tests.

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,7 +23,7 @@ Note that both [PeekPokeTester](https://github.com/freechipsproject/chisel-teste
     ```
     
 1.  Install Verilator.	
-    We currently recommend Verilator version 4.006.	
+    We currently recommend Verilator version 4.016.	
     Follow these instructions to compile it from source.	
 
     1.  Install prerequisites (if not installed already):	
@@ -39,7 +39,7 @@ Note that both [PeekPokeTester](https://github.com/freechipsproject/chisel-teste
     3.  In the Verilator repository directory, check out a known good version:	
         ```	
         git pull	
-        git checkout verilator_4_006	
+        git checkout verilator_4_016	
         ```
 
     4.  In the Verilator repository directory, build and install:	


### PR DESCRIPTION
Now that ucbbar/chisel3-tools has Verilator 4.016, use that for tests.
Reverting this PR will revert back to Verilator 4.006

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Now that [ucbbar/chisel3-tools](https://github.com/ucb-bar/chisel-ci-infra/blob/master/chisel3-tools/Dockerfile) has Verilator 4.016, use that for tests.
