### PR TITLE
[mergify] Update match string for labeling backported PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,7 +43,7 @@ pull_request_rules:
   - name: label Mergify backport PR
     conditions:
       - base=3.2.x
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify.io
+      - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:
         add: [Backport]


### PR DESCRIPTION
See freechipsproject/firrtl#1439.

This fixes the rule to apply the "Backport" label (which is a prerequisite for the no-review merge) after some upstream changes in the mergify engine.