### PR TITLE
Queue with flip flop output

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -322,7 +322,7 @@ object Queue
       entries: Int = 2,
       pipe: Boolean = false,
       flow: Boolean = false,
-      muxOut: Boolean = true): DecoupledIO[T] = {
+      muxOut: Boolean = false): DecoupledIO[T] = {
     if (entries == 0) {
       val deq = Wire(new DecoupledIO(chiselTypeOf(enq.bits)))
       deq.valid := enq.valid


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None<!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Chisel Queue class is used for various purposes
(data buffering, cutting critical path, register slicing)

But sometimes it is not enough because it's output is MUX output.
Deep Queue could make data-critical-path.
This PR proposes to make the Queue's output flip-flop without function changing.
I believe that even the operation timing is not changed.
https://app.lucidchart.com/documents/edit/691dc934-c928-4f8a-8153-91eb09e6571f/0_0
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
