### PR TITLE
Adds a .scalafmt.conf to the repo.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,20 @@
+maxColumn = 120
+align = most
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+docstrings = ScalaDoc
+lineEndings = preserve
+includeCurlyBraceInSelectChains = false
+danglingParentheses = true
+
+align.tokens.add = [
+  {
+    code = ":"
+  }
+]
+
+newlines.alwaysBeforeCurlyBraceLambdaParams  = false
+
+optIn.annotationNewlines = true
+
+rewrite.rules = [SortImports, PreferCurlyFors, AvoidInfix]


### PR DESCRIPTION
This is the agreed upon starting point for moving
out code to a standard

**Type of change**: code quality enhancement

**Impact**: no functional change

**Development Phase**: proposal
new code blocks and files should be processed by the formatter. General formatting
all files will be done by attrition or in total once the PR list is at a smaller and more manageable size, as code formatting can create conflicts in existing PRs

**Release Notes**
A format file .scalafmt.conf is now part of the chisel3 repo. Please consider adding this to you own chisel repos
