### PR TITLE
Add Scaladoc about RegNext Unset/Inferred Widths

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Reg.scala
@@ -48,11 +48,33 @@ object Reg {
 
 }
 
+/** Utility for constructing one-cycle delayed versions of signals
+  *
+  * ''The width of a `RegNext` is not set based on the `next` or `init` connections'' for [[Element]] types. In the
+  * following example, the width of `bar` will not be set and will be inferred by the FIRRTL compiler.
+  * {{{
+  * val foo = Reg(UInt(4.W))         // width is 4
+  * val bar = RegNext(foo)           // width is unset
+  * }}}
+  *
+  * If you desire an explicit width, do not use `RegNext` and instead use a register with a specified width:
+  * {{{
+  * val foo = Reg(UInt(4.W))         // width is 4
+  * val bar = Reg(chiselTypeOf(foo)) // width is 4
+  * bar := foo
+  * }}}
+  *
+  * Also note that a `RegNext` of a [[Bundle]] ''will have it's width set'' for [[Aggregate]] types.
+  * {{{
+  * class MyBundle extends Bundle {
+  *   val x = UInt(4.W)
+  * }
+  * val foo = Wire(new MyBundle)     // the width of foo.x is 4
+  * val bar = RegNext(foo)           // the width of bar.x is 4
+  * }}}
+  */
 object RegNext {
-  /** Returns a register with the specified next and no reset initialization.
-    *
-    * Essentially a 1-cycle delayed version of the input signal.
-    */
+  /** Returns a register ''with an unset width'' connected to the signal `next` and with no reset value. */
   def apply[T <: Data](next: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (next match {
       case next: Bits => next.cloneTypeWidth(Width())
@@ -66,10 +88,7 @@ object RegNext {
     reg
   }
 
-  /** Returns a register with the specified next and reset initialization.
-    *
-    * Essentially a 1-cycle delayed version of the input signal.
-    */
+  /** Returns a register ''with an unset width'' connected to the signal `next` and with the reset value `init`. */
   def apply[T <: Data](next: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val model = (next match {
       case next: Bits => next.cloneTypeWidth(Width())


### PR DESCRIPTION
Updates Scaladoc for RegNext to make it more clear about its behavior:

![RegNext](https://user-images.githubusercontent.com/1018530/73859118-8ade0b00-4807-11ea-8926-5e4b56367fd1.png)

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1311 

<!-- choose one -->
**Type of change**: documentation

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Add Scaladoc for RegNext about unset/inferred widths