### PR TITLE
Make Queue.irrevocable work properly in chisel3

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -305,7 +305,7 @@ object Queue
       flow: Boolean = false): IrrevocableIO[T] = {    
     val deq = apply(enq, entries, pipe, flow)
     require(entries > 0, "Zero-entry queues don't guarantee Irrevocability")
-    val irr = Wire(new IrrevocableIO(deq.bits))
+    val irr = Wire(new IrrevocableIO(chiselTypeOf(deq.bits)))
     irr.bits := deq.bits
     irr.valid := deq.valid
     deq.ready := irr.ready

--- a/src/test/scala/chiselTests/QueueSpec.scala
+++ b/src/test/scala/chiselTests/QueueSpec.scala
@@ -269,6 +269,13 @@ class QueueSpec extends ChiselPropSpec {
         }
       }
     }
+  }
 
+  property("Queue.irrevocable should elaborate") {
+    class IrrevocableQueue extends MultiIOModule {
+      val in = Wire(Decoupled(Bool()))
+      val iQueue = Queue.irrevocable(in, 1)
+    }
+    (new chisel3.stage.phases.Elaborate).transform(Seq(chisel3.stage.ChiselGeneratorAnnotation(() => new IrrevocableQueue)))
   }
 }


### PR DESCRIPTION
Close #1134

<!-- choose one -->
**Type of change**: bugfix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**: Fix unexpected error from attempting to use Queue.irrevocable in chisel3.