### PR TITLE
Use macro to materialize CompileOptions in Chisel._ (bp #1253)

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -9,11 +9,16 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
   import chisel3.internal.firrtl.Width
 
   import scala.language.experimental.macros
-  import scala.annotation.StaticAnnotation
-  import scala.annotation.compileTimeOnly
+  import scala.reflect.macros.blackbox.Context
+  import scala.annotation.{StaticAnnotation, compileTimeOnly}
   import scala.language.implicitConversions
 
-  implicit val defaultCompileOptions = chisel3.ExplicitCompileOptions.NotStrict
+
+  /** Default NotStrict CompileOptions for compatibility code
+    *
+    * No longer implicit, materialization macro below provides a low-priority default
+    */
+  val defaultCompileOptions = chisel3.ExplicitCompileOptions.NotStrict
 
   abstract class Direction
   case object INPUT extends Direction
@@ -584,6 +589,16 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
   val Pipe = chisel3.util.Pipe
   type Pipe[T <: Data] = chisel3.util.Pipe[T]
 
+  /** Provides a low priority NotStrict default. Can be overridden by providing a custom implicit
+    *   val in lexical scope (ie. imported)
+    * Implemented as a macro to provide a low-priority default
+    */
+  implicit def materializeCompileOptions: CompileOptions = macro materializeCompileOptions_impl
+
+  def materializeCompileOptions_impl(c: Context): c.Tree = {
+    import c.universe._
+    q"_root_.chisel3.ExplicitCompileOptions.NotStrict"
+  }
 
   /** Package for experimental features, which may have their API changed, be removed, etc.
     *

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -118,6 +118,19 @@ class CompatibiltySpec extends ChiselFlatSpec with GeneratorDrivenPropertyChecks
     }
     elaborate { new Dummy }
   }
+
+  it should "be able to provide custom CompileOptions" in {
+    implicit val CustomCompileOptions = chisel3.ExplicitCompileOptions.NotStrict.copy(inferModuleReset = true)
+    // Top-level Module always uses Bool so needs to be an inner Module
+    elaborate(new Module {
+      val io = IO(new Bundle {})
+      val inst = Module(new Module {
+        val io = IO(new Bundle {})
+        assert(reset.isInstanceOf[chisel3.ResetType])
+      })
+    })
+  }
+
   // Verify we can elaborate a design expressed in Chisel2
   class Chisel2CompatibleRisc extends Module {
     val io = new Bundle {


### PR DESCRIPTION
This is a manual backport of pull request https://github.com/freechipsproject/chisel3/pull/1253 excluding the deprecation of `Chisel.defaultCompileOptions`.

This switches from using an implicit val that required awkward
suppression (as illustrated in CompileOptionsSpec) to allowing
overriding in the same way as done in "import chisel3._" via the
creation of an implicit val in lexical scope.