### PR TITLE
BitPat supports whitespace and underscores

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -14,7 +14,7 @@ object BitPat {
     * @return bits the literal value, with don't cares being 0
     * @return mask the mask bits, with don't cares being 0 and cares being 1
     * @return width the number of bits in the literal, including values and
-    * don't cares.
+    * don't cares, but not including the white space and underscores
     */
   private def parse(x: String): (BigInt, BigInt, Int) = {
     // Notes:
@@ -25,14 +25,17 @@ object BitPat {
     require(x.head == 'b', "BitPats must be in binary and be prefixed with 'b'")
     var bits = BigInt(0)
     var mask = BigInt(0)
+    var count = 0
     for (d <- x.tail) {
-      if (d != '_') {
+      if (! (d == '_' || d.isWhitespace)) {
         require("01?".contains(d), "Literal: " + x + " contains illegal character: " + d)
         mask = (mask << 1) + (if (d == '?') 0 else 1)
         bits = (bits << 1) + (if (d == '1') 1 else 0)
+        count += 1
       }
     }
-    (bits, mask, x.length - 1)
+
+    (bits, mask, count)
   }
 
   /** Creates a [[BitPat]] literal from a string.

--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -36,8 +36,18 @@ class DecoderSpec extends ChiselPropSpec {
   val bitpatPair = for(seed <- Arbitrary.arbitrary[Int]) yield {
     val rnd = new scala.util.Random(seed)
     val bs = seed.toBinaryString
-    val bp = bs.map(if(rnd.nextBoolean) _ else "?").mkString
-    ("b" + bs, "b" + bp)
+    val bp = bs.map(if(rnd.nextBoolean) _ else "?")
+
+    // The following randomly throws in white space and underscores which are legal and ignored.
+    val bpp = bp.map { a =>
+      if (rnd.nextBoolean) {
+        a
+      } else {
+        a + (if (rnd.nextBoolean) "_" else " ")
+      }
+    }.mkString
+
+    ("b" + bs, "b" + bpp)
   }
   private def nPairs(n: Int) = Gen.containerOfN[List, (String,String)](n,bitpatPair)
 


### PR DESCRIPTION
The whitespace and _ are presumably for human readability.

**Related issue**: 
This is a fix for chisel3 PR #1069

**Type of change**: bug fix

The BitPat.parse factory though did take these into account when 
reporting the bit pattern size in `BitPat.parse`.

This fixes that adds whitespace and underscores to the unit tests

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Fixes `BitPat.parse` returned value for the size of the bit pattern, which was not
adjusted for the presence of _ or whitespace (legal formatting characters)