### PR TITLE
Use masked litOption comparisons to detect exhaustive MuxLookup

### DIFF
--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -65,8 +65,10 @@ object MuxLookup {
   def apply[S <: UInt, T <: Data] (key: S, default: T, mapping: Seq[(S, T)]): T = {
     /* If the mapping is defined for all possible values of the key, then don't use the default value */
     val (defaultx, mappingx) = try {
-      val k = mapping.map(_._1)
-      if ((math.pow(2, key.getWidth) == k.size) && (k.distinct.size == k.size)) {
+      val keySetSize = BigInt(1) << key.getWidth
+      val keyMask = keySetSize - 1
+      val distinctLitKeys = mapping.flatMap(_._1.litOption).map(_ & keyMask).distinct
+      if (distinctLitKeys.size == keySetSize) {
         (mapping.head._2, mapping.tail)
       } else {
         (default, mapping)

--- a/src/test/scala/chiselTests/MuxSpec.scala
+++ b/src/test/scala/chiselTests/MuxSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.util.{MuxLookup, log2Ceil}
 import chisel3.testers.BasicTester
 
 class MuxTester extends BasicTester {
@@ -24,4 +25,38 @@ class MuxSpec extends ChiselFlatSpec {
   "Mux" should "pass basic checks" in {
     assertTesterPasses { new MuxTester }
   }
+}
+
+class MuxLookupWrapper(keyWidth: Int, default: Int, mapping: () => Seq[(UInt, UInt)]) extends RawModule {
+  val outputWidth = log2Ceil(default).max(keyWidth) // make room for default value
+  val key = IO(Input(UInt(keyWidth.W)))
+  val output = IO(Output(UInt(outputWidth.W)))
+  output := MuxLookup(key, default.U, mapping())
+}
+
+class MuxLookupExhaustiveSpec extends ChiselPropSpec {
+  val keyWidth = 2
+  val default = 9 // must be less than 10 to avoid hex/decimal mismatches
+
+  // Assumes there are no temps with '9' in the name -> fails conservatively
+  // Assumes no binary recoding in output
+
+  val incomplete = { () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U) }
+  property("The default value should not be optimized away for an incomplete MuxLookup") {
+    val c = Driver.emit { () => new MuxLookupWrapper(keyWidth, default, incomplete) }
+    c.contains(default.toString) should be (true) // not optimized away
+  }
+
+  val exhaustive = { () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U, 3.U -> 0.U) }
+  property("The default value should be optimized away for an exhaustive MuxLookup") {
+    val c = Driver.emit { () => new MuxLookupWrapper(keyWidth, default, exhaustive) }
+    c.contains(default.toString) should be (false) // optimized away
+  }
+
+  val overlap = { () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U, 4096.U -> 0.U) }
+  property("The default value should be optimized away for a MuxLookup with 2^{keyWidth} non-distinct mappings") {
+    val c = Driver.emit { () => new MuxLookupWrapper(keyWidth, default, overlap) }
+    c.contains(default.toString) should be (true) // not optimized away
+  }
+
 }


### PR DESCRIPTION
@seldridge, this shows what I was talking about with the `0.U` vs `4096.U` and the false "full case" detection.

Fortunately, we don't have to deal with sometimes-negative `SInt` mapping keys :)