### PR TITLE
CompileOptions: allow the top module reset to be assumed as Async

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/CompileOptions.scala
@@ -22,7 +22,7 @@ trait CompileOptions {
   val explicitInvalidate: Boolean
   // Should the reset type of Module be a Bool or a Reset
   val inferModuleReset: Boolean
-  // Should the top module reset, if inferred, be an Async instead of a Bool?
+  // Should the top module reset be an Async instead of a Bool
   val topAsyncReset: Boolean
 }
 
@@ -55,7 +55,7 @@ object ExplicitCompileOptions {
     val explicitInvalidate: Boolean,
     // Should the reset type of Module be a Bool or a Reset
     val inferModuleReset: Boolean,
-    // Should the top module reset, if inferred, be a Async instead of Bool?
+    // Should the top module reset be a Async instead of Bool
     val topAsyncReset: Boolean
   ) extends CompileOptions
 

--- a/chiselFrontend/src/main/scala/chisel3/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/CompileOptions.scala
@@ -22,6 +22,8 @@ trait CompileOptions {
   val explicitInvalidate: Boolean
   // Should the reset type of Module be a Bool or a Reset
   val inferModuleReset: Boolean
+  // Should the top module reset, if inferred, be an Async instead of a Bool?
+  val topAsyncReset: Boolean
 }
 
 object CompileOptions {
@@ -52,7 +54,9 @@ object ExplicitCompileOptions {
     // Require an explicit DontCare assignment to generate a firrtl DefInvalid
     val explicitInvalidate: Boolean,
     // Should the reset type of Module be a Bool or a Reset
-    val inferModuleReset: Boolean
+    val inferModuleReset: Boolean,
+    // Should the top module reset, if inferred, be a Async instead of Bool?
+    val topAsyncReset: Boolean
   ) extends CompileOptions
 
   // Collection of "not strict" connection compile options.
@@ -64,7 +68,8 @@ object ExplicitCompileOptions {
     dontAssumeDirectionality = false,
     checkSynthesizable = false,
     explicitInvalidate = false,
-    inferModuleReset = false
+    inferModuleReset = false,
+    topAsyncReset = false
   )
 
   // Collection of "strict" connection compile options, preferred for new code.
@@ -75,6 +80,7 @@ object ExplicitCompileOptions {
     dontAssumeDirectionality = true,
     checkSynthesizable = true,
     explicitInvalidate = true,
-    inferModuleReset  = true
+    inferModuleReset  = true,
+    topAsyncReset = false
   )
 }

--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -151,7 +151,7 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
     val topAsyncReset = _parent.isEmpty && moduleCompileOptions.topAsyncReset
     IO(Input(if (inferReset) {
       Reset()
-    }else if (topAsyncReset) {
+    } else if (topAsyncReset) {
       AsyncReset()
     } else {
       Bool()

--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -148,7 +148,14 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
   val reset: Reset = {
     // Top module and compatibility mode use Bool for reset
     val inferReset = _parent.isDefined && moduleCompileOptions.inferModuleReset
-    IO(Input(if (inferReset) Reset() else Bool()))
+    val topAsyncReset = !_parent.isDefined && moduleCompileOptions.topAsyncReset
+    IO(Input(if (inferReset) {
+      Reset()
+    }else if (topAsyncReset) {
+      AsyncReset()
+    } else {
+      Bool()
+    }))
   }
 
   // Setup ClockAndReset

--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -148,7 +148,7 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
   val reset: Reset = {
     // Top module and compatibility mode use Bool for reset
     val inferReset = _parent.isDefined && moduleCompileOptions.inferModuleReset
-    val topAsyncReset = !_parent.isDefined && moduleCompileOptions.topAsyncReset
+    val topAsyncReset = _parent.isEmpty && moduleCompileOptions.topAsyncReset
     IO(Input(if (inferReset) {
       Reset()
     }else if (topAsyncReset) {


### PR DESCRIPTION
This PR adds an additional compile option which overrides the current behavior of always assuming that if you have `inferResets` option set, but top level module doesn't actually specify its reset type, then it assumes `Bool`. This lets you override that behavior.


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**:  https://github.com/freechipsproject/chisel3/issues/1355
Also related to https://github.com/freechipsproject/firrtl/issues/1406

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Additional field `topAsyncReset: Bool = false` added to `CompileOptions` which allows you to override the reset type for the top module.