### PR TITLE
Change BundleLiteral to RecordLiteral

### DIFF
--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -130,7 +130,7 @@ package object experimental {  // scalastyle:ignore object.name
   trait NoChiselNamePrefix
 
   object BundleLiterals {
-    implicit class AddBundleLiteralConstructor[T <: Bundle](x: T) {
+    implicit class AddBundleLiteralConstructor[T <: Record](x: T) {
       //scalastyle:off method.name
       def Lit(elems: (T => (Data, Data))*): T = {
         x._makeLit(elems: _*)

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental._
 import chisel3.experimental.BundleLiterals._
 import chisel3.testers.BasicTester
+import scala.collection.immutable.ListMap
 
 class LiteralExtractorSpec extends ChiselFlatSpec {
   "litValue" should "return the literal value" in {
@@ -137,5 +138,19 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     assert(myBundleLiteral.a.litValue == 42)
     assert(myBundleLiteral.b.litValue == 1)
     assert(myBundleLiteral.b.litToBoolean == true)
+  }
+
+  "record literals" should "do the right thing" in {
+    class MyRecord extends Record{
+      override val elements = ListMap(
+        "a" -> UInt(8.W),
+        "b" -> Bool()
+      )
+      override def cloneType = (new MyRecord).asInstanceOf[this.type]
+    }
+
+    val myRecordLiteral = new (MyRecord).Lit(_.elements("a") -> 42.U, _.elements("b") -> true.B)
+    assert(myRecordLiteral.elements("a").litValue == 42)
+    assert(myRecordLiteral.elements("b").litValue == 1)
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**

Since RocketChip use `Record` for `AutoBunlde` and diplomatic bundles like `TLBundle`, if we need to test RocketChip with native chisel tester, we should allow `Lit` to `Record`. 
This PR changes all `BundleLiterals` to `RecordLiterals`, which enables `Lit` method for `Record`, and deprecate original `BundleLiterals`, it won't affect existing code, and enalbe peek/poke for Diplomatic Bundle in chiseltester.

<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->