### PR TITLE
Add method asBool to Clock.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Clock.scala
@@ -2,7 +2,8 @@
 
 package chisel3
 
-import chisel3.internal.Builder.{pushOp}
+import scala.language.experimental.macros
+import chisel3.internal.Builder.pushOp
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo._
 import chisel3.internal.firrtl.PrimOp.AsUIntOp
@@ -30,9 +31,13 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   /** Not really supported */
   def toPrintable: Printable = PString("CLOCK")
 
+  /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
+  final def asBool(): Bool = macro SourceInfoTransform.noArg
+  def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this.asUInt().asBool()
+
   override def do_asUInt(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref)) // scalastyle:ignore line.size.limit
   private[chisel3] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
-    this := that.asBool.asClock
+    this := that.asBool().asClock
   }
 }

--- a/chiselFrontend/src/main/scala/chisel3/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Clock.scala
@@ -31,7 +31,7 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   /** Not really supported */
   def toPrintable: Printable = PString("CLOCK")
 
-  /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
+  /** Returns the contents of the clock wire as a [[Bool]]. */
   final def asBool(): Bool = macro SourceInfoTransform.noArg
   def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this.asUInt().asBool()
 

--- a/chiselFrontend/src/main/scala/chisel3/Clock.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Clock.scala
@@ -38,6 +38,6 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   override def do_asUInt(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref)) // scalastyle:ignore line.size.limit
   private[chisel3] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
-    this := that.asBool().asClock
+    this := that.asBool.asClock
   }
 }

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -20,7 +20,6 @@ class WithClockAndNoReset extends RawModule {
     RegNext(in)
   }
 
-  in.asUInt()
   out := a
 }
 

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -7,6 +7,7 @@ import chisel3.testers.BasicTester
 
 class ClockAsUIntTester extends BasicTester {
   assert(true.B.asClock.asUInt === 1.U)
+  assert(true.B.asClock.asBool === true.B)
   stop()
 }
 
@@ -18,6 +19,8 @@ class WithClockAndNoReset extends RawModule {
   val a = withClock(clock2) {
     RegNext(in)
   }
+
+  in.asUInt()
   out := a
 }
 


### PR DESCRIPTION

**Related issue**: 
Addresses Chisel issue #1238

**Type of change**: feature request

**Impact**: Minor API addition (no impact on existing code)

**Development Phase**:  implementation

**Release Notes**
There is now a short cut method for turning a clock to a bool
`clock.asBool`. Previously had to do `clock.asUInt.asBool`
