### PR TITLE
Fix asTypeOf for Clock

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Clock.scala
@@ -33,6 +33,6 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   override def do_asUInt(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref)) // scalastyle:ignore line.size.limit
   private[chisel3] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
-    this := that
+    this := that.asBool.asClock
   }
 }

--- a/src/test/scala/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala/chiselTests/AsTypeOfTester.scala
@@ -70,6 +70,17 @@ class ResetAsTypeOfBoolTester extends BasicTester {
   stop()
 }
 
+class AsTypeOfClockTester extends BasicTester {
+  class MyBundle extends Bundle {
+    val x = UInt(4.W)
+    val y = Clock()
+  }
+  assert(true.B.asTypeOf(Clock()).asUInt.asBool === true.B)
+
+  assert(0x1f.U.asTypeOf(new MyBundle).asUInt === 0x1f.U)
+  stop()
+}
+
 class AsChiselEnumTester extends BasicTester {
   object MyEnum extends ChiselEnum {
     val foo, bar = Value
@@ -136,5 +147,9 @@ class AsTypeOfSpec extends ChiselFlatSpec {
 
   it should "work for casting to and from ChiselEnums" in {
     assertTesterPasses(new AsChiselEnumTester)
+  }
+
+  it should "work for casting to and from Clock" in {
+    assertTesterPasses(new AsTypeOfClockTester)
   }
 }


### PR DESCRIPTION
See the test. Currently, you cannot cast via `.asTypeOf` to a `Clock`. You can legally cast from a `Bool` to a `Clock` via `.asClock`, but when you have `Aggregate`s with `Clock` members, you would like `.asTypeOf` to work. This isn't common because it's generally unsafe, but it's reasonable to do in testbench code and obviously our casting should be consistent.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Support Clock in `asTypeOf` casting
