### PR TITLE
make run function more composable

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -31,7 +31,12 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
     override val wrappers = Seq( (a: Phase) => DeletedWrapper(a) )
   }
 
-  def run(annotations: AnnotationSeq): AnnotationSeq = try {
+  def run(annotations: AnnotationSeq): AnnotationSeq = run(annotations, shell, targets, phaseManager)
+
+  def run(annotations: AnnotationSeq,
+          shell: Shell,
+          targets: Seq[Dependency[Phase]],
+          phaseManager: PhaseManager): AnnotationSeq = try {
     phaseManager.transform(annotations)
   } catch {
     case ce: ChiselException =>


### PR DESCRIPTION
Could I get this onto `3.3.x` so I can use it in rocket chip, please?

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/chipsalliance/rocket-chip/issues/2467

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This allows for `ChiselStage`'s `run` function to be called externally. For example, from `RocketStage`.
