### PR TITLE
Ignore lazy val when get public fields

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -150,12 +150,14 @@ private[chisel3] trait HasId extends InstanceId {
   }
 
   private[chisel3] def getPublicFields(rootClass: Class[_]): Seq[java.lang.reflect.Method] = {
+    def is_final(modifier: Int) =
+      (modifier & java.lang.reflect.Modifier.FINAL) == java.lang.reflect.Modifier.FINAL
     // Suggest names to nodes using runtime reflection
     def getValNames(c: Class[_]): Set[String] = {
       if (c == rootClass) {
         Set()
       } else {
-        getValNames(c.getSuperclass) ++ c.getDeclaredFields.map(_.getName)
+        getValNames(c.getSuperclass) ++ c.getDeclaredFields.filter(x => is_final(x.getModifiers())).map(_.getName)
       }
     }
     val valNames = getValNames(this.getClass)


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Ignore `lazy val` fields when called `getPublicFields` method in `generateComponent` method.

## Example

```scala
class Mux2(has_sel: Boolean) extends RawModule {
  lazy val sel = IO(Input(UInt(1.W))).suggestName("sel")
  val in0 = IO(Input(UInt(1.W)))
  val in1 = IO(Input(UInt(1.W)))
  val out = IO(Output(UInt(1.W)))

  if (has_sel) {
    sel
    out := (sel & in1) | (~sel & in0)
  }
  else
    out := in1 | in0
}
```

I want to use `has_sel` to configure whether to use `sel` input port.

Here are the result with/without `val sel`:

`new Mux2(has_sel=true)`

```firrtl
circuit Mux2 :
  module Mux2 :
    input in0 : UInt<1>
    input in1 : UInt<1>
    output out : UInt<1>
    input sel : UInt<1>
    
    node _T = and(sel, in1)
    node _T_1 = not(sel)
    node _T_2 = and(_T_1, in0)
    node _T_3 = or(_T, _T_2)
    out <= _T_3
```

`new Mux2(has_sel=false)`

```firrtl
ircuit Mux2 :
  module Mux2 :
    input in0 : UInt<1>
    input in1 : UInt<1>
    output out : UInt<1>

    node _T = or(in1, in0)
    out <= _T
```

## How Do I Implement

I try to find the difference between `val foo` and `lazy val foo`, I add this code to debug

```scala
def getValNames(c: Class[_]): Set[String] = {
  if (c == rootClass) {
    Set()
  } else {
    c.getDeclaredFields foreach { x => println(s"$x -> ${x.getName}: ${x.getModifiers()}")}
    getValNames(c.getSuperclass) ++ c.getDeclaredFields.map(_.getName)
  }
 }
```
The difference is **Modifiers**: **val foo** has **final** modifier, and **lazy val foo** doesn't.

```
private chisel3.UInt custom.Mux2.sel -> sel: 2
private final chisel3.UInt custom.Mux2.in0 -> in0: 18
private final chisel3.UInt custom.Mux2.in1 -> in1: 18
private final chisel3.UInt custom.Mux2.out -> out: 18
private volatile boolean custom.Mux2.bitmap$0 -> bitmap$0: 66

```

I think **Chisel3** should maintain the `lazy val` semantic, do not execute it unless user called it.