### PR TITLE
Builder: use LazyLogging.logger.warn to print elaboration message

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -9,6 +9,7 @@ import chisel3.experimental._
 import chisel3.internal.firrtl._
 import chisel3.internal.naming._
 import _root_.firrtl.annotations.{CircuitName, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
+import logger.LazyLogging
 
 import scala.collection.mutable
 
@@ -223,7 +224,7 @@ private[chisel3] class DynamicContext() {
 }
 
 //scalastyle:off number.of.methods
-private[chisel3] object Builder {
+private[chisel3] object Builder extends LazyLogging {
   // All global mutable state must be referenced via dynamicContextVar!!
   private val dynamicContextVar = new DynamicVariable[Option[DynamicContext]](None)
   private def dynamicContext: DynamicContext = {
@@ -410,11 +411,11 @@ private[chisel3] object Builder {
 
   def build[T <: RawModule](f: => T): (Circuit, T) = {
     dynamicContextVar.withValue(Some(new DynamicContext())) {
-      errors.info("Elaborating design...")
+      logger.warn("Elaborating design...")
       val mod = f
       mod.forceName(mod.name, globalNamespace)
       errors.checkpoint()
-      errors.info("Done elaborating.")
+      logger.warn("Done elaborating.")
 
       (Circuit(components.last.name, components, annotations), mod)
     }

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -101,10 +101,6 @@ private[chisel3] class ErrorLog {
   def warning(m: => String): Unit =
     errors += new Warning(m, getUserLineNumber)
 
-  /** Emit an informational message */
-  def info(m: String): Unit =
-    println(new Info("[%2.3f] %s".format(elapsedTime/1e3, m), None))  // scalastyle:ignore regex
-
   /** Log a deprecation warning message */
   def deprecated(m: => String, location: Option[String]): Unit = {
     val sourceLoc = location match {


### PR DESCRIPTION
This is supposed to make it possible to disable the "Elaborating design..." output by setting the log level to error.

As @jackkoenig suggested in https://github.com/freechipsproject/firrtl/issues/1680#issuecomment-642186707 this uses `logger.warn` instead of `logger.info`.

I am not entirely sure how exactly `LazyLogging` determines the log level...
@jackkoenig or @seldridge am I using the logger correctly?

fixes https://github.com/freechipsproject/chisel3/issues/1473