### PR TITLE
Fix bidirectional Wire with Analog

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/experimental/Analog.scala
+++ b/chiselFrontend/src/main/scala/chisel3/experimental/Analog.scala
@@ -57,10 +57,8 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
       case SampleElementBinding(parent) => parent.topBinding
     }
 
-    // Analog counts as different directions based on binding context
     targetTopBinding match {
-      case WireBinding(_) => direction = ActualDirection.Unspecified  // internal wire
-      case PortBinding(_) => direction = ActualDirection.Bidirectional(ActualDirection.Default)
+      case _: WireBinding | _: PortBinding => direction = ActualDirection.Bidirectional(ActualDirection.Default)
       case x => throwException(s"Analog can only be Ports and Wires, not '$x'")
     }
     binding = target

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -194,6 +194,27 @@ class AnalogSpec extends ChiselFlatSpec {
     })
   }
 
+  it should "work in bidirectional Aggregate wires" in {
+    class MyBundle extends Bundle {
+      val x = Input(UInt(8.W))
+      val y = Analog(8.W)
+    }
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val a = new MyBundle
+      })
+      val w = Wire(new MyBundle)
+      w <> io.a
+    })
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val a = Vec(1, new MyBundle)
+      })
+      val w = Wire(Vec(1, new MyBundle))
+      w <> io.a
+    })
+  }
+
   it should "work with 3 blackboxes attached" in {
     assertTesterPasses(new AnalogTester {
       val mods = Seq.fill(2)(Module(new AnalogReaderBlackBox))


### PR DESCRIPTION
For direction purposes, Analogs were treated differently in IOs vs. in Wires. This difference was added in https://github.com/freechipsproject/chisel3/pull/617, specifically commit https://github.com/freechipsproject/chisel3/commit/f4a1c40fa147924087065bf7024038cc465b95ae, but I am unable to ascertain why. @ducky64 as a reviewer in case he has insight.

The motivating reason for fixing this is that `BundleBridge` in rocket-chip materializes the tunneled Bundle via a Wire in the destination module. Currently, you cannot have BundleBridges with any mix of Analog and non-Analog components. This fixes that issue.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Support bidirectional Aggregate Wires with Analog 
