### PR TITLE
Migrate to Dependency Wrapper

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -5,7 +5,7 @@ package chisel3
 import chisel3.internal.ErrorLog
 import internal.firrtl._
 import firrtl._
-import firrtl.options.{Phase, PhaseManager, StageError}
+import firrtl.options.{Dependency, Phase, PhaseManager, StageError}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.options.Viewer.view
 import firrtl.annotations.JsonProtocol
@@ -207,16 +207,16 @@ object Driver extends BackendCompilationUtilities {
         optionsManager.commonOptions.toAnnotations
 
     val targets =
-      Seq( classOf[DriverCompatibility.AddImplicitOutputFile],
-           classOf[DriverCompatibility.AddImplicitOutputAnnotationFile],
-           classOf[DriverCompatibility.DisableFirrtlStage],
-           classOf[ChiselStage],
-           classOf[DriverCompatibility.MutateOptionsManager],
-           classOf[DriverCompatibility.ReEnableFirrtlStage],
-           classOf[DriverCompatibility.FirrtlPreprocessing],
-           classOf[chisel3.stage.phases.MaybeFirrtlStage] )
+      Seq( Dependency[DriverCompatibility.AddImplicitOutputFile],
+           Dependency[DriverCompatibility.AddImplicitOutputAnnotationFile],
+           Dependency[DriverCompatibility.DisableFirrtlStage],
+           Dependency[ChiselStage],
+           Dependency[DriverCompatibility.MutateOptionsManager],
+           Dependency[DriverCompatibility.ReEnableFirrtlStage],
+           Dependency[DriverCompatibility.FirrtlPreprocessing],
+           Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
     val currentState =
-      Seq( classOf[firrtl.stage.phases.DriverCompatibility.AddImplicitFirrtlFile] )
+      Seq( Dependency[firrtl.stage.phases.DriverCompatibility.AddImplicitFirrtlFile] )
 
     val phases: Seq[Phase] = new PhaseManager(targets, currentState) {
       override val wrappers = Seq( DeletedWrapper(_: Phase) )

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -3,7 +3,7 @@
 package chisel3.stage
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PhaseManager, PreservesAll, Shell, Stage, StageError, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageError, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.FirrtlCli
 import firrtl.options.Viewer.view
@@ -16,15 +16,15 @@ import java.io.{StringWriter, PrintWriter}
 class ChiselStage extends Stage with PreservesAll[Phase] {
   val shell: Shell = new Shell("chisel") with ChiselCli with FirrtlCli
 
-  val targets: Seq[PhaseManager.PhaseDependency] =
-    Seq( classOf[chisel3.stage.phases.Checks],
-         classOf[chisel3.stage.phases.Elaborate],
-         classOf[chisel3.stage.phases.AddImplicitOutputFile],
-         classOf[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
-         classOf[chisel3.stage.phases.MaybeAspectPhase],
-         classOf[chisel3.stage.phases.Emitter],
-         classOf[chisel3.stage.phases.Convert],
-         classOf[chisel3.stage.phases.MaybeFirrtlStage] )
+  val targets: Seq[Dependency[Phase]] =
+    Seq( Dependency[chisel3.stage.phases.Checks],
+         Dependency[chisel3.stage.phases.Elaborate],
+         Dependency[chisel3.stage.phases.AddImplicitOutputFile],
+         Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
+         Dependency[chisel3.stage.phases.MaybeAspectPhase],
+         Dependency[chisel3.stage.phases.Emitter],
+         Dependency[chisel3.stage.phases.Convert],
+         Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
 
   def run(annotations: AnnotationSeq): AnnotationSeq = try {
     new PhaseManager(targets) { override val wrappers = Seq( (a: Phase) => DeletedWrapper(a) ) }

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
@@ -4,14 +4,14 @@ package chisel3.stage.phases
 
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.AnnotationSeq
-import firrtl.options.{OutputAnnotationFileAnnotation, Phase, PreservesAll}
+import firrtl.options.{Dependency, OutputAnnotationFileAnnotation, Phase, PreservesAll}
 
 /** Adds an [[firrtl.options.OutputAnnotationFileAnnotation]] if one does not exist. This replicates old behavior where
   * an output annotation file was always written.
   */
 class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[Elaborate])
+  override val prerequisites = Seq(Dependency[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst{ case _: OutputAnnotationFileAnnotation => annotations }

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
@@ -3,7 +3,7 @@
 package chisel3.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselOutputFileAnnotation}
 
@@ -12,7 +12,7 @@ import chisel3.stage.{ChiselCircuitAnnotation, ChiselOutputFileAnnotation}
   */
 class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[Elaborate])
+  override val prerequisites = Seq(Dependency[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq =
     annotations.collectFirst{ case _: ChiselOutputFileAnnotation  => annotations }.getOrElse{

--- a/src/main/scala/chisel3/stage/phases/AspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/AspectPhase.scala
@@ -34,4 +34,3 @@ class AspectPhase extends Phase {
     } else annotations
   }
 }
-

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -6,14 +6,14 @@ import chisel3.stage.{ChiselOutputFileAnnotation, NoRunFirrtlCompilerAnnotation,
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{OptionsException, Phase, PreservesAll}
+import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
 
 /** Sanity checks an [[firrtl.AnnotationSeq]] before running the main [[firrtl.options.Phase]]s of
   * [[chisel3.stage.ChiselStage]].
   */
 class Checks extends Phase with PreservesAll[Phase] {
 
-  override val dependents = Seq(classOf[Elaborate])
+  override val dependents = Seq(Dependency[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val noF, st, outF = collection.mutable.ListBuffer[Annotation]()

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -6,7 +6,7 @@ import chisel3.experimental.RunFirrtlTransform
 import chisel3.internal.firrtl.Converter
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.{AnnotationSeq, Transform}
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 
 /** This prepares a [[ChiselCircuitAnnotation]] for compilation with FIRRTL. This does three things:
@@ -16,7 +16,7 @@ import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
   */
 class Convert extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[Elaborate])
+  override val prerequisites = Seq(Dependency[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>
@@ -34,7 +34,6 @@ class Convert extends Phase with PreservesAll[Phase] {
           case anno: RunFirrtlTransform => anno.transformClass
         }
         .distinct
-        .filterNot(_ == classOf[firrtl.Transform])
         .map { c: Class[_ <: Transform] => RunFirrtlTransformAnnotation(c.newInstance()) }
     case a => Some(a)
   }

--- a/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/chisel3/stage/phases/DriverCompatibility.scala
@@ -4,7 +4,7 @@ package chisel3.stage.phases
 
 import firrtl.{AnnotationSeq, ExecutionOptionsManager, HasFirrtlOptions}
 import firrtl.annotations.NoTargetAnnotation
-import firrtl.options.{OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, Unserializable}
+import firrtl.options.{Dependency, OptionsException, OutputAnnotationFileAnnotation, Phase, PreservesAll, Unserializable}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.stage.phases.DriverCompatibility.TopNameAnnotation
 
@@ -27,7 +27,7 @@ object DriverCompatibility {
     */
   private [chisel3] class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
 
-    override val dependents = Seq(classOf[chisel3.stage.ChiselStage])
+    override val dependents = Seq(Dependency[chisel3.stage.ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
       val hasOutputFile = annotations
@@ -51,7 +51,7 @@ object DriverCompatibility {
     */
   private[chisel3] class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
 
-    override val dependents = Seq(classOf[chisel3.stage.ChiselStage])
+    override val dependents = Seq(Dependency[chisel3.stage.ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq =
       annotations
@@ -75,7 +75,7 @@ object DriverCompatibility {
     */
   private[chisel3] class DisableFirrtlStage extends Phase with PreservesAll[Phase] {
 
-    override val dependents = Seq(classOf[ChiselStage])
+    override val dependents = Seq(Dependency[ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst { case NoRunFirrtlCompilerAnnotation => annotations                              }
@@ -84,7 +84,7 @@ object DriverCompatibility {
 
   private[chisel3] class ReEnableFirrtlStage extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(classOf[DisableFirrtlStage], classOf[ChiselStage])
+    override val prerequisites = Seq(Dependency[DisableFirrtlStage], Dependency[ChiselStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
       .collectFirst { case RunFirrtlCompilerAnnotation =>
@@ -108,9 +108,9 @@ object DriverCompatibility {
     */
   private[chisel3] class MutateOptionsManager extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(classOf[chisel3.stage.ChiselStage])
+    override val prerequisites = Seq(Dependency[chisel3.stage.ChiselStage])
 
-    override val dependents = Seq(classOf[ReEnableFirrtlStage])
+    override val dependents = Seq(Dependency[ReEnableFirrtlStage])
 
     def transform(annotations: AnnotationSeq): AnnotationSeq = {
 
@@ -137,9 +137,9 @@ object DriverCompatibility {
     */
   private [chisel3] class FirrtlPreprocessing extends Phase with PreservesAll[Phase] {
 
-    override val prerequisites = Seq(classOf[ChiselStage], classOf[MutateOptionsManager], classOf[ReEnableFirrtlStage])
+    override val prerequisites = Seq(Dependency[ChiselStage], Dependency[MutateOptionsManager], Dependency[ReEnableFirrtlStage])
 
-    override val dependents = Seq(classOf[MaybeFirrtlStage])
+    override val dependents = Seq(Dependency[MaybeFirrtlStage])
 
     private val phases =
       Seq( new firrtl.stage.phases.DriverCompatibility.AddImplicitOutputFile,

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -4,7 +4,7 @@ package chisel3.stage.phases
 
 import firrtl.{AnnotationSeq, EmittedFirrtlCircuit, EmittedFirrtlCircuitAnnotation}
 import firrtl.annotations.DeletedAnnotation
-import firrtl.options.{Phase, StageOptions}
+import firrtl.options.{Dependency, Phase, StageOptions}
 import firrtl.options.Viewer.view
 
 import chisel3.internal.firrtl.{Emitter => OldEmitter}
@@ -25,10 +25,10 @@ import java.io.{File, FileWriter}
 class Emitter extends Phase {
 
   override val prerequisites =
-    Seq( classOf[Elaborate],
-         classOf[AddImplicitOutputFile],
-         classOf[AddImplicitOutputAnnotationFile],
-         classOf[MaybeAspectPhase] )
+    Seq( Dependency[Elaborate],
+         Dependency[AddImplicitOutputFile],
+         Dependency[AddImplicitOutputAnnotationFile],
+         Dependency[MaybeAspectPhase] )
 
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: Elaborate => true

--- a/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
@@ -4,13 +4,13 @@ package chisel3.stage.phases
 
 import chisel3.aop.Aspect
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 
 /** Run [[AspectPhase]] if a [[chisel3.aop.Aspect]] is present.
   */
 class MaybeAspectPhase extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[Elaborate])
+  override val prerequisites = Seq(Dependency[Elaborate])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     if(annotations.collectFirst { case a: Aspect[_] => annotations }.isDefined) {

--- a/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
@@ -5,14 +5,14 @@ package chisel3.stage.phases
 import chisel3.stage.NoRunFirrtlCompilerAnnotation
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase, PreservesAll}
 import firrtl.stage.FirrtlStage
 
 /** Run [[firrtl.stage.FirrtlStage]] if a [[chisel3.stage.NoRunFirrtlCompilerAnnotation]] is not present.
   */
 class MaybeFirrtlStage extends Phase with PreservesAll[Phase] {
 
-  override val prerequisites = Seq(classOf[Convert])
+  override val prerequisites = Seq(Dependency[Convert])
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst { case NoRunFirrtlCompilerAnnotation => annotations }


### PR DESCRIPTION
This changes Phase dependency specification to use the new Dependency
wrapper. Previously, dependencies were specified as classes.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@ibm.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/firrtl/pull/1275

Dependes on https://github.com/freechipsproject/firrtl/pull/1357

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Migrate ChiselStage to use Dependency wrappers
