### PR TITLE
Internal BoringUtils.bore Bug Fix

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -181,8 +181,14 @@ object BoringUtils {
     * component
     */
   def bore(source: Data, sinks: Seq[Data]): String = {
-    lazy val genName = addSource(source, source.instanceName, true, true)
+    val boringName = try {
+      source.instanceName
+    } catch {
+      case _: Exception => "bore"
+    }
+    val genName = addSource(source, boringName, true, true)
     sinks.map(addSink(_, genName, true, true))
     genName
   }
+
 }

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -106,4 +106,21 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners {
       .getMessage should startWith ("Unable to determine source mapping for sink")
   }
 
+  class InternalBore extends RawModule {
+    val in = IO(Input(Bool()))
+    val out = IO(Output(Bool()))
+    out := false.B
+    BoringUtils.bore(in, Seq(out))
+  }
+
+  class InternalBoreTester extends ShouldntAssertTester {
+    val dut = Module(new InternalBore)
+    dut.in := true.B
+    chisel3.assert(dut.out === true.B)
+  }
+
+  it should "work for an internal (same module) BoringUtils.bore" in {
+    runTester(new InternalBoreTester) should be (true)
+  }
+
 }


### PR DESCRIPTION
This fixes a bug introduced in the original `BoringUtils.bore` implementation. This was using `instanceName` which meant that it could only be used for closed modules. The user-facing impact of this is an exception if you use `BoringUtils.bore` for signals in the module in which you do the bore (because that module is not closed). This adds one small test for this case.

This PR will introduce worse Verilog naming for boring signals using `BoringUtils.bore`.

Fixes #1212.

<!-- choose one -->
**Type of change**: bug report | other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Bugfix for BoringUtils.bore with signals in the same module