### PR TITLE
Support literals cast to aggregates as async reset reg init values

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -65,7 +65,7 @@ sealed abstract class Aggregate extends Data {
   private[chisel3] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
     var i = 0
-    val bits = WireDefault(UInt(this.width), that)  // handles width padding
+    val bits = if (that.isLit) that else WireDefault(UInt(this.width), that) // handles width padding
     for (x <- flatten) {
       val fieldWidth = x.getWidth
       if (fieldWidth > 0) {

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -169,4 +169,34 @@ class AsyncResetSpec extends ChiselFlatSpec {
     assertTesterPasses(new AsyncResetQueueTester)
   }
 
+  it should "allow literals cast to Aggregates as reset values" in {
+    class MyBundle extends Bundle {
+      val x = UInt(16.W)
+      val y = UInt(16.W)
+    }
+    assertTesterPasses(new BasicTester {
+      val reg = withReset(reset.asAsyncReset) {
+        RegNext(0xbad0cad0L.U.asTypeOf(new MyBundle), 0xdeadbeefL.U.asTypeOf(new MyBundle))
+      }
+      val (count, done) = Counter(true.B, 4)
+      when (count === 0.U) {
+        chisel3.assert(reg.asUInt === 0xdeadbeefL.U)
+      } .otherwise {
+        chisel3.assert(reg.asUInt === 0xbad0cad0L.U)
+      }
+      when (done) { stop() }
+    })
+    assertTesterPasses(new BasicTester {
+      val reg = withReset(reset.asAsyncReset) {
+        RegNext(0xbad0cad0L.U.asTypeOf(Vec(4, UInt(8.W))), 0xdeadbeefL.U.asTypeOf(Vec(4, UInt(8.W))))
+      }
+      val (count, done) = Counter(true.B, 4)
+      when (count === 0.U) {
+        chisel3.assert(reg.asUInt === 0xdeadbeefL.U)
+      } .otherwise {
+        chisel3.assert(reg.asUInt === 0xbad0cad0L.U)
+      }
+      when (done) { stop() }
+    })
+  }
 }

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -169,7 +169,7 @@ class AsyncResetSpec extends ChiselFlatSpec {
     assertTesterPasses(new AsyncResetQueueTester)
   }
 
-  it should "allow literals cast to Aggregates as reset values" in {
+  it should "allow literals cast to Bundles as reset values" in {
     class MyBundle extends Bundle {
       val x = UInt(16.W)
       val y = UInt(16.W)
@@ -186,6 +186,8 @@ class AsyncResetSpec extends ChiselFlatSpec {
       }
       when (done) { stop() }
     })
+  }
+  it should "allow literals cast to Vecs as reset values" in {
     assertTesterPasses(new BasicTester {
       val reg = withReset(reset.asAsyncReset) {
         RegNext(0xbad0cad0L.U.asTypeOf(Vec(4, UInt(8.W))), 0xdeadbeefL.U.asTypeOf(Vec(4, UInt(8.W))))


### PR DESCRIPTION
Accomplished by changing the code gen for casting literals to
aggregates. Rather than connecting the literal to a wire that is then
bit selected from, just bit select from the literal which saves the
creation of an intermediate wire and matches FIRRTL's semantics for
legal async reset initial values.

Turned out to be a very clean implementation, most work (as usual) in the testing.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/firrtl/pull/1201

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition? (only in that it fixes a bug)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Fix bug where literals cast to aggregates could not be used as async reset register initial values.
