### PR TITLE
Add module's name in elaborating info

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -406,7 +406,7 @@ private[chisel3] object Builder {
         val mod = f
         mod.forceName(mod.name, globalNamespace)
         errors.checkpoint()
-        errors.info("Done elaborating.")
+        errors.info(s"Done elaborating ${mod.name}.")
 
         (Circuit(components.last.name, components, annotations), mod)
       }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/chisel3/issues/1287

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: Implementation

Print Module's name in `Elaborating` information.

For example,

```scala
import chisel3._

class Mux2 extends Module {
 ...
}

class Mux4 extends Module {
  ...
}

object Main extends App {
  Driver.execute(args, () => new Mux2)
  Driver.execute(args, () => new Mux4)
}
```

It will print as below:

```shell
[info] [0.003] Elaborating design...
[info] [1.006] Done elaborating Mux2.
Total FIRRTL Compile Time: 698.4 ms
[info] [0.000] Elaborating design...
[info] [0.033] Done elaborating Mux4.
Total FIRRTL Compile Time: 174.3 ms
```
