### PR TITLE
Fix := of Reset and AsyncReset to DontCare

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/Bits.scala
@@ -989,7 +989,7 @@ final class ResetType(private[chisel3] val width: Width = Width(1)) extends Elem
     this.getClass == that.getClass
 
   override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = that match {
-    case _: Reset => super.connect(that)(sourceInfo, connectCompileOptions)
+    case _: Reset | DontCare => super.connect(that)(sourceInfo, connectCompileOptions)
     case _ => super.badConnect(that)(sourceInfo)
   }
 
@@ -1036,7 +1036,7 @@ sealed class AsyncReset(private[chisel3] val width: Width = Width(1)) extends El
     this.getClass == that.getClass
 
   override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = that match {
-    case _: AsyncReset => super.connect(that)(sourceInfo, connectCompileOptions)
+    case _: AsyncReset | DontCare => super.connect(that)(sourceInfo, connectCompileOptions)
     case _ => super.badConnect(that)(sourceInfo)
   }
 

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -119,9 +119,31 @@ class AsyncResetQueueTester extends BasicTester {
   }
 }
 
+class AsyncResetDontCareModule extends RawModule {
+  import chisel3.util.Valid
+  val monoPort = IO(Output(AsyncReset()))
+  monoPort := DontCare
+  val monoWire = Wire(AsyncReset())
+  monoWire := DontCare
+  val monoAggPort = IO(Output(Valid(AsyncReset())))
+  monoAggPort := DontCare
+  val monoAggWire = Wire(Valid(AsyncReset()))
+  monoAggWire := DontCare
+
+  // Can't bulk connect to Wire so only ports here
+  val bulkPort = IO(Output(AsyncReset()))
+  bulkPort <> DontCare
+  val bulkAggPort = IO(Output(Valid(AsyncReset())))
+  bulkAggPort <> DontCare
+}
+
 class AsyncResetSpec extends ChiselFlatSpec {
 
   behavior of "AsyncReset"
+
+  it should "be able to be connected to DontCare" in {
+    elaborate(new AsyncResetDontCareModule)
+  }
 
   it should "be allowed with literal reset values" in {
     elaborate(new BasicTester {

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -16,10 +16,32 @@ class ResetAgnosticModule extends RawModule {
   out := reg
 }
 
+class AbstractResetDontCareModule extends RawModule {
+  import chisel3.util.Valid
+  val monoPort = IO(Output(Reset()))
+  monoPort := DontCare
+  val monoWire = Wire(Reset())
+  monoWire := DontCare
+  val monoAggPort = IO(Output(Valid(Reset())))
+  monoAggPort := DontCare
+  val monoAggWire = Wire(Valid(Reset()))
+  monoAggWire := DontCare
+
+  // Can't bulk connect to Wire so only ports here
+  val bulkPort = IO(Output(Reset()))
+  bulkPort <> DontCare
+  val bulkAggPort = IO(Output(Valid(Reset())))
+  bulkAggPort <> DontCare
+}
+
 
 class ResetSpec extends ChiselFlatSpec {
 
   behavior of "Reset"
+
+  it should "be able to be connected to DontCare" in {
+    elaborate(new AbstractResetDontCareModule)
+  }
 
   it should "allow writing modules that are reset agnostic" in {
     val sync = compile(new Module {


### PR DESCRIPTION
Fix a bug where you couldn't monoconnect to `Reset()` nor `AsyncReset()`, and add tests.


**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition (no impact on existing code) (bugfix)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Fix bug where you couldn't `:=` `AsyncReset` and `Reset` to `DontCare`
