### PR TITLE
Printf: Add support for tabs, and give helpful error messages

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Printf.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Printf.scala
@@ -26,7 +26,7 @@ object printf { // scalastyle:ignore object.name
         "\\n"
       } else if (x == '\t') {
         "\\t"
-      }else {
+      } else {
         require(x.toInt >= 32, s"char ${x} to Int ${x.toInt} must be >= 32") // TODO \xNN once FIRRTL issue #59 is resolved
         x
       }

--- a/chiselFrontend/src/main/scala/chisel3/Printf.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Printf.scala
@@ -19,13 +19,15 @@ object printf { // scalastyle:ignore object.name
     require(formatIn forall (c => c.toInt > 0 && c.toInt < 128),
       "format strings must comprise non-null ASCII values")
     def escaped(x: Char) = {
-      require(x.toInt >= 0)
+      require(x.toInt >= 0, s"char ${x} to Int ${x.toInt} must be >= 0")
       if (x == '"' || x == '\\') {
         s"\\${x}"
       } else if (x == '\n') {
         "\\n"
-      } else {
-        require(x.toInt >= 32) // TODO \xNN once FIRRTL issue #59 is resolved
+      } else if (x == '\t') {
+        "\\t"
+      }else {
+        require(x.toInt >= 32, s"char ${x} to Int ${x.toInt} must be >= 32") // TODO \xNN once FIRRTL issue #59 is resolved
         x
       }
     }

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -95,6 +95,16 @@ class PrintableSpec extends FlatSpec with Matchers {
       case e => fail()
     }
   }
+  it should "correctly emit tab" in {
+    class MyModule extends BasicTester {
+      printf(p"\t")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("\t", Seq())) =>
+      case e => fail()
+    }
+  }
   it should "support names of circuit elements including submodule IO" in {
     // Submodule IO is a subtle issue because the Chisel element has a different
     // parent module

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -101,7 +101,7 @@ class PrintableSpec extends FlatSpec with Matchers {
     }
     val firrtl = Driver.emit(() => new MyModule)
     getPrintfs(firrtl) match {
-      case Seq(Printf("\t", Seq())) =>
+      case Seq(Printf("\\t", Seq())) =>
       case e => fail()
     }
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
https://github.com/freechipsproject/chisel3/issues/1321

I added support for \t in printf. I also made the `require` statements give more information if you do something wrong which is how I figured out the tab was the problem.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Printables printf now supports \t characters.
