### PR TITLE
Switch to new API links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [**Chisel**](https://www.chisel-lang.org) is a hardware design language that facilitates **advanced circuit generation and design reuse for both ASIC and FPGA digital logic designs**.
 Chisel adds hardware construction primitives to the [Scala](https://www.scala-lang.org) programming language, providing designers with the power of a modern programming language to write complex, parameterizable circuit generators that produce synthesizable Verilog.
-This generator methodology enables the creation of re-usable components and libraries, such as the FIFO queue and arbiters in the [Chisel Standard Library](https://www.chisel-lang.org/api/chisel3/latest/chisel3/util/index.html), raising the level of abstraction in design while retaining fine-grained control. 
+This generator methodology enables the creation of re-usable components and libraries, such as the FIFO queue and arbiters in the [Chisel Standard Library](https://www.chisel-lang.org/api/latest/chisel3/util/index.html), raising the level of abstraction in design while retaining fine-grained control.
 
 For more information on the benefits of Chisel see: ["What benefits does Chisel offer over classic Hardware Description Languages?"](https://stackoverflow.com/questions/53007782/what-benefits-does-chisel-offer-over-classic-hardware-description-languages)
 
@@ -103,7 +103,7 @@ These simulation-based verification tools are available for Chisel:
 
 - [**Cheat Sheet**](https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf), a 2-page reference of the base Chisel syntax and libraries
 - [**Wiki**](https://github.com/freechipsproject/chisel3/wiki), which contains various feature-specific tutorials and frequently-asked questions.
-- [**ScalaDoc**](https://www.chisel-lang.org/api/chisel3/latest/chisel3/index.html), a listing, description, and examples of the functionality exposed by Chisel   
+- [**ScalaDoc**](https://www.chisel-lang.org/api/latest/chisel3/index.html), a listing, description, and examples of the functionality exposed by Chisel
 - [**Gitter**](https://gitter.im/freechipsproject/chisel3), where you can ask questions or discuss anything Chisel
 - [**Website**](https://www.chisel-lang.org)
 


### PR DESCRIPTION
I changed the API directory structure to match the old chisel.eecs.berkeley.edu layout (to avoid breaking existing links and search engine results). This, however, re-breaks the API links in the chisel3 README.

This PR corrects the two API links in the README.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: documentation | other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
