### PR TITLE
Recursively suggests names to supported Map

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -371,11 +371,14 @@ private[chisel3] object Builder {
   /** Recursively suggests names to supported "container" classes
     * Arbitrary nestings of supported classes are allowed so long as the
     * innermost element is of type HasId
-    * (Note: Map is Iterable[Tuple2[_,_]] and thus excluded)
     */
   def nameRecursively(prefix: String, nameMe: Any, namer: (HasId, String) => Unit): Unit = nameMe match {
     case (id: HasId) => namer(id, prefix)
     case Some(elt) => nameRecursively(prefix, elt, namer)
+    case m: Map[_, _] =>
+      m foreach { case (k, v) =>
+        nameRecursively(s"${k}", v, namer)
+      }
     case (iter: Iterable[_]) if iter.hasDefiniteSize =>
       for ((elt, i) <- iter.zipWithIndex) {
         nameRecursively(s"${prefix}_${i}", elt, namer)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Support declare base data types by using `Map[String, Data]` . Suggested Name as key, the `Data` type as value. It allows automatic generation by reading some configure files to get name strings.

```scala
class Mux2 extends RawModule {
  val io = Map(
    "sel" -> IO(Input(UInt(1.W))),
    "in0" -> IO(Input(UInt(1.W))),
    "in1" -> IO(Input(UInt(1.W))),
    "out" -> IO(Output(UInt(1.W))),
  )
  val inner = Map(
    "sel_in0" -> (io("sel" )& io("in1")),
    "sel_in1" -> (~io("sel") & io("in0")),
  )
  io("out" ):= inner("sel_in0") | inner("sel_in1")
}
```
```verilog
module Mux2(
  input   sel,
  input   in0,
  input   in1,
  output  out
);
  wire  sel_in0; // @[Mux.scala 12:29]
  wire  _T; // @[Mux.scala 13:19]
  wire  sel_in1; // @[Mux.scala 13:30]
  assign sel_in0 = sel & in1; // @[Mux.scala 12:29]
  assign _T = ~ sel; // @[Mux.scala 13:19]
  assign sel_in1 = _T & in0; // @[Mux.scala 13:30]
  assign out = sel_in0 | sel_in1; // @[Mux.scala 15:13]
endmodule
```
