### PR TITLE
Java API Documents Linking

### DIFF
--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -11,7 +11,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   import scala.language.implicitConversions
 
   /**
-    * These implicit classes allow one to convert scala.Int|scala.BigInt to
+    * These implicit classes allow one to convert [[scala.Int]] or [[scala.BigInt]] to
     * Chisel.UInt|Chisel.SInt by calling .asUInt|.asSInt on them, respectively.
     * The versions .asUInt(width)|.asSInt(width) are also available to explicitly
     * mark a width for the new literal.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -61,6 +61,7 @@ object Fill {
   /** Create n repetitions of x using a tree fanout topology.
     *
     * Output data-equivalent to x ## x ## ... ## x (n repetitions).
+    * @throws java.lang.IllegalArgumentException if `n` is less than zero
     */
   def apply(n: Int, x: UInt): UInt = {
     n match {


### PR DESCRIPTION
Three things:

1. This appends to the build.sbt apiMappings so that linking against Java API docs (for the appropriate version of Java) works. I reuse the same build.sbt from Scala upstream.
1. This shows an example of this working to link to a Java exception
1. This shows an example of this working to link to Scala main API docs (which already worked before this PR)

Example:

![chisel-scaladoc](https://user-images.githubusercontent.com/1018530/75802897-7e3bcc80-5d4b-11ea-9e3b-520ac364fb18.png)

This then links to:

![chisel-javadoc](https://user-images.githubusercontent.com/1018530/75802905-809e2680-5d4b-11ea-8333-6da4147d57f0.png)

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: documentation

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Scaladoc now can link against Javadoc
