### PR TITLE
Bump for 3.2-20191106-SNAPSHOT.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
-val defaultVersions = Map("firrtl" -> "1.2-20191030-SNAPSHOT")
+val defaultVersions = Map("firrtl" -> "1.2-20191106-SNAPSHOT")
 
 lazy val commonSettings = Seq (
   resolvers ++= Seq(
@@ -36,7 +36,7 @@ lazy val commonSettings = Seq (
     Resolver.sonatypeRepo("releases")
   ),
   organization := "edu.berkeley.cs",
-  version := "3.2-20191030-SNAPSHOT",
+  version := "3.2-20191106-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.12.10",
   crossScalaVersions := Seq("2.12.10", "2.11.12"),

--- a/build.sc
+++ b/build.sc
@@ -35,7 +35,7 @@ object chiselCompileOptions {
 val crossVersions = Seq("2.12.10", "2.11.12")
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Map("firrtl" -> "1.2-20191030-SNAPSHOT")
+val defaultVersions = Map("firrtl" -> "1.2-20191106-SNAPSHOT")
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
   val version = sys.env.getOrElse(dep + "Version", defaultVersions(dep))
@@ -67,7 +67,7 @@ trait CommonChiselModule extends SbtModule {
 
 trait PublishChiselModule extends CommonChiselModule with PublishModule {
   override def artifactName = "chisel3"
-  def publishVersion = "3.2-20191030-SNAPSHOT"
+  def publishVersion = "3.2-20191106-SNAPSHOT"
 
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Bump version for 3.2-20191106-SNAPSHOT