### PR TITLE
verilator_4_016 --> v4.016

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,7 @@ Note that both [PeekPokeTester](https://github.com/freechipsproject/chisel-teste
     3.  In the Verilator repository directory, check out a known good version:	
         ```	
         git pull	
-        git checkout verilator_4_016	
+        git checkout v4.016	
         ```
 
     4.  In the Verilator repository directory, build and install:	


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Branch verilator_4_016 does not exist anymore.
<!-- choose one -->
**Type of change**: documentation

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: proposal 

**Release Notes**
It seems Verilator creators changed the way they organize their branches/version in their repository, so instead of the branch verilator_4_016, there is a version v4.016 now.

