### PR TITLE
Require target is hardware for Vec.apply(a: UInt)

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -216,6 +216,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
 
   /** @group SourceInfoTransformMacro */
   def do_apply(p: UInt)(implicit compileOptions: CompileOptions): T = {
+    requireIsHardware(this, "vec")
     requireIsHardware(p, "vec index")
     val port = gen
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -272,4 +272,15 @@ class VecSpec extends ChiselPropSpec {
       io.out := VecInit(Seq(4.U, 5.U, DontCare, 2.U))
     })
   }
+
+  property("Indexing a Chisel type Vec by a hardware type should give a sane error message") {
+    assertThrows[ExpectedHardwareException] {
+      elaborate{
+        new Module {
+          val io = IO(new Bundle{})
+          val foo = Vec(2, Bool())
+          foo(0.U) := false.B
+        }}
+    }
+  }
 }


### PR DESCRIPTION
Adds a check that a Vec being indexed by a UInt is, in fact, a
hardware type. This includes a test for this.

h/t @schoeberl
cc: @aswaterman 

Consider the following where a Chisel type Vec is indexed by a hardware type:
```scala
  property("Indexing a Chisel type Vec(Vec) should give a sane error message") {
    assertThrows[ExpectedHardwareException] {
      elaborate{
        new Module {
          val io = IO(new Bundle{})
          val foo = Vec(2, Bool())
          foo(0.U) := false.B
        }}
    }
  }
```

On master, this will generate:
```
[info] - Indexing a Chisel type Vec(Vec) should give a sane error message *** FAILED ***
[info]   java.util.NoSuchElementException: None.get
[info]   at scala.None$.get(Option.scala:349)
[info]   at scala.None$.get(Option.scala:347)
[info]   at chisel3.Data.direction(Data.scala:343)
[info]   at chisel3.Vec.do_apply(Aggregate.scala:224)
[info]   at chiselTests.VecSpec$$anon$15.<init>(Vec.scala:281)
[info]   at chiselTests.VecSpec.$anonfun$new$64(Vec.scala:278)
[info]   at chisel3.Module$.do_apply(Module.scala:53)
[info]   at chisel3.Driver$.$anonfun$elaborate$1(Driver.scala:94)
[info]   at chisel3.internal.Builder$.$anonfun$build$2(Builder.scala:352)
[info]   at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
[info]   ...
```

This adds a check that the underlying Vec is a hardware type to prodcue:
```
[info] - Indexing a Chisel type Vec(Vec) should give a sane error message *** FAILED ***
[info]   chisel3.package$ExpectedHardwareException: vec 'Bool[2]' must be hardware, not a bare Chisel type. Perhaps you forgot to wrap it in Wire(_) or IO(_)?
[info]   at chisel3.internal.requireIsHardware$.apply(Binding.scala:20)
[info]   at chisel3.Vec.do_apply(Aggregate.scala:219)
[info]   at chiselTests.VecSpec$$anon$16.<init>(Vec.scala:281)
[info]   at chiselTests.VecSpec.$anonfun$new$64(Vec.scala:278)
[info]   at chisel3.Module$.do_apply(Module.scala:53)
[info]   at chisel3.Driver$.$anonfun$elaborate$1(Driver.scala:94)
[info]   at chisel3.internal.Builder$.$anonfun$build$2(Builder.scala:352)
[info]   at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
[info]   at chisel3.internal.Builder$.$anonfun$build$1(Builder.scala:350)
[info]   at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
[info]   ...
```

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Improved error message if doing UInt indexing on a Chisel Vec