### PR TITLE
Remove unused WriteEmitted phase

### DIFF
--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -28,7 +28,6 @@ package object stage {
 
   private[chisel3] implicit object ChiselExecutionResultView extends OptionsView[ChiselExecutionResult] {
 
-    lazy val dummyWriteEmitted = new firrtl.stage.phases.WriteEmitted
     lazy val dummyConvert = new Convert
     lazy val dummyEmitter = new Emitter
 


### PR DESCRIPTION
This removes a dead line where a WriteEmitted phase is constructed.

This PR should be merged before https://github.com/freechipsproject/firrtl/pull/1277.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.