### PR TITLE
Fix add other module's port

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Module.scala
@@ -100,8 +100,9 @@ package experimental {
       * requested (so that all calls to ports will return the same information).
       * Internal API.
       */
-    def apply[T<:Data](iodef: T): T = {
+    def apply[T<:Data](ctx: BaseModule, iodef: T): T = {
       val module = Module.currentModule.get // Impossible to fail
+      require(ctx == module, s"${module.name} can't add other module ${ctx.name}'s port")
       require(!module.isClosed, "Can't add more ports after module close")
       requireIsChiselType(iodef, "io type")
 
@@ -386,7 +387,7 @@ package experimental {
       * TODO(twigg): Specifically walk the Data definition to call out which nodes
       * are problematic.
       */
-    protected def IO[T <: Data](iodef: T): T = chisel3.experimental.IO.apply(iodef) // scalastyle:ignore method.name
+    protected def IO[T <: Data](iodef: T): T = chisel3.experimental.IO.apply(this, iodef) // scalastyle:ignore method.name
 
     //
     // Internal Functions

--- a/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
+++ b/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
@@ -15,7 +15,7 @@ class PrivatePort extends NamedModuleTester {
 // Example of using composition to add ports to a Module
 class CompositionalPort(module: NamedModuleTester, name: String) {
   import chisel3.experimental.IO
-  val foo = module.expectName(IO(Output(Bool())), name)
+  val foo = module.expectName(IO(module, Output(Bool())), name)
   foo.suggestName(name)
   foo := true.B
 }


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

## Testcase

```scala
class Mux2 extends RawModule {
  def foo = IO(Input(UInt(1.W))).suggestName("foo")
  val sel = IO(Input(UInt(1.W)))
  val in0 = IO(Input(UInt(1.W)))
  val in1 = IO(Input(UInt(1.W)))
  val out = IO(Output(UInt(1.W)))
  out := (sel & in1) | (~sel & in0)
}

class Mux4 extends RawModule {
  val in0 = IO(Input(UInt(1.W)))
  val in1 = IO(Input(UInt(1.W)))
  val sel = IO(Input(UInt(1.W)))
  val out = IO(Output(UInt(1.W)))

  val m0 = Module(new Mux2)
  m0.sel := sel
  m0.in0 := in0
  m0.in1 := in1

  m0.foo

  out := m0.out
}
```

`Mux2`'s port `foo` is called in module `Mux4` and then it would add the port `foo` to module `Mux4`.

```firrtl
circuit Mux4 : 
  module Mux2 : 
    input sel : UInt<1>
    input in0 : UInt<1>
    input in1 : UInt<1>
    output out : UInt<1>
    ...
  module Mux4 : 
    input in0 : UInt<1>
    input in1 : UInt<1>
    input sel : UInt<1>
    output out : UInt<1>
    input foo : UInt<1>
    ...
```

Fix this problem and will throw exception:

```
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: Mux4 can't add other module Mux2's port
```

