### PR TITLE
Have phases.Emitter name phases.Convert as a dependent

### DIFF
--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -30,6 +30,8 @@ class Emitter extends Phase {
          Dependency[AddImplicitOutputAnnotationFile],
          Dependency[MaybeAspectPhase] )
 
+  override val dependents = Seq(Dependency[Convert])
+
   override def invalidates(phase: Phase): Boolean = phase match {
     case _: Elaborate => true
     case _ => false


### PR DESCRIPTION
This must be prefaced with i'm not at all sure this is the correct solution...

That said, under the current ordering constraints, the phase manager might elect to schedule the convert phase before the emitter phase, which removes the chisel circuit annotation before it can be processed by the emitter. Really i'm using dependent here more in "make-sure-i-run-before" sense, i'm not sure that's the right idea.

The underlying problem here is that certain phases need to run at some point during the lifetime of specific annotations and often it's not clear what that lifetime is, short of reading each phase. If an annotation is going to be used by multiple consumer passes, some of which might be outside of chisel's control, it may make sense to dedicate an entire pass to the removal of certain annotations if we choose to remove them at all (ie. RemoveChiselCircuitAnnotationPhase) -- after all, another possible fix here is simply not to delete the annotation (and potentially mark it so it is not serialized). 

**Type of change**: bug report 

**Impact**: no functional change

**Release Notes**

Have the emitter Phase name the Convert phase as a dependent.
