### PR TITLE
Fix Queue.apply for size 0 in chisel3._ code

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -277,7 +277,7 @@ object Queue
       pipe: Boolean = false,
       flow: Boolean = false): DecoupledIO[T] = {
     if (entries == 0) {
-      val deq = Wire(new DecoupledIO(enq.bits))
+      val deq = Wire(new DecoupledIO(chiselTypeOf(enq.bits)))
       deq.valid := enq.valid
       deq.bits := enq.bits
       enq.ready := deq.ready

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -97,6 +97,7 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
       val dcd = Wire(Decoupled(data))
       dcd shouldBe a [DecoupledIO[UInt]]
       Queue(dcd) shouldBe a [DecoupledIO[UInt]]
+      Queue(dcd, 0) shouldBe a [DecoupledIO[UInt]]
       Enum(UInt(), 2) shouldBe a [List[UInt]]
       ListLookup(wire, List(wire), Array((BitPat("b1"), List(wire)))) shouldBe a [List[UInt]]
       Lookup(wire, wire, Seq((BitPat("b1"), wire))) shouldBe a [UInt]


### PR DESCRIPTION
Incredibly, this didn't work (in `import chisel3.`) and may never have worked.

This really ought to go in to 3.2

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
