### PR TITLE
Remove over design

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -18,7 +18,7 @@ private[chisel3] class Namespace(keywords: Set[String]) {
     names(keyword) = 1
 
   private def rename(n: String): String = {
-    val index = names.getOrElse(n, 1L)
+    val index = names(n)
     val tryName = s"${n}_${index}"
     names(n) = index + 1
     if (this contains tryName) rename(n) else tryName


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional changemodification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

 `rename` is private, and it only is called when  `names` contains new name string in method `def name` . Thus no need to use `getOrElse`

```scala
if (this contains sanitized) {
      name(rename(sanitized))
}
``` 
