### PR TITLE
Change when/switch thunk type to Any

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/When.scala
+++ b/chiselFrontend/src/main/scala/chisel3/When.scala
@@ -28,7 +28,7 @@ object when {  // scalastyle:ignore object.name
     * }}}
     */
 
-  def apply(cond: => Bool)(block: => Unit)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): WhenContext = { // scalastyle:ignore line.size.limit
+  def apply(cond: => Bool)(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): WhenContext = { // scalastyle:ignore line.size.limit
     new WhenContext(sourceInfo, Some(() => cond), block)
   }
 }
@@ -43,7 +43,7 @@ object when {  // scalastyle:ignore object.name
   *  succeeding elsewhen or otherwise; therefore, this information is
   *  added by preprocessing the command queue.
   */
-final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block: => Unit, firrtlDepth: Int = 0) {
+final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block: => Any, firrtlDepth: Int = 0) {
 
   /** This block of logic gets executed if above conditions have been
     * false and this condition is true. The lazy argument pattern
@@ -51,7 +51,7 @@ final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block:
     * declaration and assignment of the Bool node of the predicate in
     * the correct place.
     */
-  def elsewhen (elseCond: => Bool)(block: => Unit)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): WhenContext = { // scalastyle:ignore line.size.limit
+  def elsewhen (elseCond: => Bool)(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): WhenContext = { // scalastyle:ignore line.size.limit
     new WhenContext(sourceInfo, Some(() => elseCond), block, firrtlDepth + 1)
   }
 
@@ -62,7 +62,7 @@ final class WhenContext(sourceInfo: SourceInfo, cond: Option[() => Bool], block:
     * assignment of the Bool node of the predicate in the correct
     * place.
     */
-  def otherwise(block: => Unit)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit =
+  def otherwise(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit =
     new WhenContext(sourceInfo, None, block, firrtlDepth + 1)
 
   /*

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -15,7 +15,7 @@ import chisel3._
 object unless {  // scalastyle:ignore object.name
   /** Does the same thing as [[when$ when]], but with the condition inverted.
     */
-  def apply(c: Bool)(block: => Unit) {
+  def apply(c: Bool)(block: => Any) {
     when (!c) { block }
   }
 }
@@ -25,7 +25,7 @@ object unless {  // scalastyle:ignore object.name
   * @note DO NOT USE. This API is subject to change without warning.
   */
 class SwitchContext[T <: Element](cond: T, whenContext: Option[WhenContext], lits: Set[BigInt]) {
-  def is(v: Iterable[T])(block: => Unit): SwitchContext[T] = {
+  def is(v: Iterable[T])(block: => Any): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
         require(w.litOption.isDefined, "is condition must be literal")
@@ -43,8 +43,8 @@ class SwitchContext[T <: Element](cond: T, whenContext: Option[WhenContext], lit
       this
     }
   }
-  def is(v: T)(block: => Unit): SwitchContext[T] = is(Seq(v))(block)
-  def is(v: T, vr: T*)(block: => Unit): SwitchContext[T] = is(v :: vr.toList)(block)
+  def is(v: T)(block: => Any): SwitchContext[T] = is(Seq(v))(block)
+  def is(v: T, vr: T*)(block: => Any): SwitchContext[T] = is(v :: vr.toList)(block)
 }
 
 /** Use to specify cases in a [[switch]] block, equivalent to a [[when$ when]] block comparing to
@@ -60,19 +60,19 @@ object is {   // scalastyle:ignore object.name
   // TODO: Begin deprecation of non-type-parameterized is statements.
   /** Executes `block` if the switch condition is equal to any of the values in `v`.
     */
-  def apply(v: Iterable[Element])(block: => Unit) {
+  def apply(v: Iterable[Element])(block: => Any) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to `v`.
     */
-  def apply(v: Element)(block: => Unit) {
+  def apply(v: Element)(block: => Any) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to any of the values in the argument list.
     */
-  def apply(v: Element, vr: Element*)(block: => Unit) {
+  def apply(v: Element, vr: Element*)(block: => Any) {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 }
@@ -91,7 +91,7 @@ object is {   // scalastyle:ignore object.name
   * }}}
   */
 object switch {  // scalastyle:ignore object.name
-  def apply[T <: Element](cond: T)(x: => Unit): Unit = macro impl
+  def apply[T <: Element](cond: T)(x: => Any): Unit = macro impl
   def impl(c: Context)(cond: c.Tree)(x: c.Tree): c.Tree = { import c.universe._
     val q"..$body" = x
     val res = body.foldLeft(q"""new SwitchContext($cond, None, Set.empty)""") {


### PR DESCRIPTION
This changes the type of the thunk used by `when` and `switch` method from `=> Unit` to `=> Any`.

This avoids a warning related to discarding a non-Unit value (`-Ywarn-value-discard` ) if you do something like what is describe in #1298.

Alternatively, and as I suggested in #1298, I think you could also get rid of this by making the methods polymorphic in the type of the thunk, e.g., `apply[A](a: => A): FooContext`. However, this is not like `withClock` where the type of the thunk is returned. Therefore, I opted for the simpler solution of using `Any`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Fixes #1298 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Prevent warnings from -Ywarn-value-discard in when/switch