### PR TITLE
Fixed problem creating Interval literals with full ranges

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -2162,16 +2162,16 @@ package experimental {
 
     protected[chisel3] def Lit(value: BigInt, range: IntervalRange): Interval = {
       val lit = IntervalLit(value, range.getWidth, range.binaryPoint)
-      val bigDecimal = BigDecimal(value)
+      val bigDecimal = BigDecimal(value) / (1 << lit.binaryPoint.get)
       val inRange = (range.lowerBound, range.upperBound) match {
         case (firrtlir.Closed(l), firrtlir.Closed(u)) => l <= bigDecimal && bigDecimal <= u
-        case (firrtlir.Closed(l), firrtlir.Open(u))   => l <= bigDecimal && bigDecimal <= u
-        case (firrtlir.Open(l), firrtlir.Closed(u))   => l <= bigDecimal && bigDecimal <= u
-        case (firrtlir.Open(l), firrtlir.Open(u))     => l <= bigDecimal && bigDecimal <= u
+        case (firrtlir.Closed(l), firrtlir.Open(u))   => l <= bigDecimal && bigDecimal < u
+        case (firrtlir.Open(l), firrtlir.Closed(u))   => l < bigDecimal && bigDecimal <= u
+        case (firrtlir.Open(l), firrtlir.Open(u))     => l < bigDecimal && bigDecimal < u
       }
       if(! inRange) {
         throw new ChiselException(
-          s"Error literal interval value $value is not contained in specified range $range"
+          s"Error literal interval value $bigDecimal is not contained in specified range $range"
         )
       }
       val result = Interval(range)

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -456,8 +456,50 @@ class IntervalSpec extends FreeSpec with Matchers with ChiselRunners {
           () =>
             new BasicTester {
               val x = 5.I(range"[0,4]")
-          }
+            }
         ).elaborate
+      }
+    }
+  }
+
+  "Interval literals creation handles edge cases" - {
+    "value at closed boundaries works" in {
+      val inputRange = range"[-6, 6].2"
+      val in1 = (-6.0).I(inputRange)
+      val in2 = 6.0.I(inputRange)
+      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be (-6)
+      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be (6)
+      intercept[ChiselException] {
+        (-6.25).I(inputRange)
+      }
+      intercept[ChiselException] {
+        (6.25).I(inputRange)
+      }
+    }
+    "value at open boundaries works" in {
+      val inputRange = range"(-6, 6).2"
+      val in1 = (-5.75).I(inputRange)
+      val in2 = 5.75.I(inputRange)
+      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be (-5.75)
+      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be (5.75)
+      intercept[ChiselException] {
+        (-6.0).I(inputRange)
+      }
+      intercept[ChiselException] {
+        (6.0).I(inputRange)
+      }
+    }
+    "values not precisely at open boundaries works but are converted to nearest match" in {
+      val inputRange = range"(-6, 6).2"
+      val in1 = (-5.95).I(inputRange)
+      val in2 = 5.95.I(inputRange)
+      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be (-5.75)
+      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be (5.75)
+      intercept[ChiselException] {
+        (-6.1).I(inputRange)
+      }
+      intercept[ChiselException] {
+        (6.1).I(inputRange)
       }
     }
   }


### PR DESCRIPTION
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

**Development Phase**:  implementation
- boundary testing was not taking binary point into account correctly
- add tests to show where things work and where they are supposed to fail

**Release Notes**
A bug that affected could cause exceptions when creating intervals with range specifiers was fixed, e.g. `val iLit = 6.0.I(range"[0,6]")` would fail even though 6 is legal in that range.