### PR TITLE
Fix mergify to backports: omit jenkins CI

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -51,16 +51,12 @@ pull_request_rules:
 
   - name: automatic squash-and-merge of backport PRs
     conditions:
-      - status-success=1 - compile
-      - status-success=2 - checkstyle
-      - status-success=2 - test
       - "status-success=ci/circleci: build-firrtl"
       - "status-success=ci/circleci: build-prep"
       - "status-success=ci/circleci: checkstyle-chisel"
       - "status-success=ci/circleci: test-chisel-2_11"
       - "status-success=ci/circleci: test-chisel-2_12"
       - status-success=license/cla
-      - status-success=pull request checks
       - "#changes-requested-reviews-by=0"
       - base=3.2.x
       - label="Backport"


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Bugfix mergify, because jenkins builds are not run on backport branches
