### PR TITLE
adding dshlw to test

### DIFF
--- a/src/test/scala/chiselTests/util/OverprovisionWidthsSpec.scala
+++ b/src/test/scala/chiselTests/util/OverprovisionWidthsSpec.scala
@@ -12,10 +12,12 @@ class OverprovisionWidthsSpec extends ChiselFlatSpec {
   class Top(param: String) extends Module {
     val io = IO(new Bundle{
       val in = Input(UInt(3.W))
+      val shamt = Input(UInt(2.W))
       val out = Output(UInt())
     })
     val mid = Module(new Middle(param))
     mid.io.middlein := io.in
+    mid.io.shamt := io.shamt
     io.out := mid.io.middleout
     // Overprovisioning from the parent works as well
     if(param == "Top") {
@@ -27,6 +29,7 @@ class OverprovisionWidthsSpec extends ChiselFlatSpec {
   class Middle(param: String) extends Module {
     val io = IO(new Bundle{
       val middlein = Input(UInt(3.W))
+      val shamt = Input(UInt(2.W))
       val middleout = Output(UInt())
     })
     val bot = Module(new Bottom)
@@ -35,7 +38,7 @@ class OverprovisionWidthsSpec extends ChiselFlatSpec {
     val intermediate = Wire(UInt(3.W))
 
     intermediate := bot.io.botout
-    io.middleout := intermediate
+    io.middleout := intermediate << io.shamt
 
     if(param == "Middle") {
       overprovision(io.middlein, 10.W)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1337 

<!-- choose one -->
**Type of change**: bug report
I made some test changes that were meant to test `dshlw` with overprovisioning, but I ran into the following error:
```
firrtl.EmitterException: Can't emit firrtl.ir.DoPrim as PrimOp argument
```

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
