### PR TITLE
java.lang.NullPointerException instead of scala.UnitializedFieldE…

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -22,7 +22,6 @@ object chiselCompileOptions {
     "-feature",
     "-language:reflectiveCalls",
     "-unchecked",
-    "-Xcheckinit",
     "-Xlint:infer-any"
 /*    "-Xlint:missing-interpolator" // this causes a:
 //[error] .../chisel3/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala:605:48: recursive value outer needs type


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

Thanks @seldridge 

```scala
class Foo { val x: Int = 1 }
class Bar { println(child.x); val child = new Foo }
new Bar
```
Run in a repl without and with the `-Xcheckinit` option on, it'll either be a `java.lang.NullPointerException` or a `scala.UnitializedFieldError`.

If using `scala.UnitializedFieldError` ,  Run `mill chisel3.test` will report error as below in `ModuleSpec` 

```
- A desiredName parameterized by a submodule should work
[info] [0.000] Elaborating design...
- A name generating a null pointer exception should provide a good error message *** FAILED ***
  "Uninitialized field:  chisel3/src/test/scala/chiselTests/Module.scala: 75" did not include substring "desiredName of chiselTests.NullModuleWrapper is null" (Module.scala:159)
```
