### PR TITLE
Switch to HowToSerialize for Emission

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -231,7 +231,8 @@ object Driver extends BackendCompilationUtilities {
            Dependency[DriverCompatibility.FirrtlPreprocessing],
            Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
     val currentState =
-      Seq( Dependency[firrtl.stage.phases.DriverCompatibility.AddImplicitFirrtlFile] )
+      Seq( Dependency[firrtl.stage.phases.DriverCompatibility.AddImplicitFirrtlFile],
+           Dependency[chisel3.stage.phases.Convert] )
 
     val phases: Seq[Phase] = new PhaseManager(targets, currentState) {
       override val wrappers = Seq( DeletedWrapper(_: Phase) )

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -115,7 +115,7 @@ case class ChiselCircuitAnnotation(circuit: Circuit)
 
   protected def suffix: Option[String] = Some(".fir")
 
-  override def toBytes: Iterable[Byte] = OldEmitter.emit(circuit).toBytes
+  override def getBytes: Iterable[Byte] = OldEmitter.emit(circuit).getBytes
 
 }
 

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -3,20 +3,26 @@
 package chisel3.stage
 
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, OptionsException, ShellOption, Unserializable}
+import firrtl.options.{CustomFileEmission, HasShellOptions, OptionsException, ShellOption, StageOptions, Unserializable}
+import firrtl.options.Viewer.view
 import chisel3.{ChiselException, Module}
 import chisel3.RawModule
 import chisel3.internal.Builder
-import chisel3.internal.firrtl.Circuit
+import chisel3.internal.firrtl.{Circuit, Emitter => OldEmitter}
 import firrtl.AnnotationSeq
+import java.io.File
 
 /** Mixin that indicates that this is an [[firrtl.annotations.Annotation]] used to generate a [[ChiselOptions]] view.
   */
-sealed trait ChiselOption extends Unserializable { this: Annotation => }
+sealed trait ChiselOption { this: Annotation => }
 
 /** Disable the execution of the FIRRTL compiler by Chisel
   */
-case object NoRunFirrtlCompilerAnnotation extends NoTargetAnnotation with ChiselOption with HasShellOptions {
+case object NoRunFirrtlCompilerAnnotation
+    extends NoTargetAnnotation
+    with ChiselOption
+    with HasShellOptions
+    with Unserializable {
 
   val options = Seq(
     new ShellOption[Unit](
@@ -29,7 +35,11 @@ case object NoRunFirrtlCompilerAnnotation extends NoTargetAnnotation with Chisel
 
 /** On an exception, this will cause the full stack trace to be printed as opposed to a pruned stack trace.
   */
-case object PrintFullStackTraceAnnotation extends NoTargetAnnotation with ChiselOption with HasShellOptions {
+case object PrintFullStackTraceAnnotation
+    extends NoTargetAnnotation
+    with ChiselOption
+    with HasShellOptions
+    with Unserializable {
 
   val options = Seq(
     new ShellOption[Unit](
@@ -90,14 +100,26 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
 /** Stores a Chisel Circuit
   * @param circuit a Chisel Circuit
   */
-case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption {
+case class ChiselCircuitAnnotation(circuit: Circuit)
+    extends NoTargetAnnotation
+    with ChiselOption
+    with CustomFileEmission {
   /* Caching the hashCode for a large circuit is necessary due to repeated queries.
    * Not caching the hashCode will cause severe performance degredations for large [[Circuit]]s.
    */
   override lazy val hashCode: Int = circuit.hashCode
+
+  protected def baseFileName(annotations: AnnotationSeq): String = {
+    view[ChiselOptions](annotations).outputFile.getOrElse(circuit.name)
+  }
+
+  protected def suffix: Option[String] = Some(".fir")
+
+  override def toBytes: Iterable[Byte] = OldEmitter.emit(circuit).toBytes
+
 }
 
-case class ChiselOutputFileAnnotation(file: String) extends NoTargetAnnotation with ChiselOption
+case class ChiselOutputFileAnnotation(file: String) extends NoTargetAnnotation with ChiselOption with Unserializable
 
 object ChiselOutputFileAnnotation extends HasShellOptions {
 

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -82,7 +82,7 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
 
     execute(Array("-X", "high") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
       .collectFirst {
-        case DeletedAnnotation(_, EmittedFirrtlCircuitAnnotation(a)) => a
+        case EmittedFirrtlCircuitAnnotation(a) => a
       }
       .get
       .value
@@ -102,7 +102,7 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
 
     execute(Array("-X", "verilog") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
       .collectFirst {
-        case DeletedAnnotation(_, EmittedVerilogCircuitAnnotation(a)) => a
+        case EmittedVerilogCircuitAnnotation(a) => a
       }
       .get
       .value

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -3,7 +3,6 @@
 package chisel3.stage
 
 import firrtl.{ir => fir, AnnotationSeq, EmittedFirrtlCircuitAnnotation, EmittedVerilogCircuitAnnotation}
-import firrtl.annotations.DeletedAnnotation
 import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageError, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlCli}
@@ -23,7 +22,6 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
          Dependency[chisel3.stage.phases.AddImplicitOutputFile],
          Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
          Dependency[chisel3.stage.phases.MaybeAspectPhase],
-         Dependency[chisel3.stage.phases.Emitter],
          Dependency[chisel3.stage.phases.Convert],
          Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
 
@@ -60,12 +58,15 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
     args: Array[String] = Array.empty,
     annotations: AnnotationSeq = Seq.empty): String = {
 
-    execute(Array("-X", "none") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
+    val annos = execute(Array("--no-run-firrtl") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
+
+    annos
       .collectFirst {
-        case DeletedAnnotation(_, EmittedFirrtlCircuitAnnotation(a)) => a
+        case a: ChiselCircuitAnnotation => a.toBytes.get
       }
       .get
-      .value
+      .map(_.toChar)
+      .mkString
 
   }
 
@@ -121,7 +122,7 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
 
     execute(Array("-X", "sverilog") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
       .collectFirst {
-        case DeletedAnnotation(_, EmittedVerilogCircuitAnnotation(a)) => a
+        case EmittedVerilogCircuitAnnotation(a) => a
       }
       .get
       .value

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -62,7 +62,7 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
 
     annos
       .collectFirst {
-        case a: ChiselCircuitAnnotation => a.toBytes.get
+        case a: ChiselCircuitAnnotation => a.getBytes
       }
       .get
       .map(_.toChar)

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -3,11 +3,9 @@
 package chisel3
 
 import firrtl._
-import firrtl.annotations.DeletedAnnotation
 import firrtl.options.OptionsView
 
 import chisel3.internal.firrtl.{Circuit => ChiselCircuit}
-import chisel3.stage.phases.{Convert, Emitter}
 
 package object stage {
 
@@ -28,17 +26,14 @@ package object stage {
 
   private[chisel3] implicit object ChiselExecutionResultView extends OptionsView[ChiselExecutionResult] {
 
-    lazy val dummyConvert = new Convert
-    lazy val dummyEmitter = new Emitter
-
     def view(options: AnnotationSeq): ChiselExecutionResult = {
       var chiselCircuit: Option[ChiselCircuit] = None
       var chirrtlCircuit: Option[String] = None
 
       options.foreach {
-        case DeletedAnnotation(dummyConvert.name, ChiselCircuitAnnotation(a)) => chiselCircuit = Some(a)
-        case DeletedAnnotation(dummyEmitter.name, EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit(_, a, _))) =>
-          chirrtlCircuit = Some(a)
+        case a@ ChiselCircuitAnnotation(b) =>
+          chiselCircuit = Some(b)
+          chirrtlCircuit = a.toBytes.map(_.map(_.toChar).mkString)
         case _ =>
       }
 

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -33,7 +33,7 @@ package object stage {
       options.foreach {
         case a@ ChiselCircuitAnnotation(b) =>
           chiselCircuit = Some(b)
-          chirrtlCircuit = a.toBytes.map(_.map(_.toChar).mkString)
+          chirrtlCircuit = Some(a.getBytes.map(_.toChar).mkString)
         case _ =>
       }
 

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -20,6 +20,7 @@ class Convert extends Phase with PreservesAll[Phase] {
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>
+      Some(a) ++
       /* Convert this Chisel Circuit to a FIRRTL Circuit */
       Some(FirrtlCircuitAnnotation(Converter.convert(a.circuit))) ++
       /* Convert all Chisel Annotations to FIRRTL Annotations */

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -78,7 +78,7 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
       .execute(Array("--target-dir", createTestDirectory(this.getClass.getSimpleName).toString),
                Seq(ChiselGeneratorAnnotation(() => t)))
       .collectFirst {
-        case DeletedAnnotation(_, EmittedVerilogCircuitAnnotation(a)) => a.value
+        case EmittedVerilogCircuitAnnotation(a) => a.value
       }.getOrElse(fail("No Verilog circuit was emitted by the FIRRTL compiler!"))
   }
 }

--- a/src/test/scala/chiselTests/MuxSpec.scala
+++ b/src/test/scala/chiselTests/MuxSpec.scala
@@ -38,7 +38,7 @@ class MuxLookupWrapper(keyWidth: Int, default: Int, mapping: () => Seq[(UInt, UI
 class MuxLookupExhaustiveSpec extends ChiselPropSpec {
   val keyWidth = 2
   val default = 9 // must be less than 10 to avoid hex/decimal mismatches
-  val firrtlLit = s"""UInt<4>("h$default")"""
+  val firrtlLit = s"""UInt<4>("h0$default")"""
   val stage = new ChiselStage
 
   // Assumes there are no literals with 'UInt<4>("h09")' in the output FIRRTL


### PR DESCRIPTION
This removes the `chisel3.stage.phases.Emitter` and moves its emission logic into the `ChiselCircuitAnnotation`. This uses the new `HowToSerialize` mix-in provided by https://github.com/freechipsproject/firrtl/pull/1277. 

A consequence of this is that there is no longer a need for generating `DeletedAnnotation`s and for introspection of `DeletedAnnotation`s to determine an execution result or a view of some sequence of annotations.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Depends on https://github.com/freechipsproject/firrtl/pull/1277

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
