### PR TITLE
Retain default version assignment

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -8,6 +8,16 @@ import mill.contrib.buildinfo.BuildInfo
 
 object chisel3 extends mill.Cross[chisel3CrossModule]("2.11.12", "2.12.10") 
 
+// The following stanza is searched for and used when preparing releases.
+// Please retain it.
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map("firrtl" -> "1.3-SNAPSHOT")
+
+def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
+  val version = sys.env.getOrElse(dep + "Version", defaultVersions(dep))
+  ivy"$org::$dep:$version"
+}
+
 // Since chisel contains submodule chiselFrontend and coreMacros, a CommonModule is needed
 trait CommonModule extends ScalaModule with SbtModule with PublishModule {
   def firrtlModule: Option[PublishModule]
@@ -32,7 +42,7 @@ trait CommonModule extends ScalaModule with SbtModule with PublishModule {
   }
   
   def ivyDeps = if(firrtlModule.isEmpty) Agg(
-    ivy"edu.berkeley.cs::firrtl:1.3-SNAPSHOT",
+    getVersion("firrtl"),
   ) else Agg.empty[Dep]
 
   def moduleDeps = Seq() ++ firrtlModule


### PR DESCRIPTION
The release process uses python to scan and set expected versions for a release. The `val defaultVersions = ` stanza should be present for this to work.

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Restore the `defaultVersions` map to facilitate release generation and testing.
