### PR TITLE
sbt compatible publish for mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -132,4 +132,6 @@ class chisel3CrossModule(crossVersionValue: String) extends CommonModule with Pu
       "-Xlint:infer-any"
     )
   }
+  // make mill publish sbt compatible package
+  def artifactName = "chisel3"
 }


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Currently mill will only publish in `~/.ivy2/local/edu.berkeley.cs/chisel3-2.12.10_2.12/3.3-SNAPSHOT/`, which is non-compatible to sbt build.
This patch will overwrite `artifactName` from `chisel3-$crossVersion_$artifactScalaVersion` to `chisel3-$artifactScalaVersion`, giving the same directory with sbt.