### PR TITLE
Add ChiselEnum to BundleLiterals

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -8,6 +8,7 @@ import scala.language.experimental.macros
 
 import chisel3.experimental.BaseModule
 import chisel3.experimental.BundleLiteralException
+import chisel3.experimental.EnumType
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._
@@ -550,6 +551,15 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
           value.topBinding.asInstanceOf[BundleLitBinding].litMap.map { case (valueField, valueValue) =>
             remap(valueField) -> valueValue
           }
+        case field: EnumType => {
+          if (!(field typeEquivalent value)) {
+            throw new BundleLiteralException(s"field $fieldName $field specified with non-type-equivalent enum value $value")
+          }
+          val litArg = valueBinding match {
+            case ElementLitBinding(litArg) => litArg
+          }
+          Seq(field -> litArg)
+        }
         case _ => throw new BundleLiteralException(s"unsupported field $fieldName of type $field")
       }
     }  // don't convert to a Map yet to preserve duplicate keys


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1214 <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This PR enables the use of EnumType in BundleLiterals. For example, the following code should work:
```scala
object ENUM extends ChiselEnum {
  val a, b, c = Value
}
class t extends Bundle {
  val a = ENUM()
}
class tIO extends Bundle {
  val a = Output(new t())
}
class TestModule extends Module {
  val io = IO(new tIO())

  io.a := (new t).Lit(_.a -> ENUM.b)
}
```
