### PR TITLE
Patch fix #1109

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -49,8 +49,10 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
               " name is already taken by another port!")
           }
           port.setRef(ModuleIO(this, _namespace.name(name)))
-        case None => Builder.error(s"Unable to name port $port in $this, " +
-          "try making it a public field of the Module")
+        case None =>
+          Builder.error(s"Unable to name port $port in $this, " +
+            "try making it a public field of the Module")
+          port.setRef(ModuleIO(this, "<UNNAMED>"))
       }
     }
   }


### PR DESCRIPTION
This isn't a full fix, but it's an improvement of the status quo we've had for months.

Given something like:
```scala
import chisel3._

class MyModule extends RawModule {
  def func(): Unit = {
    val port = IO(Output(UInt(8.W))) //.suggestName("port")
    port := 3.U
  }
  func()
}

object MyMain extends App {
  println(chisel3.Driver.emit(() => new MyModule))
}
```

Currently, you get the following error:
```
[error] Exception in thread "main" java.lang.ClassCastException: chisel3.internal.firrtl.Ref cannot be cast to chisel3.internal.firrtl.ModuleIO
```

Pretty worthless. This PR changes the error to
```
[info] [error] RawModule.scala:53: Unable to name port UInt<8>(IO <UNNAMED> in MyModule) in MyModule@a67c67e, try making it a public field of the Module in class chisel3.RawModule
```

It does not pinpoint the error so I'm not going to call this a full fix, but at least it tells you something.

A better solution would come from adding source locators to ports such that we could then report the line. I think this is helpful enough to be worth merging without having to adopt that larger project.

**Related issue**: #1109 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Patch #1109 giving a better error message
