### PR TITLE
Bugfix: Select.instances now works with blackboxes

### DIFF
--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -80,8 +80,11 @@ object Select {
     */
   def instances(module: BaseModule): Seq[BaseModule] = {
     check(module)
-    module._component.get.asInstanceOf[DefModule].commands.collect {
-      case i: DefInstance => i.id
+    module._component.get match {
+      case d: DefModule => d.commands.collect {
+        case i: DefInstance => i.id
+      }
+      case other => Nil
     }
   }
 

--- a/src/test/scala/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala/chiselTests/aop/SelectSpec.scala
@@ -7,7 +7,9 @@ import chiselTests.ChiselFlatSpec
 import chisel3._
 import chisel3.aop.Select.{PredicatedConnect, When, WhenNot}
 import chisel3.aop.{Aspect, Select}
-import firrtl.{AnnotationSeq}
+import chisel3.experimental.ExtModule
+import chisel3.stage.{ChiselGeneratorAnnotation, DesignAnnotation}
+import firrtl.AnnotationSeq
 
 import scala.reflect.runtime.universe.TypeTag
 
@@ -137,6 +139,18 @@ class SelectSpec extends ChiselFlatSpec {
         ))
       }
     )
+  }
+
+  "Blackboxes" should "be supported in Select.instances" in {
+    class BB extends ExtModule { }
+    class Top extends RawModule {
+      val bb = Module(new BB)
+    }
+    val top = ChiselGeneratorAnnotation(() => {
+      new Top()
+    }).elaborate(1).asInstanceOf[DesignAnnotation[Top]].design
+    val bbs = Select.collectDeep(top) { case b: BB => b }
+    assert(bbs.size == 1)
   }
 
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: bug report
<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Previously, `Select.instances` would fail on a cast error if called on a module that was a black box. Now, it just returns `Nil`, because a black box by default has no instances. This enables other functions to rely on more consistent behavior, such as `Select.collectDeep`.
