### PR TITLE
Upcoming Events: Remove CCC, add Dev Meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Upcoming Events
 
+Chisel/FIRRTL development meetings happen every Monday from 1100--1300 PT.
 
+Call-in info and meeting notes are available [here](https://docs.google.com/document/d/1Mpnqigmx6F8jdC77YWP3akp9H2V1bS1b2XiYjVX0brE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@
 
 ## Upcoming Events
 
-[The 3rd Chisel Community Conference (hosted by CHIPS Alliance) is happening on January 29--30, 2020!](https://events.linuxfoundation.org/chisel-community-conference/)
 
-We're [accepting talk proposals](https://events.linuxfoundation.org/chisel-community-conference/program/cfp/) for through December 12th.
-(*Acceptances are rolling, so if you have travel/visa requirements, get your submissions in!*)
-
-Make sure to [register](https://events.linuxfoundation.org/chisel-community-conference/register/) and attend to meet some other Chisel-ers and FIRRTL-ers!
 
 ---
 


### PR DESCRIPTION
Two changes:

- Removes the CCC20 as an "upcoming event"
- Adds Developer meetings with Google Docs link as upcoming event.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: documentation 

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.
