### PR TITLE
Clone child elements lazily in Vec

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Aggregate.scala
@@ -165,9 +165,12 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
   // Note: the constructor takes a gen() function instead of a Seq to enforce
   // that all elements must be the same and because it makes FIRRTL generation
   // simpler.
-  private val self: Seq[T] = Vector.fill(length)(gen)
-  for ((elt, i) <- self.zipWithIndex)
-    elt.setRef(this, i)
+  private lazy val self: Seq[T] = {
+    val _self = Vector.fill(length)(gen)
+    for ((elt, i) <- _self.zipWithIndex)
+      elt.setRef(this, i)
+    _self
+  }
 
   /**
   * sample_element 'tracks' all changes to the elements.


### PR DESCRIPTION
Credit to @aswaterman for this idea while we walked across Bordeaux at ORConf. We can lazily clone the elements of `Vecs` to improve performance. The key observation is that most clones are thrown away, so why do we bother creating more than just the `sample_element` for a `Vec` unless necessary?

This simple change has an absolutely **massive** performance impact on SiFive designs:

| Design | Runtime - master | Runtime - this branch |
| -- | -- | -- |
| Small | 108 seconds | 39 seconds |
| Large | 8 minutes | 3 minutes |

If anyone isn't convinced, try running the following:
```scala
object MyBundle {
  private var count = 0L
  def inc(): Unit = this.synchronized {
    count += 1
    println(s"Cloned $count times")
  }
}

class MyBundle extends Bundle {
  MyBundle.inc()
  val foo = UInt(8.W)
}

class MyModule extends Module {
  val io = IO(new Bundle {
    val in = Input(Vec(4, Vec(4, Vec(4, new MyBundle))))
  })
}

object MyMain extends App {
  chisel3.Driver.elaborate(() => new MyModule)
}
```

On master, you'll see:
```
[info] Cloned 4862 times
```
On this branch:
```
[info] Cloned 682 times
```

**Note that 682 times is kind of absurd.** I think there is so much more room for improvement, but this simple change is worth it on its own.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Improve performance by lazily cloning Vec elements
