### PR TITLE
Standard code formatting

### DIFF
--- a/.scalafmt.config
+++ b/.scalafmt.config
@@ -1,18 +1,164 @@
-style = defaultWithAlign
-
+version = "2.0.0"
+maxColumn = 100
+docstrings = ScalaDoc
+optIn.configStyleArguments = true
+optIn.breaksInsideChains = false
+optIn.breakChainOnFirstMethodDot = true
+optIn.selfAnnotationNewline = true
+optIn.annotationNewlines = true
+optIn.blankLineBeforeDocstring = false
+binPack.unsafeCallSite = false
+binPack.unsafeDefnSite = false
+binPack.parentConstructors = false
+binPack.literalArgumentLists = true
+binPack.literalsMinArgCount = 5
+binPack.literalsInclude = [
+  ".*"
+]
+binPack.literalsExclude = [
+  String
+  "Term.Name"
+]
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 4
+continuationIndent.extendSite = 4
 align.openParenCallSite = false
 align.openParenDefnSite = false
-align.tokens = [{code = “->“}, {code = “<-“}, {code = “=>“, owner = “Case”}]
-continuationIndent.callSite = 2
-continuationIndent.defnSite = 2
-danglingParentheses = true
-indentOperator = spray
-maxColumn = 100
-newlines.alwaysBeforeTopLevelStatements = true
-project.excludeFilters = [“.*\\.sbt”]
-rewrite.rules = [RedundantParens, SortImports]
+align.tokens = [
+  {
+    code = "=>"
+    owner = Case
+  }
+]
+align.arrowEnumeratorGenerator = false
+align.ifWhileOpenParen = true
+align.treeCategory."Defn.Trait" = "class/object/trait"
+align.treeCategory."Enumerator.Val" = for
+align.treeCategory."Defn.Class" = "class/object/trait"
+align.treeCategory."Defn.Object" = "class/object/trait"
+align.treeCategory."Defn.Val" = "val/var/def"
+align.treeCategory."Defn.Def" = "val/var/def"
+align.treeCategory."Defn.Var" = "val/var/def"
+align.treeCategory."Enumerator.Generator" = for
+spaces.beforeContextBoundColon = Never
+spaces.afterTripleEquals = false
 spaces.inImportCurlyBraces = false
-unindentTopLevelOperators = true
-verticalMultiline.atDefnSite = true
+spaces.inParentheses = false
+spaces.neverAroundInfixTypes = []
+spaces.afterKeywordBeforeParen = true
+spaces.inByNameTypes = true
+spaces.afterSymbolicDefs = false
+literals.long = Upper
+literals.float = Lower
+literals.double = Lower
+lineEndings = unix
+rewrite.rules = []
+rewrite.redundantBraces.methodBodies = true
+rewrite.redundantBraces.includeUnitMethods = true
+rewrite.redundantBraces.maxLines = 100
+rewrite.redundantBraces.stringInterpolation = false
+rewrite.redundantBraces.generalExpressions = false
+rewrite.sortModifiers.order = [
+  "`implicit`"
+  "`final`"
+  "`sealed`"
+  "`abstract`"
+  "`override`"
+  "`private`"
+  "`protected`"
+  "`lazy`"
+]
+rewrite.neverInfix.includeFilters = [
+  "[\w\d_]+"
+]
+rewrite.neverInfix.excludeFilters = [
+  until
+  to
+  by
+  eq
+  ne
+  "should.*"
+  "contain.*"
+  "must.*"
+  in
+  ignore
+  be
+  taggedAs
+  thrownBy
+  synchronized
+  have
+  when
+  size
+  only
+  noneOf
+  oneElementOf
+  noElementsOf
+  atLeastOneElementOf
+  atMostOneElementOf
+  allElementsOf
+  inOrderElementsOf
+  theSameElementsAs
+]
+indentOperator.include = ".*"
+indentOperator.exclude = "^(&&|\|\|)$"
+newlines.neverInResultType = false
+newlines.neverBeforeJsNative = false
+newlines.sometimesBeforeColonInMethodReturnType = true
+newlines.penalizeSingleSelectMultiArgList = true
+newlines.alwaysBeforeCurlyBraceLambdaParams = false
+newlines.alwaysBeforeTopLevelStatements = false
+newlines.afterCurlyLambda = never
+newlines.afterImplicitKWInVerticalMultiline = false
+newlines.beforeImplicitKWInVerticalMultiline = false
+newlines.alwaysBeforeElseAfterCurlyIf = false
+newlines.alwaysBeforeMultilineDef = true
+newlines.avoidAfterYield = true
+runner.debug = false
+runner.eventCallback = "<FormatEvent => Unit>"
+runner.parser = "<Parse[Tree]>"
+runner.optimizer.dequeueOnNewStatements = true
+runner.optimizer.escapeInPathologicalCases = true
+runner.optimizer.maxVisitsPerToken = 513
+runner.optimizer.maxEscapes = 16
+runner.optimizer.maxDepth = 100
+runner.optimizer.acceptOptimalAtHints = true
+runner.optimizer.disableOptimizationsInsideSensitiveAreas = true
+runner.optimizer.pruneSlowStates = true
+runner.optimizer.recurseOnBlocks = true
+runner.optimizer.forceConfigStyleOnOffset = 150
+runner.optimizer.forceConfigStyleMinArgCount = 2
+runner.maxStateVisits = 1000000
+runner.dialect = "<Dialect>"
+runner.ignoreWarnings = false
+runner.fatalWarnings = false
+indentYieldKeyword = true
+importSelectors = noBinPack
+unindentTopLevelOperators = false
+includeCurlyBraceInSelectChains = true
+includeNoParensInSelectChains = false
+assumeStandardLibraryStripMargin = false
+danglingParentheses = true
+poorMansTrailingCommasInConfigStyle = false
+trailingCommas = never
+verticalMultilineAtDefinitionSite = false
+verticalMultilineAtDefinitionSiteArityThreshold = 100
+verticalMultiline.atDefnSite = false
 verticalMultiline.arityThreshold = 100
-verticalMultiline.newlineAfterOpenParen = true
+verticalMultiline.newlineBeforeImplicitKW = false
+verticalMultiline.newlineAfterImplicitKW = false
+verticalMultiline.newlineAfterOpenParen = false
+verticalMultiline.excludeDanglingParens = [
+  "`class`"
+  "`trait`"
+]
+verticalAlignMultilineOperators = false
+onTestFailure = ""
+encoding = "UTF-8"
+project.git = false
+project.files = []
+project.includeFilters = [
+  ".*\.scala$"
+  ".*\.sbt$"
+  ".*\.sc$"
+]
+project.excludeFilters = []

--- a/.scalafmt.config
+++ b/.scalafmt.config
@@ -1,0 +1,18 @@
+style = defaultWithAlign
+
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.tokens = [{code = “->“}, {code = “<-“}, {code = “=>“, owner = “Case”}]
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 2
+danglingParentheses = true
+indentOperator = spray
+maxColumn = 100
+newlines.alwaysBeforeTopLevelStatements = true
+project.excludeFilters = [“.*\\.sbt”]
+rewrite.rules = [RedundantParens, SortImports]
+spaces.inImportCurlyBraces = false
+unindentTopLevelOperators = true
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 100
+verticalMultiline.newlineAfterOpenParen = true


### PR DESCRIPTION
We have talked about the need for consistent code formatting for a while now. Consistent formatting
should  make our code easier to read. Automating the formatting ensures that the formatting is consistent no matter who works on the code. This is more important as we have new contributors with different personal styles.

**Resources**:
[https://scalameta.org/scalafmt/](https://scalameta.org/scalafmt/)

**Type of change**: Code formatting

**Impact**: No functional change.
Visually different code

**Development Phase**: Proposal
I would encourage interested parties to play with the settings in the file. I personally like the more
open style but it comes in some cost in total number of lines

If adopted we should make a decision about doing a pass over every file or perhaps at first 
reformatting files as they are changed in other PRs

**Release Notes**
Chisel3 is moving to a standard automated code formatting style