### PR TITLE
Make implicit clock and reset final vals

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -144,8 +144,8 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
 abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
     extends RawModule {
   // Implicit clock and reset pins
-  val clock: Clock = IO(Input(Clock()))
-  val reset: Reset = {
+  final val clock: Clock = IO(Input(Clock()))
+  final val reset: Reset = {
     // Top module and compatibility mode use Bool for reset
     val inferReset = _parent.isDefined && moduleCompileOptions.inferModuleReset
     IO(Input(if (inferReset) Reset() else Bool()))


### PR DESCRIPTION
Overriding will always result in a `NullPointerException` due to https://github.com/freechipsproject/chisel3/blob/aac6e175645960b65eace70d16d0e4df523e0327/chiselFrontend/src/main/scala/chisel3/RawModule.scala#L155 which 

This is definitely not source compatible, so I don't think we should backport it. Although if someone is doing this it cannot be a Module they ever actually construct because it's `NullPointerException` 100% of the time.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Make implicit clock and reset final vals fixing buggy hole in API
