### PR TITLE
add toTarget for NamedComponent, and Module, deprcate toNamed.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Module.scala
@@ -230,7 +230,7 @@ package experimental {
       * @note Should not be called until circuit elaboration is complete
       */
     @deprecated("Use Target instead, will be removed in 1.3", "1.2")
-    final def toNamed: ModuleName = ModuleName(this.name, CircuitName(this.circuitName))
+    final def toNamed: ModuleName = toTarget.toNamed
 
     /** Returns a FIRRTL ModuleTarget that references this object
       * @note Should not be called until circuit elaboration is complete

--- a/chiselFrontend/src/main/scala/chisel3/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Module.scala
@@ -229,7 +229,7 @@ package experimental {
     /** Returns a FIRRTL ModuleName that references this object
       * @note Should not be called until circuit elaboration is complete
       */
-    @deprecated("Use Target instead, will be removed in 1.3", "1.2")
+    @deprecated("Use toTarget instead", "3.1")
     final def toNamed: ModuleName = toTarget.toNamed
 
     /** Returns a FIRRTL ModuleTarget that references this object

--- a/chiselFrontend/src/main/scala/chisel3/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Module.scala
@@ -15,7 +15,7 @@ import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{InstTransform, SourceInfo}
 import chisel3.experimental.BaseModule
 
-import _root_.firrtl.annotations.{CircuitName, ModuleName}
+import _root_.firrtl.annotations.{CircuitName, ModuleName, ModuleTarget}
 
 object Module extends SourceInfoDoc {
   /** A wrapper method that all Module instantiations must be wrapped in
@@ -229,7 +229,13 @@ package experimental {
     /** Returns a FIRRTL ModuleName that references this object
       * @note Should not be called until circuit elaboration is complete
       */
+    @deprecated("Use Target instead, will be removed in 1.3", "1.2")
     final def toNamed: ModuleName = ModuleName(this.name, CircuitName(this.circuitName))
+
+    /** Returns a FIRRTL ModuleTarget that references this object
+      * @note Should not be called until circuit elaboration is complete
+      */
+    final def toTarget: ModuleTarget = ModuleTarget(this.circuitName, this.name)
 
     /**
      * Internal API. Returns a list of this module's generated top-level ports as a map of a String

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -8,7 +8,7 @@ import chisel3._
 import chisel3.experimental._
 import chisel3.internal.firrtl._
 import chisel3.internal.naming._
-import _root_.firrtl.annotations.{CircuitName, ComponentName, ModuleName, Named}
+import _root_.firrtl.annotations._
 
 private[chisel3] class Namespace(keywords: Set[String]) {
   private val names = collection.mutable.HashMap[String, Long]()
@@ -163,8 +163,18 @@ private[chisel3] trait NamedComponent extends HasId {
   /** Returns a FIRRTL ComponentName that references this object
     * @note Should not be called until circuit elaboration is complete
     */
+  @deprecated("Use toTarget instead, will be removed in 1.3", "1.2")
   final def toNamed: ComponentName =
     ComponentName(this.instanceName, ModuleName(this.parentModName, CircuitName(this.circuitName)))
+
+  /** Returns a FIRRTL [[ReferenceTarget]] that references this object
+    * @note Should not be called until circuit elaboration is complete
+    */
+  def toTarget: ReferenceTarget = {
+    Target.toTargetTokens(this.instanceName).toList match {
+      case TargetToken.Ref(r) :: components => ReferenceTarget(this.circuitName, this.parentModName, Nil, r, components)
+    }
+  }
 }
 
 // Mutable global state for chisel that can appear outside a Builder context

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -69,6 +69,7 @@ trait InstanceId {
   def parentModName: String
   /** Returns a FIRRTL Named that refers to this object in the elaborated hardware graph */
   def toNamed: Named
+  def toTarget: Target
 
 }
 
@@ -164,9 +165,7 @@ private[chisel3] trait NamedComponent extends HasId {
     * @note Should not be called until circuit elaboration is complete
     */
   @deprecated("Use toTarget instead, will be removed in 1.3", "1.2")
-  final def toNamed: ComponentName =
-    ComponentName(this.instanceName, ModuleName(this.parentModName, CircuitName(this.circuitName)))
-
+  final def toNamed: ComponentName = toTarget.toNamed
   /** Returns a FIRRTL [[ReferenceTarget]] that references this object
     * @note Should not be called until circuit elaboration is complete
     */

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -164,7 +164,7 @@ private[chisel3] trait NamedComponent extends HasId {
   /** Returns a FIRRTL ComponentName that references this object
     * @note Should not be called until circuit elaboration is complete
     */
-  @deprecated("Use toTarget instead, will be removed in 1.3", "1.2")
+  @deprecated("Use toTarget instead", "3.1")
   final def toNamed: ComponentName = toTarget.toNamed
   /** Returns a FIRRTL [[ReferenceTarget]] that references this object
     * @note Should not be called until circuit elaboration is complete


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: API addition (no impact on existing code)

**Development Phase**: proposal

**Release Notes**
Since `Named` is deprecated in firrtl, It's more elegant to deprecate correspond `toNamed` in `chiselFrontend` with `toTarget`.   