### PR TITLE
Fix deprecation warning that leaks into user code

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Data.scala
@@ -493,7 +493,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc { // sc
     case _ => None
   }
 
-  def isLit(): Boolean = litArg.isDefined
+  def isLit(): Boolean = litOption.isDefined
 
   /**
    * If this is a literal that is representable as bits, returns the value as a BigInt.


### PR DESCRIPTION
Data.isLit called Data.litArg which would trigger a Chisel runtime
deprecation warning in user code with source locator Data.scala:488

As reported in https://stackoverflow.com/questions/59049673/how-to-initialize-a-reg-of-bundle-in-chisel/59058082?noredirect=1#comment104418728_59058082

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Fix internal deprecation warning on Data.isLit that leaked into user code