### PR TITLE
expose typeEquivalent

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -131,7 +131,16 @@ package experimental {
       target.direction
     }
 
-    /** check two data type is equal.
+    /** Check if two Chisel types are the same type.
+      * Internally, this is dispatched to each Chisel type's
+      * `typeEquivalent` function for each type to determine
+      * if the types are intended to be equal.
+      *
+      * For most types, different parameters should ensure
+      * that the types are different.
+      * For example, `UInt(8.W)` and `UInt(16.W)` are different.
+      * Likewise, Records check that both Records have the same
+      * elements with the same types.
       *
       * @param x first data type
       * @param y second data type

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -142,9 +142,9 @@ package experimental {
       * Likewise, Records check that both Records have the same
       * elements with the same types.
       *
-      * @param x first data type
-      * @param y second data type
-      * @return true if two data type is equal.
+      * @param x First Chisel type
+      * @param y Second Chisel type
+      * @return true if the two Chisel types are equal.
       **/
     def checkTypeEquivalence(x: Data, y: Data): Boolean = x.typeEquivalent(y)
 

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -130,6 +130,7 @@ package experimental {
       requireIsHardware(target, "node requested directionality on")
       target.direction
     }
+    def checkTypeEquivalence(x: Data, y: Data): Boolean = x.typeEquivalent(y)
 
     // Returns the top-level module ports
     // TODO: maybe move to something like Driver or DriverUtils, since this is mainly for interacting

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -130,6 +130,13 @@ package experimental {
       requireIsHardware(target, "node requested directionality on")
       target.direction
     }
+
+    /** check two data type is equal.
+      *
+      * @param x first data type
+      * @param y second data type
+      * @return true if two data type is equal.
+      **/
     def checkTypeEquivalence(x: Data, y: Data): Boolean = x.typeEquivalent(y)
 
     // Returns the top-level module ports

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -99,6 +99,14 @@ trait RecordSpecUtils {
     assert(wire("0").asUInt === 123.U)
     stop()
   }
+
+  class RecordTypeTester extends BasicTester {
+    val wire0 = Wire(new CustomBundle("0"-> UInt(32.W)))
+    val wire1 = Reg(new CustomBundle("0"-> UInt(32.W)))
+    val wire2 = Wire(new CustomBundle("1"-> UInt(32.W)))
+    require(DataMirror.checkTypeEquivalence(wire0, wire1))
+    require(!DataMirror.checkTypeEquivalence(wire1, wire2))
+  }
 }
 
 class RecordSpec extends ChiselFlatSpec with RecordSpecUtils {
@@ -145,5 +153,9 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils {
       val wire = Wire(gen)
       io := wire
     })
+  }
+
+  "CustomBundle" should "check the types" in {
+    elaborate { new RecordTypeTester }
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
This PR expose typeEquivalent method to DataMirror for compile time reflection to Data Type, it can help chiseltester with more strict `peek`/`poke` constraint.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->