### PR TITLE
Provide API to set concrete type of implicit reset

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/RawModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/RawModule.scala
@@ -134,6 +134,14 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
   }
 }
 
+trait RequireAsyncReset extends MultiIOModule {
+  override private[chisel3] def mkReset: AsyncReset = AsyncReset()
+}
+
+trait RequireSyncReset extends MultiIOModule {
+  override private[chisel3] def mkReset: Bool = Bool()
+}
+
 /** Abstract base class for Modules, which behave much like Verilog modules.
   * These may contain both logic and state which are written in the Module
   * body (constructor).
@@ -145,10 +153,12 @@ abstract class MultiIOModule(implicit moduleCompileOptions: CompileOptions)
     extends RawModule {
   // Implicit clock and reset pins
   val clock: Clock = IO(Input(Clock()))
-  val reset: Reset = {
+  val reset: Reset = IO(Input(mkReset))
+
+  private[chisel3] def mkReset: Reset = {
     // Top module and compatibility mode use Bool for reset
     val inferReset = _parent.isDefined && moduleCompileOptions.inferModuleReset
-    IO(Input(if (inferReset) Reset() else Bool()))
+    if (inferReset) Reset() else Bool()
   }
 
   // Setup ClockAndReset

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -68,4 +68,28 @@ class ResetSpec extends ChiselFlatSpec {
     })
     async should include ("always @(posedge clk or posedge rst)")
   }
+
+  behavior of "Users"
+
+  they should "be able to force implicit reset to be synchronous" in {
+    val fir = generateFirrtl(new MultiIOModule with RequireSyncReset {
+      reset shouldBe a [Bool]
+    })
+    fir should include ("input reset : UInt<1>")
+  }
+
+  they should "be able to force implicit reset to be asynchronous" in {
+    val fir = generateFirrtl(new MultiIOModule with RequireAsyncReset {
+      reset shouldBe an [AsyncReset]
+    })
+    fir should include ("input reset : AsyncReset")
+  }
+
+  "Chisel" should "error if sync and async modules are nested" in {
+    a [ChiselException] shouldBe thrownBy {
+      elaborate(new MultiIOModule with RequireAsyncReset {
+        val mod = Module(new MultiIOModule with RequireSyncReset)
+      })
+    }
+  }
 }


### PR DESCRIPTION
Introduces mutually-exclusive traits RequireAsyncReset and
RequireSyncReset to set the type of the implicit reset in
MultiIOModules. The Scala-type remains Reset, but the Chisel
elaboration-time checks apply.

This implements my proposal from the Chisel Dev Meeting today (24 Feb 2020). In the notes this is the "subtractive" approach because `MultiIOModule` has an implicit reset of type `Reset` and these traits allow us to constrain the runtime type. There is an alternative "additive" approach that I still plan to prototype but I do think this is pretty slick and relatively intuitive.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal &  implementation

**Release Notes**
Add RequireAsyncReset and RequireSyncReset traits for setting type of implicit reset
