### PR TITLE
Dependency API (take 2)

### DIFF
--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
@@ -4,12 +4,14 @@ package chisel3.stage.phases
 
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.AnnotationSeq
-import firrtl.options.{OutputAnnotationFileAnnotation, Phase}
+import firrtl.options.{OutputAnnotationFileAnnotation, Phase, PreservesAll}
 
 /** Adds an [[firrtl.options.OutputAnnotationFileAnnotation]] if one does not exist. This replicates old behavior where
   * an output annotation file was always written.
   */
-class AddImplicitOutputAnnotationFile extends Phase {
+class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst{ case _: OutputAnnotationFileAnnotation => annotations }

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
@@ -3,14 +3,16 @@
 package chisel3.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselOutputFileAnnotation}
 
 /** Add a output file for a Chisel circuit, derived from the top module in the circuit, if no
   * [[ChiselOutputFileAnnotation]] already exists.
   */
-class AddImplicitOutputFile extends Phase {
+class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq =
     annotations.collectFirst{ case _: ChiselOutputFileAnnotation  => annotations }.getOrElse{

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -6,12 +6,14 @@ import chisel3.stage.{ChiselOutputFileAnnotation, NoRunFirrtlCompilerAnnotation,
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase}
+import firrtl.options.{OptionsException, Phase, PreservesAll}
 
 /** Sanity checks an [[firrtl.AnnotationSeq]] before running the main [[firrtl.options.Phase]]s of
   * [[chisel3.stage.ChiselStage]].
   */
-class Checks extends Phase {
+class Checks extends Phase with PreservesAll[Phase] {
+
+  override val dependents = Seq(classOf[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val noF, st, outF = collection.mutable.ListBuffer[Annotation]()

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -6,7 +6,7 @@ import chisel3.experimental.RunFirrtlTransform
 import chisel3.internal.firrtl.Converter
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.{AnnotationSeq, Transform}
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 
 /** This prepares a [[ChiselCircuitAnnotation]] for compilation with FIRRTL. This does three things:
@@ -14,7 +14,9 @@ import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
   *   - Extracts all [[firrtl.annotations.Annotation]]s from the [[chisel3.internal.firrtl.Circuit]]
   *   - Generates any needed [[RunFirrtlTransformAnnotation]]s from extracted [[firrtl.annotations.Annotation]]s
   */
-class Convert extends Phase {
+class Convert extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>

--- a/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
@@ -4,12 +4,12 @@ package chisel3.stage.phases
 
 import firrtl.{AnnotationSeq, ExecutionOptionsManager, HasFirrtlOptions}
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{OutputAnnotationFileAnnotation, Phase, PreservesAll}
+import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, Unserializable}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
 
 import chisel3.HasChiselExecutionOptions
-import chisel3.stage.{NoRunFirrtlCompilerAnnotation, ChiselOutputFileAnnotation}
+import chisel3.stage.{ChiselStage, NoRunFirrtlCompilerAnnotation, ChiselOutputFileAnnotation}
 
 /** This provides components of a compatibility wrapper around Chisel's deprecated [[chisel3.Driver]].
   *
@@ -25,9 +25,9 @@ object DriverCompatibility {
     * the correct behavior before a circuit has been elaborated.
     * @note the output suffix is unspecified and will be set by the underlying [[firrtl.EmittedComponent]]
     */
-private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+  private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-    override val dependents = Seq( classOf[firrtl.stage.phases.DriverCompatibility.AddImplicitOutputFile] )
+    override val dependents = Seq(classOf[chisel3.stage.ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
       val hasOutputFile = annotations
@@ -51,6 +51,8 @@ private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Ph
     */
   private[chisel3] class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
 
+    override val dependents = Seq(classOf[chisel3.stage.ChiselStage])
+
     def transform(annotations: AnnotationSeq): AnnotationSeq =
       annotations
         .collectFirst{ case _: OutputAnnotationFileAnnotation => annotations }
@@ -71,14 +73,18 @@ private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Ph
     * situations where you need to do something between Chisel compilation and FIRRTL compilations, e.g., update a
     * mutable data structure.
     */
-  private[chisel3] class DisableFirrtlStage extends Phase {
+  private[chisel3] class DisableFirrtlStage extends Phase with PreservesAll[Phase] {
+
+    override val dependents = Seq(classOf[ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst { case NoRunFirrtlCompilerAnnotation => annotations                              }
       .getOrElse    { Seq(RunFirrtlCompilerAnnotation, NoRunFirrtlCompilerAnnotation) ++ annotations }
   }
 
-  private[chisel3] class ReEnableFirrtlStage extends Phase {
+  private[chisel3] class ReEnableFirrtlStage extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq(classOf[DisableFirrtlStage], classOf[ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst { case RunFirrtlCompilerAnnotation =>
@@ -92,14 +98,26 @@ private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Ph
 
   }
 
+  private[chisel3] case class OptionsManagerAnnotation(
+    manager: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions)
+      extends NoTargetAnnotation with Unserializable
+
   /** Mutate an input [[firrtl.ExecutionOptionsManager]] based on information encoded in an [[firrtl.AnnotationSeq]].
     * This is intended to be run between [[chisel3.stage.ChiselStage ChiselStage]] and [[firrtl.stage.FirrtlStage]] if
     * you want to have backwards compatibility with an [[firrtl.ExecutionOptionsManager]].
     */
-  private[chisel3] class MutateOptionsManager(
-    optionsManager: ExecutionOptionsManager with HasChiselExecutionOptions with HasFirrtlOptions) extends Phase {
+  private[chisel3] class MutateOptionsManager extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq(classOf[chisel3.stage.ChiselStage])
+
+    override val dependents = Seq(classOf[ReEnableFirrtlStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
+
+      val optionsManager = annotations
+        .collectFirst{ case OptionsManagerAnnotation(a) => a }
+        .getOrElse{ throw new OptionsException(
+                     "An OptionsManagerException must exist for Chisel Driver compatibility mode") }
 
       val firrtlCircuit = annotations.collectFirst{ case FirrtlCircuitAnnotation(a) => a }
       optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
@@ -111,6 +129,25 @@ private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Ph
       annotations
 
     }
+
+  }
+
+  /** A [[Phase]] that lets us run
+    * @todo a better solution than the current state hack below may be needed
+    */
+  private [chisel3] class FirrtlPreprocessing extends Phase with PreservesAll[Phase] {
+
+    override val prerequisites = Seq(classOf[ChiselStage], classOf[MutateOptionsManager], classOf[ReEnableFirrtlStage])
+
+    override val dependents = Seq(classOf[MaybeFirrtlStage])
+
+    private val phases =
+      Seq( new firrtl.stage.phases.DriverCompatibility.AddImplicitOutputFile,
+           new firrtl.stage.phases.DriverCompatibility.AddImplicitEmitter )
+
+    override def transform(annotations: AnnotationSeq): AnnotationSeq =
+      phases
+        .foldLeft(annotations)( (a, p) => p.transform(a) )
 
   }
 

--- a/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
@@ -4,7 +4,7 @@ package chisel3.stage.phases
 
 import firrtl.{AnnotationSeq, ExecutionOptionsManager, HasFirrtlOptions}
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{OutputAnnotationFileAnnotation, Phase}
+import firrtl.options.{OutputAnnotationFileAnnotation, Phase, PreservesAll}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
 
@@ -25,7 +25,9 @@ object DriverCompatibility {
     * the correct behavior before a circuit has been elaborated.
     * @note the output suffix is unspecified and will be set by the underlying [[firrtl.EmittedComponent]]
     */
-  private[chisel3] class AddImplicitOutputFile extends Phase {
+private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+
+    override val dependents = Seq( classOf[firrtl.stage.phases.DriverCompatibility.AddImplicitOutputFile] )
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
       val hasOutputFile = annotations
@@ -47,7 +49,7 @@ object DriverCompatibility {
     * correct behavior before a circuit has been elaborated.
     * @note the output suffix is unspecified and will be set by [[firrtl.options.phases.WriteOutputAnnotations]]
     */
-  private[chisel3] class AddImplicitOutputAnnotationFile extends Phase {
+  private[chisel3] class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
 
     def transform(annotations: AnnotationSeq): AnnotationSeq =
       annotations

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -9,11 +9,11 @@ import chisel3.internal.ErrorLog
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselOptions}
 import firrtl.AnnotationSeq
 import firrtl.options.Viewer.view
-import firrtl.options.{OptionsException, Phase}
+import firrtl.options.{OptionsException, Phase, PreservesAll}
 
 /** Elaborate all [[chisel3.stage.ChiselGeneratorAnnotation]]s into [[chisel3.stage.ChiselCircuitAnnotation]]s.
   */
-class Elaborate extends Phase {
+class Elaborate extends Phase with PreservesAll[Phase] {
 
   /**
     * @todo Change this to print to STDERR (`Console.err.println`)

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -24,6 +24,17 @@ import java.io.{File, FileWriter}
   */
 class Emitter extends Phase {
 
+  override val prerequisites =
+    Seq( classOf[Elaborate],
+         classOf[AddImplicitOutputFile],
+         classOf[AddImplicitOutputAnnotationFile],
+         classOf[MaybeAspectPhase] )
+
+  override def invalidates(phase: Phase): Boolean = phase match {
+    case _: Elaborate => true
+    case _ => false
+  }
+
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val copts = view[ChiselOptions](annotations)
     val sopts = view[StageOptions](annotations)

--- a/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
@@ -4,11 +4,13 @@ package chisel3.stage.phases
 
 import chisel3.aop.Aspect
 import firrtl.AnnotationSeq
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 
 /** Run [[AspectPhase]] if a [[chisel3.aop.Aspect]] is present.
   */
-class MaybeAspectPhase extends Phase {
+class MaybeAspectPhase extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     if(annotations.collectFirst { case a: Aspect[_] => annotations }.isDefined) {

--- a/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
@@ -5,12 +5,14 @@ package chisel3.stage.phases
 import chisel3.stage.NoRunFirrtlCompilerAnnotation
 
 import firrtl.AnnotationSeq
-import firrtl.options.Phase
+import firrtl.options.{Phase, PreservesAll}
 import firrtl.stage.FirrtlStage
 
 /** Run [[firrtl.stage.FirrtlStage]] if a [[chisel3.stage.NoRunFirrtlCompilerAnnotation]] is not present.
   */
-class MaybeFirrtlStage extends Phase {
+class MaybeFirrtlStage extends Phase with PreservesAll[Phase] {
+
+  override val prerequisites = Seq(classOf[Convert])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst { case NoRunFirrtlCompilerAnnotation => annotations }


### PR DESCRIPTION
This uses the new `firrtl.options` Dependency API to determine a valid `Phase` ordering instead of statically encoding one. This supersedes #1080.

This primarily consists of:
- Adding prerequisites and dependencies to every `Phase`
- Defining `ChiselStage` to use a `PhaseManager` internally
- Defining `Driver` to user a `PhaseManager` internally

Note: this PR is very explicit in terms of targets. You can get away with being more terse, but after going through this with FIRRTL, it seems that it's clearer to define all the `targets` you want to run as opposed to hiding the targets from the user.

While support does not yet exist for this, it should be trivial to start thinking about a `RunChiselPhaseAnnotation` that is injected into `ChiselStage`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
