### PR TITLE
Make ChiselStage targets not private

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -16,7 +16,7 @@ import java.io.{StringWriter, PrintWriter}
 class ChiselStage extends Stage with PreservesAll[Phase] {
   val shell: Shell = new Shell("chisel") with ChiselCli with FirrtlCli
 
-  private val targets =
+  val targets =
     Seq( classOf[chisel3.stage.phases.Checks],
          classOf[chisel3.stage.phases.Elaborate],
          classOf[chisel3.stage.phases.AddImplicitOutputFile],


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This enables users to use the nice run method of `ChiselStage` with their own set of phases.
