### PR TITLE
Band aid until litOption is implemented for Aggregates.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -43,7 +43,7 @@ sealed abstract class Aggregate extends Data {
     }
   }
 
-  override def litOption: Option[BigInt] = ???  // TODO implement me
+  override def litOption: Option[BigInt] = None  // TODO implement me
 
   /** Returns a Seq of the immediate contents of this Aggregate, in order.
     */


### PR DESCRIPTION
This is just a band aid until an Aggregate `isLit()` method (for which work has begun) is implemented.

**Related issue**: #1256, ucb-bar/dsptools#184

**Type of change**: bug report

**Impact**: API modification

**Development Phase**: implementation

**Release Notes**
Prevent `isLit()` on Aggregates failing with a `scala.NotImplementedError: an implementation is missing` error.