### PR TITLE
 Bug fixes to support code for Interval

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -9,6 +9,7 @@ import chisel3.experimental._
 import _root_.firrtl.{ir => firrtlir}
 import _root_.firrtl.PrimOps
 
+import scala.collection.immutable.NumericRange
 import scala.math.BigDecimal.RoundingMode
 
 // scalastyle:off number.of.types
@@ -432,7 +433,7 @@ sealed class IntervalRange(
   val getHighestPossibleValue: Option[BigDecimal] = {
     increment match {
       case Some(inc) =>
-        lower match {
+        upper match {
           case firrtlir.Closed(n) => Some(n)
           case firrtlir.Open(n) => Some(n - inc)
           case _ => None
@@ -446,7 +447,7 @@ sealed class IntervalRange(
     * Mostly to be used for testing
     * @return
     */
-  def getPossibleValues: Seq[BigDecimal] = {
+  def getPossibleValues: NumericRange[BigDecimal] = {
     (getLowestPossibleValue, getHighestPossibleValue, increment) match {
       case (Some(low), Some(high), Some(inc)) => (low to high by inc)
       case (_, _, None) =>

--- a/src/test/scala/chiselTests/IntervalRangeSpec.scala
+++ b/src/test/scala/chiselTests/IntervalRangeSpec.scala
@@ -216,6 +216,23 @@ class IntervalRangeSpec extends FreeSpec with Matchers {
         checkRange(range"[-7.875,7.875].3".setPrecision(1.BP), C(-8.0), C(7.5), 1.BP)
       }
     }
+
+    "get possible values should return all values from high to low" in {
+      var range = range"[0,4]"
+      range.getLowestPossibleValue should be (Some(0))
+      range.getHighestPossibleValue should be (Some(4))
+      range.getPossibleValues should be (Seq(0, 1, 2, 3, 4))
+
+      range = range"(0,4)"
+      range.getLowestPossibleValue should be (Some(1))
+      range.getHighestPossibleValue should be (Some(3))
+      range.getPossibleValues should be (Seq(1, 2, 3))
+
+      range = range"(-1,4).1"
+      range.getLowestPossibleValue should be (Some(-0.5))
+      range.getHighestPossibleValue should be (Some(3.5))
+      range.getPossibleValues should be (Seq(-0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5))
+    }
   }
 
 }


### PR DESCRIPTION
- Change getPossibleValues of Interval to return a NumericRange formerly Seq materialized all values
- Fixed computation in getHighestPossibleValue, erroneously was using lower intead of upper

**Type of change**: bug fix
**Impact**: no functional change

**Release Notes**
Fixed bug that miscalculated the highest possible value of an IntervalRange