### PR TITLE
Improve naming of anonymous/class-in-function Modules

### DIFF
--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -158,4 +158,19 @@ class ModuleSpec extends ChiselPropSpec {
     (the [Exception] thrownBy (Driver.elaborate(() => new NullModuleWrapper)))
       .getMessage should include ("desiredName of chiselTests.NullModuleWrapper is null")
   }
+  property("The name of a module in a function should be sane") {
+    def foo = {
+      class Foo1 extends RawModule {
+        assert(name == "Foo1")
+      }
+      new Foo1
+    }
+    Driver.elaborate(() => foo)
+  }
+  property("The name of an anonymous module should include '_Anon'") {
+    trait Foo { this: RawModule =>
+      assert(name.contains("_Anon"))
+    }
+    Driver.elaborate(() => new RawModule with Foo)
+  }
 }


### PR DESCRIPTION
This provides a fix for #1223 where modules that are either anonymous or defined in function bodies now produce non-purely-numeric names.

This is an amalgamation of a fix proposed by @aswaterman (which actually is necessary to fix classes in modules) and the use of an `_Anon` prefix for anonymous modules.

This includes tests and more documentation for `desiredName`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #1223 

<!-- choose one -->
**Type of change**: bug report | documentation

<!-- choose one -->
**Impact**: No functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Better naming of anonymous modules and modules defined in functions