### PR TITLE
Fix Num.+ Scaladoc

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -492,7 +492,7 @@ abstract trait Num[T <: Data] {
     *
     * @param that a $numType
     * @return the sum of this $coll and `that`
-    * $maxWidthPlusOne
+    * $maxWidth
     * @group Arithmetic
     */
   final def + (that: T): T = macro SourceInfoTransform.thatArg


### PR DESCRIPTION
Change `Num.+` Scaladoc to state that this is not a growing
addition. Note that this is problematic either way as this macro is
resolved to an abstract method. Classes implementing this typeclass
are technically free to violate what we put in the Scaladoc here.

h/t @kammoh
  - See: https://gitter.im/freechipsproject/chisel3?at=5d38a6b935e05c099394c591

An alternative would be to remove the width documentation in the Scaladoc.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: documentation

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
