### PR TITLE
Remove Deprecations since before 3.2

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -348,16 +348,6 @@ trait VecLike[T <: Data] extends collection.IndexedSeq[T] with HasId with Source
   override def hashCode: Int = super[HasId].hashCode
   override def equals(that: Any): Boolean = super[HasId].equals(that)
 
-  @chiselRuntimeDeprecated
-  @deprecated("Use Vec.apply instead", "chisel3")
-  def read(idx: UInt)(implicit compileOptions: CompileOptions): T = do_apply(idx)(compileOptions)
-
-  @chiselRuntimeDeprecated
-  @deprecated("Use Vec.apply instead", "chisel3")
-  def write(idx: UInt, data: T)(implicit compileOptions: CompileOptions): Unit = {
-    do_apply(idx)(compileOptions).:=(data)(DeprecatedSourceInfo, compileOptions)
-  }
-
   /** Outputs true if p outputs true for every element.
     */
   def forall(p: T => Bool): Bool = macro SourceInfoTransform.pArg

--- a/chiselFrontend/src/main/scala/chisel3/Annotation.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Annotation.scala
@@ -18,17 +18,6 @@ trait ChiselAnnotation {
   /** Conversion to FIRRTL Annotation */
   def toFirrtl: Annotation
 }
-object ChiselAnnotation {
-  @deprecated("Write a custom ChiselAnnotation subclass instead", "3.1")
-  def apply(component: InstanceId, transformClass: Class[_ <: Transform], value: String): ChiselLegacyAnnotation =
-    ChiselLegacyAnnotation(component, transformClass, value)
-  @deprecated("Write a custom ChiselAnnotation subclass instead", "3.1")
-  def unapply(anno: ChiselAnnotation): Option[(InstanceId, Class[_ <: Transform], String)] =
-    anno match {
-      case ChiselLegacyAnnotation(c, t, v) => Some(c, t, v)
-      case _ => None
-    }
-}
 
 /** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this Annotation is present
   * during a run of

--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -404,28 +404,6 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     throwException(s"Cannot call .asFixedPoint on $this")
   }
 
-  /** Reinterpret cast to Bits. */
-  @chiselRuntimeDeprecated
-  @deprecated("Use asUInt, which does the same thing but returns a more concrete type", "chisel3")
-  final def asBits(implicit compileOptions: CompileOptions): Bits = {
-    implicit val sourceInfo = DeprecatedSourceInfo
-    do_asUInt
-  }
-
-  @chiselRuntimeDeprecated
-  @deprecated("Use asSInt, which makes the reinterpret cast more explicit", "chisel3")
-  final def toSInt(implicit compileOptions: CompileOptions): SInt = {
-    implicit val sourceInfo = DeprecatedSourceInfo
-    do_asSInt
-  }
-
-  @chiselRuntimeDeprecated
-  @deprecated("Use asUInt, which makes the reinterpret cast more explicit", "chisel3")
-  final def toUInt(implicit compileOptions: CompileOptions): UInt = {
-    implicit val sourceInfo = DeprecatedSourceInfo
-    do_asUInt
-  }
-
   final def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     width match {
       case KnownWidth(1) => this(0)
@@ -830,7 +808,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
   override def do_>= (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, GreaterEqOp, that)
 
   @chiselRuntimeDeprecated
-  @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")
+  @deprecated("Use '=/=', which avoids potential precedence problems", "3.0")
   final def != (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this =/= that
 
   /** Dynamic not equals operator
@@ -1120,7 +1098,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   override def do_>= (that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, GreaterEqOp, that)
 
   @chiselRuntimeDeprecated
-  @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")
+  @deprecated("Use '=/=', which avoids potential precedence problems", "3.0")
   final def != (that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this =/= that
 
   /** Dynamic not equals operator
@@ -1652,11 +1630,6 @@ package experimental {
     def apply(): FixedPoint = apply(Width(), BinaryPoint())
 
     /** Create an FixedPoint type or port with fixed width. */
-    @chiselRuntimeDeprecated
-    @deprecated("Use FixedPoint(width: Width, binaryPoint: BinaryPoint) example FixedPoint(16.W, 8.BP)", "chisel3")
-    def apply(width: Int, binaryPoint: Int): FixedPoint = apply(Width(width), BinaryPoint(binaryPoint))
-
-    /** Create an FixedPoint type or port with fixed width. */
     def apply(width: Width, binaryPoint: BinaryPoint): FixedPoint = new FixedPoint(width, binaryPoint)
 
     /** Create an FixedPoint literal with inferred width from BigInt.
@@ -1681,17 +1654,6 @@ package experimental {
       else {
         apply(value, Width(width), BinaryPoint(binaryPoint))
       }
-    /** Create an FixedPoint literal with inferred width from Double.
-      * Use PrivateObject to force users to specify width and binaryPoint by name
-      */
-    @chiselRuntimeDeprecated
-    @deprecated("use fromDouble(value: Double, width: Width, binaryPoint: BinaryPoint)", "chisel3")
-    def fromDouble(value: Double, dummy: PrivateType = PrivateObject,
-                   width: Int = -1, binaryPoint: Int = 0): FixedPoint = {
-      fromBigInt(
-        toBigInt(value, binaryPoint), width = width, binaryPoint = binaryPoint
-      )
-    }
     /** Create an FixedPoint literal with inferred width from Double.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
@@ -1737,9 +1699,6 @@ package experimental {
 
   //      implicit class fromDoubleToLiteral(val double: Double) extends AnyVal {
       implicit class fromDoubleToLiteral(double: Double) {
-        @deprecated("Use notation <double>.F(<binary_point>.BP) instead", "chisel3")
-        def F(binaryPoint: Int): FixedPoint = FixedPoint.fromDouble(double, binaryPoint = binaryPoint)
-
         def F(binaryPoint: BinaryPoint): FixedPoint = {
           FixedPoint.fromDouble(double, Width(), binaryPoint)
         }

--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -905,7 +905,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
 }
 
 // This is currently a factory because both Bits and UInt inherit it.
-trait UIntFactoryBase {
+trait UIntFactory {
   /** Create a UInt type with inferred width. */
   def apply(): UInt = apply(Width())
   /** Create a UInt port with specified width. */
@@ -1158,7 +1158,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   }
 }
 
-trait SIntFactoryBase {
+trait SIntFactory {
   /** Create an SInt type with inferred width. */
   def apply(): SInt = apply(Width())
   /** Create a SInt type or port with fixed width. */
@@ -1181,7 +1181,7 @@ trait SIntFactoryBase {
   }
 }
 
-object SInt extends SIntFactoryBase
+object SInt extends SIntFactory
 
 sealed trait Reset extends Element with ToBoolable
 
@@ -1288,7 +1288,7 @@ sealed class Bool() extends UInt(1.W) with Reset {
   def do_asClock(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Clock = pushOp(DefPrim(sourceInfo, Clock(), AsClockOp, ref))
 }
 
-trait BoolFactoryBase {
+trait BoolFactory {
   /** Creates an empty Bool.
    */
   def apply(): Bool = new Bool()
@@ -1303,7 +1303,7 @@ trait BoolFactoryBase {
   }
 }
 
-object Bool extends BoolFactoryBase
+object Bool extends BoolFactory
 
 package experimental {
   //scalastyle:off number.of.methods

--- a/chiselFrontend/src/main/scala/chisel3/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Data.scala
@@ -494,7 +494,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
   final def <> (that: Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = this.bulkConnect(that)(sourceInfo, connectionCompileOptions) // scalastyle:ignore line.size.limit
 
   @chiselRuntimeDeprecated
-  @deprecated("litArg is deprecated, use litOption or litTo*Option", "chisel3.2")
+  @deprecated("litArg is deprecated, use litOption or litTo*Option", "3.2")
   def litArg(): Option[LitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case Some(BundleLitBinding(litMap)) => None  // this API does not support Bundle literals

--- a/chiselFrontend/src/main/scala/chisel3/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Data.scala
@@ -110,12 +110,6 @@ object ActualDirection {
   }
 }
 
-object debug {  // scalastyle:ignore object.name
-  @chiselRuntimeDeprecated
-  @deprecated("debug doesn't do anything in Chisel3 as no pruning happens in the frontend", "chisel3")
-  def apply (arg: Data): Data = arg
-}
-
 package experimental {
 
   /** Experimental hardware construction reflection API
@@ -522,14 +516,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
   /** Returns Some(width) if the width is known, else None. */
   final def widthOption: Option[Int] = if (isWidthKnown) Some(getWidth) else None
 
-  /** Packs the value of this object as plain Bits.
-    *
-    * This performs the inverse operation of fromBits(Bits).
-    */
-  @chiselRuntimeDeprecated
-  @deprecated("Best alternative, .asUInt()", "chisel3")
-  def toBits(implicit compileOptions: CompileOptions): UInt = do_asUInt(DeprecatedSourceInfo, compileOptions)
-
   /** Does a reinterpret cast of the bits in this node into the format that provides.
     * Returns a new Wire of that type. Does not modify existing nodes.
     *
@@ -610,23 +596,7 @@ trait WireFactory {
   * }}}
   *
   */
-object Wire extends WireFactory {
-
-  @chiselRuntimeDeprecated
-  @deprecated("Wire(init=init) is deprecated, use WireDefault(init) instead", "chisel3")
-  def apply[T <: Data](dummy: Int = 0, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    WireDefault(init)
-
-  @chiselRuntimeDeprecated
-  @deprecated("Wire(t, init) is deprecated, use WireDefault(t, init) instead", "chisel3")
-  def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    WireDefault(t, init)
-
-  @chiselRuntimeDeprecated
-  @deprecated("Wire(t, init) is deprecated, use WireDefault(t, init) instead", "chisel3")
-  def apply[T <: Data](t: T, init: DontCare.type)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    WireDefault(t, init)
-}
+object Wire extends WireFactory
 
 /** Utility for constructing hardware wires with a default connection
   *

--- a/chiselFrontend/src/main/scala/chisel3/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Mem.scala
@@ -10,15 +10,6 @@ import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{SourceInfo, SourceInfoTransform, UnlocatableSourceInfo, MemTransform}
 
 object Mem {
-  // scalastyle:off line.size.limit
-  @chiselRuntimeDeprecated
-  @deprecated("Mem argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](t: T, size: BigInt)(implicit compileOptions: CompileOptions): Mem[T] = do_apply(size, t)(UnlocatableSourceInfo, compileOptions)
-
-  // scalastyle:off line.size.limit
-  @chiselRuntimeDeprecated
-  @deprecated("Mem argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](t: T, size: Int)(implicit compileOptions: CompileOptions): Mem[T] = do_apply(size, t)(UnlocatableSourceInfo, compileOptions)
 
   /** Creates a combinational/asynchronous-read, sequential/synchronous-write [[Mem]].
     *
@@ -150,13 +141,6 @@ sealed abstract class MemBase[T <: Data](t: T, val length: BigInt) extends HasId
 sealed class Mem[T <: Data] private (t: T, length: BigInt) extends MemBase(t, length)
 
 object SyncReadMem {
-  @chiselRuntimeDeprecated
-  @deprecated("SeqMem/SyncReadMem argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](t: T, size: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] = do_apply(size, t)
-
-  @chiselRuntimeDeprecated
-  @deprecated("SeqMem/SyncReadMem argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](t: T, size: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SyncReadMem[T] = do_apply(size, t)
 
   /** Creates a sequential/synchronous-read, sequential/synchronous-write [[SyncReadMem]].
     *

--- a/chiselFrontend/src/main/scala/chisel3/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Module.scala
@@ -285,14 +285,6 @@ package experimental {
       */
     def _compatAutoWrapPorts() {} // scalastyle:ignore method.name
 
-    //
-    // BaseModule User API functions
-    //
-    @deprecated("Use chisel3.experimental.annotate instead", "3.1")
-    protected def annotate(annotation: ChiselAnnotation): Unit = {
-      Builder.annotations += annotation
-    }
-
     /** Chisel2 code didn't require the IO(...) wrapper and would assign a Chisel type directly to
       * io, then do operations on it. This binds a Chisel type in-place (mutably) as an IO.
       */

--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -171,29 +171,6 @@ abstract class LegacyModule(implicit moduleCompileOptions: CompileOptions)
   protected var override_clock: Option[Clock] = None
   protected var override_reset: Option[Bool] = None
 
-  // _clock and _reset can be clock and reset in these 2ary constructors
-  // once chisel2 compatibility issues are resolved
-  @chiselRuntimeDeprecated
-  @deprecated("Module constructor with override_clock and override_reset deprecated, use withClockAndReset", "chisel3")
-  def this(override_clock: Option[Clock]=None, override_reset: Option[Bool]=None)
-      (implicit moduleCompileOptions: CompileOptions) = {
-    this()
-    this.override_clock = override_clock
-    this.override_reset = override_reset
-  }
-
-  @chiselRuntimeDeprecated
-  @deprecated("Module constructor with override _clock deprecated, use withClock", "chisel3")
-  def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), None)(moduleCompileOptions) // scalastyle:ignore line.size.limit
-
-  @chiselRuntimeDeprecated
-  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
-  def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  = this(None, Option(_reset))(moduleCompileOptions) // scalastyle:ignore line.size.limit
-
-  @chiselRuntimeDeprecated
-  @deprecated("Module constructor with override _clock, _reset deprecated, use withClockAndReset", "chisel3")
-  def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), Option(_reset))(moduleCompileOptions) // scalastyle:ignore line.size.limit
-
   // IO for this Module. At the Scala level (pre-FIRRTL transformations),
   // connections in and out of a Module may only go through `io` elements.
   def io: Record

--- a/chiselFrontend/src/main/scala/chisel3/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Reg.scala
@@ -46,32 +46,6 @@ object Reg {
     reg
   }
 
-  @chiselRuntimeDeprecated
-  @deprecated("Use Reg(t), RegNext(next, [init]) or RegInit([t], init) instead", "chisel3")
-  def apply[T <: Data](t: T = null, next: T = null, init: T = null)
-                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-    if (t ne null) {
-      val reg = if (init ne null) {
-        RegInit(t, init)
-      } else {
-        Reg(t)
-      }
-      if (next ne null) {
-        reg := next
-      }
-      reg
-    } else if (next ne null) {
-      if (init ne null) {
-        RegNext(next, init)
-      } else {
-        RegNext(next)
-      }
-    } else if (init ne null) {
-      RegInit(init)
-    } else {
-      throwException("cannot infer type")
-    }
-  }
 }
 
 object RegNext {

--- a/chiselFrontend/src/main/scala/chisel3/core/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/package.scala
@@ -234,10 +234,6 @@ package object core {
   implicit class fromIntToBinaryPoint(int: Int) extends experimental.FixedPoint.Implicits.fromIntToBinaryPoint(int)
 
   @deprecated("Use the version in chisel3.experimental._", "3.2")
-  type ChiselAnnotation = chisel3.experimental.ChiselAnnotation
-  @deprecated("Use the version in chisel3.experimental._", "3.2")
-  val ChiselAnnotation = chisel3.experimental.ChiselAnnotation
-  @deprecated("Use the version in chisel3.experimental._", "3.2")
   type RunFirrtlTransform = chisel3.experimental.RunFirrtlTransform
 
   @deprecated("Use the version in chisel3.experimental._", "3.2")

--- a/chiselFrontend/src/main/scala/chisel3/core/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/package.scala
@@ -62,16 +62,16 @@ package object core {
 
   // These provide temporary compatibility for those who foolishly imported from chisel3.core
   @deprecated("Avoid importing from chisel3.core, these are not public APIs and may change at any time. " +
-    " Use chisel3.experimental.RawModule instead.", "since the beginning of time")
+    " Use chisel3.experimental.RawModule instead. This alias will be removed in 3.3.", "since the beginning of time")
   type RawModule = chisel3.experimental.RawModule
   @deprecated("Avoid importing from chisel3.core, these are not public APIs and may change at any time. " +
-    "Use chisel3.experimental.MultiIOModule instead.", "since the beginning of time")
+    "Use chisel3.experimental.MultiIOModule instead. This alias will be removed in 3.3.", "since the beginning of time")
   type MultiIOModule = chisel3.experimental.MultiIOModule
   @deprecated("Avoid importing from chisel3.core, these are not public APIs and may change at any time. " +
-    " Use chisel3.experimental.RawModule instead.", "since the beginning of time")
+    " Use chisel3.experimental.RawModule instead. This alias will be removed in 3.3.", "since the beginning of time")
   type UserModule = chisel3.experimental.RawModule
   @deprecated("Avoid importing from chisel3.core, these are not public APIs and may change at any time. " +
-    "Use chisel3.experimental.MultiIOModule instead.", "since the beginning of time")
+    "Use chisel3.experimental.MultiIOModule instead. This alias will be removed in 3.3.", "since the beginning of time")
   type ImplicitModule = chisel3.experimental.MultiIOModule
 
   @deprecated("Use the version in chisel3._", "3.2")

--- a/chiselFrontend/src/main/scala/chisel3/experimental/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/experimental/package.scala
@@ -20,11 +20,11 @@ package object experimental {  // scalastyle:ignore object.name
 
   type ChiselEnum = EnumFactory
 
-  @deprecated("Use the version in chisel3._", "chisel3.2")
+  @deprecated("Use the version in chisel3._", "3.2")
   val withClockAndReset = chisel3.withClockAndReset
-  @deprecated("Use the version in chisel3._", "chisel3.2")
+  @deprecated("Use the version in chisel3._", "3.2")
   val withClock = chisel3.withClock
-  @deprecated("Use the version in chisel3._", "chisel3.2")
+  @deprecated("Use the version in chisel3._", "3.2")
   val withReset = chisel3.withReset
 
   // Rocket Chip-style clonemodule

--- a/chiselFrontend/src/main/scala/chisel3/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/package.scala
@@ -135,21 +135,6 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   // (UInt|SInt)\(([_a-zA-Z][_0-9a-zA-Z]*),\s*(?:width\s*=)?\s*(\d+|[_a-zA-Z][_0-9a-zA-Z]*)\)
   //  => $2.as$1($3.W)
 
-  /** This contains literal constructor factory methods that are deprecated as of Chisel3.
-    * These will be removed very soon. It's recommended you port your code ASAP.
-    */
-  trait UIntFactory extends UIntFactoryBase
-
-  /** This contains literal constructor factory methods that are deprecated as of Chisel3.
-    * These will be removed very soon. It's recommended you move your code soon.
-    */
-  trait SIntFactory extends SIntFactoryBase
-
-  /** This contains literal constructor factory methods that are deprecated as of Chisel3.
-    * These will be removed very soon. It's recommended you move your code soon.
-    */
-  trait BoolFactory extends BoolFactoryBase
-
   object Bits extends UIntFactory
   object UInt extends UIntFactory
   object SInt extends SIntFactory

--- a/chiselFrontend/src/main/scala/chisel3/package.scala
+++ b/chiselFrontend/src/main/scala/chisel3/package.scala
@@ -116,70 +116,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
   val WireInit = WireDefault
 
-  implicit class AddDirectionToData[T<:Data](target: T) {
-    @chiselRuntimeDeprecated
-    @deprecated("Input(Data) should be used over Data.asInput", "chisel3")
-    def asInput(implicit compileOptions: CompileOptions): T = Input(target)
-
-    @chiselRuntimeDeprecated
-    @deprecated("Output(Data) should be used over Data.asOutput", "chisel3")
-    def asOutput(implicit compileOptions: CompileOptions): T = Output(target)
-
-    @chiselRuntimeDeprecated
-    @deprecated("Flipped(Data) should be used over Data.flip", "chisel3")
-    def flip()(implicit compileOptions: CompileOptions): T = Flipped(target)
-  }
-
-  implicit class fromBitsable[T <: Data](data: T) {
-
-    @chiselRuntimeDeprecated
-    @deprecated("fromBits is deprecated, use asTypeOf instead", "chisel3")
-    def fromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-      that.asTypeOf(data)
-    }
-  }
-
-  implicit class cloneTypeable[T <: Data](target: T) {
-    @chiselRuntimeDeprecated
-    @deprecated("chiselCloneType is deprecated, use chiselTypeOf(...) to get the Chisel Type of a hardware object", "chisel3") // scalastyle:ignore line.size.limit
-    def chiselCloneType: T = {
-      target.cloneTypeFull.asInstanceOf[T]
-    }
-  }
-
-  object Vec extends VecFactory {
-    import scala.language.experimental.macros
-
-    @chiselRuntimeDeprecated
-    @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
-    def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.Vec[T] =
-      apply(n, gen)
-
-    @chiselRuntimeDeprecated
-    @deprecated("Vec.fill(n)(gen) is deprecated, use VecInit(Seq.fill(n)(gen)) instead", "chisel3")
-    def fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.Vec[T] =
-      apply(Seq.fill(n)(gen))
-
-    def apply[T <: Data](elts: Seq[T]): chisel3.Vec[T] = macro VecTransform.apply_elts
-    @chiselRuntimeDeprecated
-    @deprecated("Vec(elts) is deprecated, use VecInit(elts) instead", "chisel3")
-    def do_apply[T <: Data](elts: Seq[T])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.Vec[T] =
-      chisel3.VecInit(elts)
-
-    def apply[T <: Data](elt0: T, elts: T*): chisel3.Vec[T] = macro VecTransform.apply_elt0
-    @chiselRuntimeDeprecated
-    @deprecated("Vec(elt0, ...) is deprecated, use VecInit(elt0, ...) instead", "chisel3")
-    def do_apply[T <: Data](elt0: T, elts: T*)
-        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.Vec[T] =
-      VecInit(elt0 +: elts.toSeq)
-
-    def tabulate[T <: Data](n: Int)(gen: (Int) => T): chisel3.Vec[T] = macro VecTransform.tabulate
-    @chiselRuntimeDeprecated
-    @deprecated("Vec.tabulate(n)(gen) is deprecated, use VecInit.tabulate(n)(gen) instead", "chisel3")
-    def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)
-        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.Vec[T] =
-      chisel3.VecInit.tabulate(n)(gen)
-  }
+  object Vec extends VecFactory
 
   // Some possible regex replacements for the literal specifier deprecation:
   // (note: these are not guaranteed to handle all edge cases! check all replacements!)
@@ -201,91 +138,17 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     * These will be removed very soon. It's recommended you port your code ASAP.
     */
-  trait UIntFactory extends UIntFactoryBase {
-    /** Create a UInt literal with inferred width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use n.U", "chisel3, will be removed by end of 2017")
-    def apply(n: String): UInt = n.asUInt
-
-    /** Create a UInt literal with fixed width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use n.U(width.W)", "chisel3, will be removed by end of 2017")
-    def apply(n: String, width: Int): UInt = n.asUInt(width.W)
-
-    /** Create a UInt literal with specified width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.U(width)", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt, width: Width): UInt = value.asUInt(width)
-
-    /** Create a UInt literal with fixed width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.U(width.W)", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt, width: Int): UInt = value.asUInt(width.W)
-
-    /** Create a UInt literal with inferred width.- compatibility with Chisel2. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.U", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt): UInt = value.asUInt
-
-    /** Create a UInt with a specified width */
-    @chiselRuntimeDeprecated
-    @deprecated("use UInt(width.W)", "chisel3, will be removed by end of 2017")
-    def width(width: Int): UInt = apply(width.W)
-
-    /** Create a UInt port with specified width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use UInt(width)", "chisel3, will be removed by end of 2017")
-    def width(width: Width): UInt = apply(width)
-  }
+  trait UIntFactory extends UIntFactoryBase
 
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     * These will be removed very soon. It's recommended you move your code soon.
     */
-  trait SIntFactory extends SIntFactoryBase {
-    /** Create a SInt type or port with fixed width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use SInt(width.W)", "chisel3, will be removed by end of 2017")
-    def width(width: Int): SInt = apply(width.W)
-
-    /** Create an SInt type with specified width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use SInt(width)", "chisel3, will be removed by end of 2017")
-    def width(width: Width): SInt = apply(width)
-
-    /** Create an SInt literal with inferred width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.S", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt): SInt = value.asSInt
-
-    /** Create an SInt literal with fixed width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.S(width.W)", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt, width: Int): SInt = value.asSInt(width.W)
-
-    /** Create an SInt literal with specified width. */
-    @chiselRuntimeDeprecated
-    @deprecated("use value.S(width)", "chisel3, will be removed by end of 2017")
-    def apply(value: BigInt, width: Width): SInt = value.asSInt(width)
-
-    @chiselRuntimeDeprecated
-    @deprecated("use value.S", "chisel3, will be removed by end of 2017")
-    def Lit(value: BigInt): SInt = value.asSInt // scalastyle:ignore method.name
-
-    @chiselRuntimeDeprecated
-    @deprecated("use value.S(width)", "chisel3, will be removed by end of 2017")
-    def Lit(value: BigInt, width: Int): SInt = value.asSInt(width.W) // scalastyle:ignore method.name
-  }
+  trait SIntFactory extends SIntFactoryBase
 
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     * These will be removed very soon. It's recommended you move your code soon.
     */
-  trait BoolFactory extends BoolFactoryBase {
-    /** Creates Bool literal.
-     */
-    @chiselRuntimeDeprecated
-    @deprecated("use x.B", "chisel3, will be removed by end of 2017")
-    def apply(x: Boolean): Bool = x.B
-  }
+  trait BoolFactory extends BoolFactoryBase
 
   object Bits extends UIntFactory
   object UInt extends UIntFactory
@@ -293,11 +156,6 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   object Bool extends BoolFactory
 
   type InstanceId = internal.InstanceId
-
-  @deprecated("Use 'SyncReadMem'", "chisel3")
-  val SeqMem = chisel3.SyncReadMem
-  @deprecated("Use 'SyncReadMem'", "chisel3")
-  type SeqMem[T <: Data] = SyncReadMem[T]
 
   type Module = chisel3.experimental.LegacyModule
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -150,7 +150,7 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
 
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     */
-  trait UIntFactory extends chisel3.UIntFactoryBase {
+  trait UIntFactory extends chisel3.UIntFactory {
     /** Create a UInt literal with inferred width. */
     def apply(n: String): UInt = n.asUInt
     /** Create a UInt literal with fixed width. */
@@ -190,7 +190,7 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
 
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     */
-  trait SIntFactory extends chisel3.SIntFactoryBase {
+  trait SIntFactory extends chisel3.SIntFactory {
     /** Create a SInt type or port with fixed width. */
     def width(width: Int): SInt = apply(width.W)
     /** Create an SInt type with specified width. */
@@ -225,7 +225,7 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
 
   /** This contains literal constructor factory methods that are deprecated as of Chisel3.
     */
-  trait BoolFactory extends chisel3.BoolFactoryBase {
+  trait BoolFactory extends chisel3.BoolFactory {
     /** Creates Bool literal.
       */
     def apply(x: Boolean): Bool = x.B

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -54,10 +54,6 @@ object BitPat {
     */
   def dontCare(width: Int): BitPat = BitPat("b" + ("?" * width))
 
-  @chiselRuntimeDeprecated
-  @deprecated("Use BitPat.dontCare", "chisel3")
-  def DC(width: Int): BitPat = dontCare(width)  // scalastyle:ignore method.name
-
   /** Allows BitPats to be used where a UInt is expected.
     *
     * @note the BitPat must not have don't care bits (will error out otherwise)
@@ -95,7 +91,7 @@ object BitPat {
 
     final def != (that: BitPat): Bool = macro SourceInfoTransform.thatArg
     @chiselRuntimeDeprecated
-    @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")
+    @deprecated("Use '=/=', which avoids potential precedence problems", "3.0")
     def do_!= (that: BitPat)  // scalastyle:ignore method.name
               (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = that != x
   }
@@ -128,7 +124,7 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) extends Sou
 
   def != (that: UInt): Bool = macro SourceInfoTransform.thatArg
   @chiselRuntimeDeprecated
-  @deprecated("Use '=/=', which avoids potential precedence problems", "chisel3")
+  @deprecated("Use '=/=', which avoids potential precedence problems", "3.0")
   def do_!= (that: UInt)  // scalastyle:ignore method.name
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     this =/= that

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -191,16 +191,6 @@ class Queue[T <: Data](gen: T,
                        flow: Boolean = false)
                       (implicit compileOptions: chisel3.CompileOptions)
     extends Module() {
-  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
-  def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, override_reset: Option[Bool]) = {
-    this(gen, entries, pipe, flow)
-    this.override_reset = override_reset
-  }
-  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
-  def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, _reset: Bool) = {
-    this(gen, entries, pipe, flow)
-    this.override_reset = Some(_reset)
-  }
 
   val genType = if (compileOptions.declaredTypeMustBeUnbound) {
     requireIsChiselType(gen)

--- a/src/main/scala/chisel3/util/Enum.scala
+++ b/src/main/scala/chisel3/util/Enum.scala
@@ -39,12 +39,4 @@ trait Enum {
   def apply(n: Int): List[UInt] = createValues(n).toList
 }
 
-object Enum extends Enum {
-  @chiselRuntimeDeprecated
-  @deprecated("use Enum(n)", "chisel3, will be removed soon")
-  def apply[T <: Bits](nodeType: T, n: Int): List[T] = {
-    require(nodeType.isInstanceOf[UInt], "Only UInt supported for enums")
-    require(!nodeType.widthKnown, "Bit width may no longer be specified for enums")
-    apply(n).asInstanceOf[List[T]]
-  }
-}
+object Enum extends Enum

--- a/src/main/scala/chisel3/util/LFSR.scala
+++ b/src/main/scala/chisel3/util/LFSR.scala
@@ -36,10 +36,10 @@ object LFSR16 {
   @deprecated("Use chisel3.util.random.LFSR(16) for a 16-bit LFSR", "3.2")
   @chiselName
   def apply(increment: Bool = true.B): UInt =
-    Vec( FibonacciLFSR
-          .maxPeriod(16, increment, seed = Some(BigInt(1) << 15))
-          .asBools
-          .reverse )
+    VecInit( FibonacciLFSR
+              .maxPeriod(16, increment, seed = Some(BigInt(1) << 15))
+              .asBools
+              .reverse )
       .asUInt
 
 }


### PR DESCRIPTION
This removes most deprecations `since` before `"3.2"`. Notably `!=` is not removed.

### Deprecations and Compatibility Mode

Anything deprecated that was previously available via compatibility mode (`import Chisel._`) that is removed by this PR is migrated to live inside the compatibility mode.

### Exceptions

The `!=` operator, while deprecated for a long time, is difficult to move into the compatibility mode for reasons elucidated below.

When removing something and adding it to the compatibility mode, there are two approaches:
- Add the removed functionality back in using an `implicit class`
- Define a new type hierarchy inside the compatibility mode

Implicit classes don't work when trying to override methods (and apparently for `!=`). Certain Chisel3 types are `sealed` which limits inheritance as a path to add functionality. Additionally, the hack of moving sealed internal to a `private[chisel3]` trait does not work as the compatibility layer is not under `chisel3`. 

In summary, I think that dealing with `!=` is out of scope of this PR due to it likely requiring some refactoring of the codebase.

### Miscellaneous Updates

- Deprecations since `"chisel3.2"` are changed to since `"3.2"`
- The deprecations on internal core types (e.g., `RawModule`) are clarified to state that these will be removed in `"3.3"` even though they have been deprecated "since the beginning of time".
- The old LFSR was using a deprecated version of `Vec`. This is changed to `VecInit`.

### Todo

- [x] Figure out how to handle deprecations which hit compatibility mode
- [x] Test on Rocket Chip
  - This builds here: https://github.com/chipsalliance/rocket-chip/pull/2056

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Remove most deprecated items since before 3.2