### PR TITLE
Fix Double Elaboration Backportably

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -20,7 +20,6 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
 
   val targets: Seq[Dependency[Phase]] =
     Seq( Dependency[chisel3.stage.phases.Checks],
-         Dependency[chisel3.stage.phases.Elaborate],
          Dependency[chisel3.stage.phases.AddImplicitOutputFile],
          Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
          Dependency[chisel3.stage.phases.MaybeAspectPhase],

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -28,11 +28,12 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
          Dependency[chisel3.stage.phases.Convert],
          Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
 
+  final lazy val phaseManager = new PhaseManager(targets) {
+    override val wrappers = Seq( (a: Phase) => DeletedWrapper(a) )
+  }
+
   def run(annotations: AnnotationSeq): AnnotationSeq = try {
-    new PhaseManager(targets) { override val wrappers = Seq( (a: Phase) => DeletedWrapper(a) ) }
-      .transformOrder
-      .map(firrtl.options.phases.DeletedWrapper(_))
-      .foldLeft(annotations)( (a, f) => f.transform(a) )
+    phaseManager.transform(annotations)
   } catch {
     case ce: ChiselException =>
       val stackTrace = if (!view[ChiselOptions](annotations).printFullStackTrace) {

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -30,10 +30,9 @@ class Emitter extends Phase {
          Dependency[AddImplicitOutputAnnotationFile],
          Dependency[MaybeAspectPhase] )
 
-  override def invalidates(phase: Phase): Boolean = phase match {
-    case _: Elaborate => true
-    case _ => false
-  }
+  override def optionalPrerequisiteOf = Seq(Dependency[Convert])
+
+  override def invalidates(phase: Phase): Boolean = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val copts = view[ChiselOptions](annotations)

--- a/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
@@ -8,6 +8,8 @@ import chisel3.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import firrtl.options.Dependency
+
 object ChiselStageSpec {
 
   class Foo extends MultiIOModule {
@@ -55,6 +57,17 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers {
 
   it should "generate a CHIRRTL circuit from a Chisel module" in {
     ChiselStage.convert(new Foo)
+  }
+
+  behavior of "ChiselStage phase ordering"
+
+  it should "only run elaboration once" in new ChiselStageFixture {
+    info("Phase order is:\n" + stage.phaseManager.prettyPrint("    "))
+
+    val order = stage.phaseManager.flattenedTransformOrder.map(Dependency.fromTransform)
+
+    info("Elaborate only runs once")
+    exactly (1, order) should be (Dependency[chisel3.stage.phases.Elaborate])
   }
 
 }


### PR DESCRIPTION
This is a replacement for #1412 that also fixes the double elaboration problem in a backwards compatible way. This PR does the following things:

1. It removes the requirement that `Elaborate` run in `ChiselStage` (you don't care that elaboration ran and wasn't invalidated)
2. It removes the invalidation of `Elaborate` by the `Emitter` (the emitter doesn't touch any annotations)
3. It adds an `optionalPrerequisiteOf` from `Emitter` -> `Convert` to get the correct ordering (this is @davidbiancolin's #1412)

To test this, this adds:

4. An API expansion where `ChiselStage` exposes it's phase manager
5. It adds a test that elaboration runs once by looking at this phase manager

When running `ChiselStage`, you now get the following phase order:

```
[info] - should only run elaboration once
[info]   + Phase order is:
[info]     chisel3.stage.ChiselStage$$anon$2
[info]     ├── chisel3.stage.phases.Checks
[info]     ├── chisel3.stage.phases.Elaborate
[info]     ├── chisel3.stage.phases.AddImplicitOutputFile
[info]     ├── chisel3.stage.phases.AddImplicitOutputAnnotationFile
[info]     ├── chisel3.stage.phases.MaybeAspectPhase
[info]     ├── chisel3.stage.phases.Emitter
[info]     ├── chisel3.stage.phases.Convert
[info]     └── chisel3.stage.phases.MaybeFirrtlStage
```

This cannot fix the bug where `Convert` should invalidate `Elaborate` due to the use of `PreservesAll`. Mixing in `PreservesAll` or removing it from being mixed in is backwards incompatible and should probably be killed 1.4. :grimacing: 

Closes #1412 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1412, #1418

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
