### PR TITLE
Report Builder.error errors as exceptions outside hardware context

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -387,7 +387,13 @@ private[chisel3] object Builder {
   }
 
   def errors: ErrorLog = dynamicContext.errors
-  def error(m: => String): Unit = if (dynamicContextVar.value.isDefined) errors.error(m)
+  def error(m: => String): Unit = {
+    if (dynamicContextVar.value.isDefined) {
+      errors.error(m)
+    } else {
+      throwException(m)
+    }
+  }
   def warning(m: => String): Unit = if (dynamicContextVar.value.isDefined) errors.warning(m)
   def deprecated(m: => String, location: Option[String] = None): Unit =
     if (dynamicContextVar.value.isDefined) errors.deprecated(m, location)

--- a/src/test/scala/chiselTests/ImplicitConversionsSpec.scala
+++ b/src/test/scala/chiselTests/ImplicitConversionsSpec.scala
@@ -39,5 +39,10 @@ class ImplicitConversionsSpec extends ChiselFlatSpec {
     import chisel3.util._
     assertTypeError("Decoupled(UInt(8.W)).target")
   }
-}
 
+  "X.B for X not in [0,1]" should "throw an exception, even outside hardware context" in {
+    a [ChiselException] should be thrownBy {
+      65.B
+    }
+  }
+}


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: no functional change
**Development Phase**: implementation
**Release Notes**
Some errors that were previously hidden when calling Chisel API methods outside of an active hardware generation context (see #1422) will now be immediately thrown as exception.