### PR TITLE
Emit FIRRTL andr, orr for Bits.{andR, orR}

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -581,13 +581,9 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
   final def xorR(): Bool = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
-  def do_orR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this =/= 0.U
+  def do_orR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = redop(sourceInfo, OrReduceOp)
   /** @group SourceInfoTransformMacro */
-  def do_andR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = width match {
-    // Generate a simpler expression if the width is known
-    case KnownWidth(w) => this === ((BigInt(1) << w) - 1).U
-    case UnknownWidth() =>  ~this === 0.U
-  }
+  def do_andR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = redop(sourceInfo, AndReduceOp)
   /** @group SourceInfoTransformMacro */
   def do_xorR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = redop(sourceInfo, XorReduceOp)
 

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -47,6 +47,8 @@ object PrimOp {
   val NotEqualOp = PrimOp("neq")
   val NegOp = PrimOp("neg")
   val MultiplexOp = PrimOp("mux")
+  val AndReduceOp = PrimOp("andr")
+  val OrReduceOp = PrimOp("orr")
   val XorReduceOp = PrimOp("xorr")
   val ConvertOp = PrimOp("cvt")
   val AsUIntOp = PrimOp("asUInt")

--- a/src/test/scala/chiselTests/BitwiseOps.scala
+++ b/src/test/scala/chiselTests/BitwiseOps.scala
@@ -13,6 +13,8 @@ class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends BasicTester {
   assert((a & b) === (_a & _b).asUInt)
   assert((a | b) === (_a | _b).asUInt)
   assert((a ^ b) === (_a ^ _b).asUInt)
+  assert((a.orR) === (_a != 0).asBool)
+  assert((a.andR) === (s"%${w}s".format(BigInt(_a).toString(2)).foldLeft(true)(_ && _ == '1') ).asBool)
   stop()
 }
 


### PR DESCRIPTION
Change the emission strategy for `Bits` methods `andR` and `orR` to emit FIRRTL bitwise reduce operations `andr` and `orr`. The CHIRRTL emission strategy for these two operations now matches the emission of `xorR` (which already used `xorr`).

Add two tests that assert the correct behavior of these operations in `BitwiseOpsSpec`.

This should fix one of the Verilog emission problems shown in freechipsproject/firrtl#1338 of:

```scala
class Foo(n: Int) extends RawModule {
  val in = IO(Input(UInt(n.W)))
  val out = IO(Output(Vec(3, Bool())))
  out(0) := in.andR
  out(1) := in.orR
  out(2) := in.xorR
}
```

This will now emit the following CHIRRTL for `Foo(4)`:

```
circuit Foo : 
  module Foo : 
    input in : UInt<4>
    output out : UInt<1>[3]
    
    node _T = andr(in)
    out[0] <= _T
    node _T_1 = orr(in)
    out[1] <= _T_1
    node _T_2 = xorr(in)
    out[2] <= _T_2
```

And the resulting Verilog:

```verilog
module Foo(
  input  [3:0] in,
  output       out_0,
  output       out_1,
  output       out_2
);
  assign out_0 = &in;
  assign out_1 = |in;
  assign out_2 = ^in;
endmodule
```

For the case of a zero-width wire, you get the reductions that @albert-magyar introduced in https://github.com/freechipsproject/firrtl/pull/1362.

```verilog
module Foo(
  output  out_0,
  output  out_1,
  output  out_2
);
  assign out_0 = 1'h1;
  assign out_1 = |1'h0;
  assign out_2 = ^1'h0;
endmodule

```

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: 
  - https://github.com/freechipsproject/firrtl/issues/1338
  - Depends on https://github.com/freechipsproject/firrtl/pull/1362

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification (to emitted CHIRRTL)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Change andR, orR emission to use FIRRTL andr, orr
