### PR TITLE
Remove Deprecated Usages of chisel3.Driver, CircuitForm

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -61,6 +61,7 @@ trait BackendCompilationUtilities extends FirrtlBackendCompilationUtilities {
 /**
   * This family provides return values from the chisel3 and possibly firrtl compile steps
   */
+@deprecated("This will be removed in Chisel 3.5", "Chisel3 3.4")
 trait ChiselExecutionResult
 
 /**
@@ -69,6 +70,7 @@ trait ChiselExecutionResult
   * @param emitted            The emitted Chirrrl text
   * @param firrtlResultOption Optional Firrtl result, @see freechipsproject/firrtl for details
   */
+@deprecated("This will be removed in Chisel 3.5", "Chisel 3.4")
 case class ChiselExecutionSuccess(
                                   circuitOption: Option[Circuit],
                                   emitted: String,
@@ -80,6 +82,7 @@ case class ChiselExecutionSuccess(
   *
   * @param message A clue might be provided here.
   */
+@deprecated("This will be removed in Chisel 3.5", "Chisel 3.4")
 case class ChiselExecutionFailure(message: String) extends ChiselExecutionResult
 
 @deprecated("Please switch to chisel3.stage.ChiselStage. Driver will be removed in 3.4.", "3.2.4")

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -405,7 +405,7 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
     private var target_dir: Option[String] = None
 
     private def parseArgs(args: Array[String]): Unit = {
-      for (i <- 0 until args.size) {
+      for (i <- args.indices) {
         if (args(i) == "--targetDir") {
           target_dir = Some(args(i + 1))
         }

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -186,7 +186,7 @@ private class Emitter(circuit: Circuit) {
   private def withIndent(f: => Unit) { indent(); f; unindent() }
 
   private val res = new StringBuilder()
-  res ++= s";${Driver.chiselVersionString}\n"
+  res ++= s";${BuildInfo.toString}\n"
   res ++= s"circuit ${circuit.name} : "
   withIndent { circuit.components.foreach(c => res ++= emit(c)) }
   res ++= newline

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util._
 import chisel3.testers.BasicTester
 import chisel3.experimental.{Analog, attach, BaseModule}
@@ -82,12 +83,12 @@ abstract class AnalogTester extends BasicTester {
     assert(reader.out === BusValue)
 }
 
-class AnalogSpec extends ChiselFlatSpec {
+class AnalogSpec extends ChiselFlatSpec with Utils {
   behavior of "Analog"
 
   it should "NOT be bindable to registers" in {
-    a [ChiselException] should be thrownBy {
-      elaborate { new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {})
         val reg = Reg(Analog(32.W))
       }}
@@ -95,15 +96,15 @@ class AnalogSpec extends ChiselFlatSpec {
   }
 
   it should "NOT be bindable to a direction" in {
-    a [ChiselException] should be thrownBy {
-      elaborate { new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {
           val a = Input(Analog(32.W))
         })
       }}
     }
-    a [ChiselException] should be thrownBy {
-      elaborate { new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {
           val a = Output(Analog(32.W))
         })
@@ -112,7 +113,7 @@ class AnalogSpec extends ChiselFlatSpec {
   }
 
   it should "be flippable" in {
-    elaborate { new Module {
+    ChiselStage.elaborate { new Module {
       val io = IO(new Bundle {
         val a = Flipped(Analog(32.W))
       })
@@ -122,8 +123,8 @@ class AnalogSpec extends ChiselFlatSpec {
   // There is no binding on the type of a memory
   // Should this be an error?
   ignore should "NOT be a legal type for Mem" in {
-    a [ChiselException] should be thrownBy {
-      elaborate { new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {})
         val mem = Mem(16, Analog(32.W))
       }}
@@ -131,8 +132,8 @@ class AnalogSpec extends ChiselFlatSpec {
   }
 
   it should "NOT be bindable to Mem ports" in {
-    a [ChiselException] should be thrownBy {
-      elaborate { new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {})
         val mem = Mem(16, Analog(32.W))
         val port = mem(5.U)
@@ -161,16 +162,16 @@ class AnalogSpec extends ChiselFlatSpec {
   }
 
   it should "error if any bulk connected more than once" in {
-    a [ChiselException] should be thrownBy {
-      elaborate(new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(3)(Wire(Analog(32.W)))
         wires(0) <> wires(1)
         wires(0) <> wires(2)
       })
     }
-    a [ChiselException] should be thrownBy {
-      elaborate(new Module {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(2)(Wire(Analog(32.W)))
         wires(0) <> DontCare
@@ -180,13 +181,13 @@ class AnalogSpec extends ChiselFlatSpec {
   }
 
   it should "allow DontCare connection" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val a = Analog(1.W)
       })
       io.a := DontCare
     })
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val a = Analog(1.W)
       })
@@ -199,14 +200,14 @@ class AnalogSpec extends ChiselFlatSpec {
       val x = Input(UInt(8.W))
       val y = Analog(8.W)
     }
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val a = new MyBundle
       })
       val w = Wire(new MyBundle)
       w <> io.a
     })
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val a = Vec(1, new MyBundle)
       })
@@ -295,4 +296,3 @@ class AnalogSpec extends ChiselFlatSpec {
     }, Seq("/chisel3/AnalogBlackBox.v"))
   }
 }
-

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -4,7 +4,8 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.doNotDedup
-import firrtl.FirrtlExecutionSuccess
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
+import firrtl.stage.FirrtlCircuitAnnotation
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -41,33 +42,34 @@ class UsesMuchUsedModule(addAnnos: Boolean) extends Module {
 }
 
 class AnnotationNoDedup extends AnyFreeSpec with Matchers {
+  val stage = new ChiselStage
   // scalastyle:off line.size.limit
   "Firrtl provides transform that reduces identical modules to a single instance" - {
     "Annotations can be added which will prevent this deduplication for specific modules instances" in {
-      Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new UsesMuchUsedModule(addAnnos = true)) match {
-        case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
-          val lowFirrtl = firrtlResult.emitted
-
-          lowFirrtl should include ("module MuchUsedModule :")
-          lowFirrtl should include ("module MuchUsedModule_1 :")
-          lowFirrtl should include ("module MuchUsedModule_3 :")
-          lowFirrtl should not include "module MuchUsedModule_2 :"
-          lowFirrtl should not include "module MuchUsedModule_4 :"
-        case _ =>
-      }
+      val lowFirrtl = stage
+        .execute(Array("-X", "low", "--target-dir", "test_run_dir"),
+                 Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule(addAnnos = true))))
+        .collectFirst {
+          case FirrtlCircuitAnnotation(circuit) => circuit.serialize
+        }.getOrElse(fail)
+      lowFirrtl should include ("module MuchUsedModule :")
+      lowFirrtl should include ("module MuchUsedModule_1 :")
+      lowFirrtl should include ("module MuchUsedModule_3 :")
+      lowFirrtl should not include "module MuchUsedModule_2 :"
+      lowFirrtl should not include "module MuchUsedModule_4 :"
     }
     "Turning off these annotations dedups all the occurrences" in {
-      Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new UsesMuchUsedModule(addAnnos = false)) match {
-        case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
-          val lowFirrtl = firrtlResult.emitted
-
-          lowFirrtl should include ("module MuchUsedModule :")
-          lowFirrtl should not include "module MuchUsedModule_1 :"
-          lowFirrtl should not include "module MuchUsedModule_3 :"
-          lowFirrtl should not include "module MuchUsedModule_2 :"
-          lowFirrtl should not include "module MuchUsedModule_4 :"
-        case _ =>
-      }
+      val lowFirrtl = stage
+        .execute(Array("-X", "low", "--target-dir", "test_run_dir"),
+                 Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule(addAnnos = false))))
+        .collectFirst {
+          case FirrtlCircuitAnnotation(circuit) => circuit.serialize
+        }.getOrElse(fail)
+      lowFirrtl should include ("module MuchUsedModule :")
+      lowFirrtl should not include "module MuchUsedModule_1 :"
+      lowFirrtl should not include "module MuchUsedModule_3 :"
+      lowFirrtl should not include "module MuchUsedModule_2 :"
+      lowFirrtl should not include "module MuchUsedModule_4 :"
     }
   }
   // scalastyle:on line.size.limit

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
 
@@ -60,7 +61,7 @@ class BadUnescapedPercentAssertTester extends BasicTester {
   stop()
 }
 
-class AssertSpec extends ChiselFlatSpec {
+class AssertSpec extends ChiselFlatSpec with Utils {
   "A failing assertion" should "fail the testbench" in {
     assert(!runTester{ new FailingAssertTester })
   }
@@ -78,7 +79,9 @@ class AssertSpec extends ChiselFlatSpec {
   }
   they should "not allow unescaped % in the message" in {
     a [java.util.UnknownFormatConversionException] should be thrownBy {
-      elaborate { new BadUnescapedPercentAssertTester }
+      extractCause[java.util.UnknownFormatConversionException] {
+        ChiselStage.elaborate { new BadUnescapedPercentAssertTester }
+      }
     }
   }
 }

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.{Counter, Queue}
 import chisel3.testers.BasicTester
 import firrtl.checks.CheckResets.NonLiteralAsyncResetValueException
@@ -137,22 +138,22 @@ class AsyncResetDontCareModule extends RawModule {
   bulkAggPort <> DontCare
 }
 
-class AsyncResetSpec extends ChiselFlatSpec {
+class AsyncResetSpec extends ChiselFlatSpec with Utils {
 
   behavior of "AsyncReset"
 
   it should "be able to be connected to DontCare" in {
-    elaborate(new AsyncResetDontCareModule)
+    ChiselStage.elaborate(new AsyncResetDontCareModule)
   }
 
   it should "be allowed with literal reset values" in {
-    elaborate(new BasicTester {
+    ChiselStage.elaborate(new BasicTester {
       withReset(reset.asAsyncReset)(RegInit(123.U))
     })
   }
 
   it should "NOT be allowed with non-literal reset values" in {
-    a [NonLiteralAsyncResetValueException] shouldBe thrownBy {
+    a [NonLiteralAsyncResetValueException] should be thrownBy extractCause[NonLiteralAsyncResetValueException] {
       compile(new BasicTester {
         val x = WireInit(123.U + 456.U)
         withReset(reset.asAsyncReset)(RegInit(x))
@@ -161,8 +162,8 @@ class AsyncResetSpec extends ChiselFlatSpec {
   }
 
   it should "NOT be allowed to connect directly to a Bool" in {
-    a [ChiselException] shouldBe thrownBy {
-      elaborate(new BasicTester {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new BasicTester {
         val bool = Wire(Bool())
         val areset = reset.asAsyncReset
         bool := areset
@@ -179,7 +180,7 @@ class AsyncResetSpec extends ChiselFlatSpec {
   }
 
   it should "allow casting to and from Bool" in {
-    elaborate(new BasicTester {
+    ChiselStage.elaborate(new BasicTester {
       val r: Reset = reset
       val a: AsyncReset = WireInit(r.asAsyncReset)
       val b: Bool = a.asBool

--- a/src/test/scala/chiselTests/BetterNamingTests.scala
+++ b/src/test/scala/chiselTests/BetterNamingTests.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util._
 
 import scala.collection.mutable
@@ -63,19 +64,19 @@ class BetterNamingTests extends ChiselFlatSpec {
 
   it should "provide unique counters for each name" in {
     var module: PerNameIndexing = null
-    elaborate { module = new PerNameIndexing(4); module }
+    ChiselStage.elaborate { module = new PerNameIndexing(4); module }
     assert(module.getNameFailures() == Nil)
   }
 
   it should "provide names for things defined in Iterable[HasId] and Option[HasId]" in {
     var module: IterableNaming = null
-    elaborate { module = new IterableNaming; module }
+    ChiselStage.elaborate { module = new IterableNaming; module }
     assert(module.getNameFailures() == Nil)
   }
 
   it should "allow digits to be field names in Records" in {
     var module: DigitFieldNamesInRecord  = null
-    elaborate { module = new DigitFieldNamesInRecord; module }
+    ChiselStage.elaborate { module = new DigitFieldNamesInRecord; module }
     assert(module.getNameFailures() == Nil)
   }
 
@@ -87,8 +88,9 @@ class BetterNamingTests extends ChiselFlatSpec {
       }
       WireDefault(3.U)
     }
-    val withLits = chisel3.Driver.emit(() => new MyModule(true))
-    val noLits = chisel3.Driver.emit(() => new MyModule(false))
+    val stage = new ChiselStage
+    val withLits = stage.emitChirrtl(new MyModule(true))
+    val noLits = stage.emitChirrtl(new MyModule(false))
     withLits should equal (noLits)
   }
 }

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
 
@@ -169,7 +170,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
         Seq("/chisel3/BlackBoxTest.v"))
   }
   "DataMirror.modulePorts" should "work with BlackBox" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle { })
       val m = Module(new BlackBoxPassthrough)
       assert(DataMirror.modulePorts(m) == Seq(

--- a/src/test/scala/chiselTests/BlackBoxImpl.scala
+++ b/src/test/scala/chiselTests/BlackBoxImpl.scala
@@ -6,6 +6,7 @@ import java.io.File
 
 import chisel3._
 import chisel3.util.{HasBlackBoxInline, HasBlackBoxResource, HasBlackBoxPath}
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import firrtl.FirrtlExecutionSuccess
 import org.scalacheck.Test.Failed
 import org.scalatest.Succeeded
@@ -91,39 +92,29 @@ class UsesBlackBoxMinusViaPath extends Module {
 
 class BlackBoxImplSpec extends AnyFreeSpec with Matchers {
   val targetDir = "test_run_dir"
+  val stage = new ChiselStage
   "BlackBox can have verilator source implementation" - {
     "Implementations can be contained in-line" in {
-      Driver.execute(Array("-X", "verilog", "--target-dir", targetDir), () => new UsesBlackBoxAddViaInline) match {
-        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val verilogOutput = new File(targetDir, "BlackBoxAdd.v")
-          verilogOutput.exists() should be (true)
-          verilogOutput.delete()
-          Succeeded
-        case _ =>
-          Failed
-      }
+      stage.execute(Array("-X", "verilog", "--target-dir", targetDir),
+                    Seq(ChiselGeneratorAnnotation(() => new UsesBlackBoxAddViaInline)))
+      val verilogOutput = new File(targetDir, "BlackBoxAdd.v")
+      verilogOutput.exists() should be (true)
+      verilogOutput.delete()
     }
     "Implementations can be contained in resource files" in {
-      Driver.execute(Array("-X", "low", "--target-dir", targetDir), () => new UsesBlackBoxMinusViaResource) match {
-        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val verilogOutput = new File(targetDir, "BlackBoxTest.v")
-          verilogOutput.exists() should be (true)
-          verilogOutput.delete()
-          Succeeded
-        case _ =>
-          Failed
-      }
+      stage.execute(Array("-X", "low", "--target-dir", targetDir),
+                    Seq(ChiselGeneratorAnnotation(() => new UsesBlackBoxMinusViaResource)))
+      val verilogOutput = new File(targetDir, "BlackBoxTest.v")
+      verilogOutput.exists() should be (true)
+      verilogOutput.delete()
     }
     "Implementations can be contained in arbitrary files" in {
-      Driver.execute(Array("-X", "low", "--target-dir", targetDir), () => new UsesBlackBoxMinusViaPath) match {
-        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
-          val verilogOutput = new File(targetDir, "BlackBoxTest.v")
-          verilogOutput.exists() should be (true)
-          verilogOutput.delete()
-          Succeeded
-        case _ =>
-          Failed
-      }
+      stage.execute(Array("-X", "low", "--target-dir", targetDir),
+                    Seq(ChiselGeneratorAnnotation(() => new UsesBlackBoxMinusViaPath)))
+      val verilogOutput = new File(targetDir, "BlackBoxTest.v")
+      verilogOutput.exists() should be (true)
+      verilogOutput.delete()
+      Succeeded
     }
   }
 }

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 trait BundleSpecUtils {
@@ -55,9 +56,9 @@ trait BundleSpecUtils {
   }
 }
 
-class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
+class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
   "Bundles with the same fields but in different orders" should "bulk connect" in {
-    elaborate { new MyModule(new BundleFooBar, new BundleBarFoo) }
+    ChiselStage.elaborate { new MyModule(new BundleFooBar, new BundleBarFoo) }
   }
 
   "Bundles" should "follow UInt serialization/deserialization API" in {
@@ -65,18 +66,18 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
   }
 
   "Bulk connect on Bundles" should "check that the fields match" in {
-    (the [ChiselException] thrownBy {
-      elaborate { new MyModule(new BundleFooBar, new BundleFoo) }
+    (the [ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new MyModule(new BundleFooBar, new BundleFoo) }
     }).getMessage should include ("Right Record missing field")
 
-    (the [ChiselException] thrownBy {
-      elaborate { new MyModule(new BundleFoo, new BundleFooBar) }
+    (the [ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new MyModule(new BundleFoo, new BundleFooBar) }
     }).getMessage should include ("Left Record missing field")
   }
 
   "Bundles" should "not be able to use Seq for constructing hardware" in {
-    (the[ChiselException] thrownBy {
-      elaborate {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate {
         new Module {
           val io = IO(new Bundle {
             val b = new BadSeqBundle
@@ -116,8 +117,8 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils {
   }
 
   "Bundles" should "not have aliased fields" in {
-    (the[ChiselException] thrownBy {
-      elaborate { new Module {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(Output(new Bundle {
           val a = UInt(8.W)
           val b = a

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -270,11 +270,19 @@ trait Utils {
     }
   }
 
-  /** Run some code extracting an exception cause that matches a type parameter
+  /** Run some code and rethrow an exception with a specific type if an exception of that type occurs anywhere in the
+    * stack trace.
+    *
+    * This is useful for "extracting" one exception that may be wrapped by other exceptions.
+    *
+    * Example usage:
+    * {{{
+    * a [ChiselException] should be thrownBy extractCause[ChiselException] { /* ... */ }
+    * }}}
+    *
     * @param thunk some code to run
-    * @tparam A the type of the exception to expect
+    * @tparam A the type of the exception to extract
     * @return nothing
-    * @throws the exception of type parameter A if it was found
     */
   def extractCause[A <: Throwable : ClassTag](thunk: => Any): Unit = {
     def unrollCauses(a: Throwable): Seq[Throwable] = a match {

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class ClockAsUIntTester extends BasicTester {
@@ -30,7 +31,7 @@ class ClockSpec extends ChiselPropSpec {
   }
 
   property("Should be able to use withClock in a module with no reset") {
-    val circuit = Driver.emit { () => new WithClockAndNoReset }
+    val circuit = (new ChiselStage).emitChirrtl(new WithClockAndNoReset)
     circuit.contains("reg a : UInt<1>, clock2") should be (true)
   }
 }

--- a/src/test/scala/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala/chiselTests/CloneModuleSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.{Queue, EnqIO, DeqIO, QueueIO, log2Ceil}
 import chisel3.experimental.{CloneModuleAsRecord, IO}
 import chisel3.testers.BasicTester
@@ -71,7 +72,7 @@ class CloneModuleSpec extends ChiselPropSpec {
   }
 
   property("QueueClone's cloned queues should share the same module") {
-    val c = Driver.toFirrtl(Driver.elaborate(() => new QueueClone))
+    val c = ChiselStage.convert(new QueueClone)
     assert(c.modules.length == 2)
   }
 
@@ -82,7 +83,7 @@ class CloneModuleSpec extends ChiselPropSpec {
   }
 
   property("Clones of MultiIOModules should share the same module") {
-    val c = Driver.toFirrtl(Driver.elaborate(() => new QueueClone(multiIO=true)))
+    val c = ChiselStage.convert(new QueueClone(multiIO=true))
     assert(c.modules.length == 3)
   }
 

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -2,6 +2,7 @@
 
 package chiselTests
 
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 import org.scalacheck.Gen
@@ -17,13 +18,13 @@ object CompatibilityCustomCompileOptions {
   }
 }
 
-class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks {
+class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks with Utils {
   import Chisel._
 
   behavior of "Chisel compatibility layer"
 
   it should "accept direction arguments" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       // Choose a random direction
       val directionArgument: Direction = Gen.oneOf(INPUT, OUTPUT, NODIR).sample.get
       val expectedDirection = directionArgument match {
@@ -126,7 +127,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       Valid(data) shouldBe a [ValidIO[UInt]]
       Pipe(Wire(Valid(data)), 2) shouldBe a [ValidIO[UInt]]
     }
-    elaborate { new Dummy }
+    ChiselStage.elaborate { new Dummy }
   }
   // Verify we can elaborate a design expressed in Chisel2
   class Chisel2CompatibleRisc extends Module {
@@ -178,11 +179,11 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
   }
 
   it should "Chisel2CompatibleRisc should elaborate" in {
-    elaborate { new Chisel2CompatibleRisc }
+    ChiselStage.elaborate { new Chisel2CompatibleRisc }
   }
 
   it should "not try to assign directions to Analog" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = new Bundle {
         val port = chisel3.experimental.Analog(32.W)
       }
@@ -210,7 +211,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       }
       io.out := io.in
     }
-    elaborate { new ConnectFieldMismatchModule() }
+    ChiselStage.elaborate { new ConnectFieldMismatchModule() }
   }
 
   "A Module in which a Reg is created with a bound type when compiled with the Chisel compatibility package" should "not throw an exception" in {
@@ -222,7 +223,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       }
       val badReg = Reg(UInt(7, width=4))
     }
-    elaborate { new CreateRegFromBoundTypeModule() }
+    ChiselStage.elaborate { new CreateRegFromBoundTypeModule() }
   }
 
   "A Module with unwrapped IO when compiled with the Chisel compatibility package" should "not throw an exception" in {
@@ -234,7 +235,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       }
       io.out := io.in(1)
     }
-    elaborate { new RequireIOWrapModule() }
+    ChiselStage.elaborate { new RequireIOWrapModule() }
   }
 
   "A Module connecting output as source to input as sink when compiled with the Chisel compatibility package" should "not throw an exception" in {
@@ -249,7 +250,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       val child = Module(new SimpleModule)
       io.in := child.io.out
     }
-    elaborate { new SwappedConnectionModule() }
+    ChiselStage.elaborate { new SwappedConnectionModule() }
   }
 
   "A Module with directionless connections when compiled with the Chisel compatibility package" should "not throw an exception" in {
@@ -268,12 +269,12 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       val child = Module(new SimpleModule)
       b := child.noDir
     }
-    elaborate { new DirectionLessConnectionModule() }
+    ChiselStage.elaborate { new DirectionLessConnectionModule() }
   }
 
   "Vec ports" should "give default directions to children so they can be used in chisel3.util" in {
     import Chisel._
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = new Bundle {
         val in = Vec(1, UInt(width = 8)).flip
         val out = UInt(width = 8)
@@ -284,7 +285,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
 
   "Reset" should "still walk, talk, and quack like a Bool" in {
     import Chisel._
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = new Bundle {
         val in = Bool(INPUT)
         val out = Bool(OUTPUT)
@@ -295,7 +296,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
 
   "Data.dir" should "give the correct direction for io" in {
     import Chisel._
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = (new Bundle {
         val foo = Bool(OUTPUT)
         val bar = Bool().flip
@@ -308,8 +309,8 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
   // Note: This is a regression (see https://github.com/freechipsproject/chisel3/issues/668)
   it should "fail for Chisel types" in {
     import Chisel._
-    an [chisel3.ExpectedHardwareException] should be thrownBy {
-      elaborate(new Module {
+    an [chisel3.ExpectedHardwareException] should be thrownBy extractCause[chisel3.ExpectedHardwareException] {
+      ChiselStage.elaborate(new Module {
         val io = new Bundle { }
         UInt(INPUT).dir
       })
@@ -318,7 +319,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
 
   "Mux return value" should "be able to be used on the RHS" in {
     import Chisel._
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val gen = new Bundle { val foo = UInt(width = 8) }
       val io = new Bundle {
         val a = Vec(2, UInt(width = 8)).asInput
@@ -336,7 +337,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
 
   "Chisel3 IO constructs" should "be useable in Chisel2" in {
     import Chisel._
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val in = Input(Bool())
         val foo = Output(Bool())
@@ -366,7 +367,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       // (UInt(4) != bp) shouldBe a [Bool]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Enum"
@@ -389,7 +390,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       }.getMessage should include ("Bit width may no longer be specified for enums")
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Queue"
@@ -405,7 +406,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       val explicit = Module(new Queue(UInt(), 4, false, false, Bool(true)))
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "LFSR16"
@@ -424,7 +425,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       lfsr.getWidth should be (16)
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Mem"
@@ -442,7 +443,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       memInt shouldBe a [Mem[SInt]]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "SeqMem"
@@ -460,7 +461,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       seqMemInt shouldBe a [SeqMem[UInt]]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "debug"
@@ -473,7 +474,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       debug(data)
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Data methods"
@@ -491,7 +492,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       Vec.fill(4)(wire).toBits.getWidth should be (wire.getWidth * 4)
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Wire"
@@ -513,7 +514,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       third shouldBe a [UInt]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "Vec"
@@ -562,7 +563,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       UInt(1).toBool shouldBe a [Bool]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "UInt"
@@ -575,7 +576,7 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       (UInt(1) != UInt(1)) shouldBe a [Bool]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   behavior of "SInt"
@@ -588,13 +589,13 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
       (SInt(-1) != SInt(-1)) shouldBe a [Bool]
     }
 
-    elaborate(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   it should "properly propagate custom compileOptions in Chisel.Module" in {
     import CompatibilityCustomCompileOptions._
     var result: Foo = null
-    elaborate({result = new Foo; result})
+    ChiselStage.elaborate({result = new Foo; result})
     result.compileOptions should be theSameInstanceAs (customCompileOptions)
   }
 

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -4,8 +4,9 @@ package chiselTests
 
 import chisel3._
 import chisel3.CompileOptions._
+import chisel3.stage.ChiselStage
 
-class CompileOptionsSpec extends ChiselFlatSpec {
+class CompileOptionsSpec extends ChiselFlatSpec with Utils {
 
   abstract class StrictModule extends Module()(chisel3.ExplicitCompileOptions.Strict)
   abstract class NotStrictModule extends Module()(chisel3.ExplicitCompileOptions.NotStrict)
@@ -22,7 +23,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
 
   // scalastyle:off line.size.limit
   "A Module with missing bundle fields when compiled with implicit Strict.CompileOption " should "throw an exception" in {
-    a [ChiselException] should be thrownBy {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
       import chisel3.ExplicitCompileOptions.Strict
 
       class ConnectFieldMismatchModule extends Module {
@@ -32,7 +33,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         })
         io.out := io.in
       }
-      elaborate { new ConnectFieldMismatchModule() }
+      ChiselStage.elaborate { new ConnectFieldMismatchModule() }
     }
   }
 
@@ -46,11 +47,11 @@ class CompileOptionsSpec extends ChiselFlatSpec {
       })
       io.out := io.in
     }
-    elaborate { new ConnectFieldMismatchModule() }
+    ChiselStage.elaborate { new ConnectFieldMismatchModule() }
   }
 
   "A Module in which a Reg is created with a bound type when compiled with implicit Strict.CompileOption " should "throw an exception" in {
-    a [BindingException] should be thrownBy {
+    a [BindingException] should be thrownBy extractCause[BindingException] {
       import chisel3.ExplicitCompileOptions.Strict
 
       class CreateRegFromBoundTypeModule extends Module {
@@ -60,7 +61,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         })
         val badReg = Reg(7.U(4.W))
       }
-      elaborate { new CreateRegFromBoundTypeModule() }
+      ChiselStage.elaborate { new CreateRegFromBoundTypeModule() }
     }
   }
 
@@ -74,7 +75,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
       })
       val badReg = Reg(7.U(4.W))
     }
-    elaborate { new CreateRegFromBoundTypeModule() }
+    ChiselStage.elaborate { new CreateRegFromBoundTypeModule() }
   }
 
   "A Module with wrapped IO when compiled with implicit Strict.CompileOption " should "not throw an exception" in {
@@ -87,11 +88,11 @@ class CompileOptionsSpec extends ChiselFlatSpec {
       })
       io.out := io.in(1)
     }
-    elaborate { new RequireIOWrapModule() }
+    ChiselStage.elaborate { new RequireIOWrapModule() }
   }
 
   "A Module with unwrapped IO when compiled with implicit Strict.CompileOption " should "throw an exception" in {
-    a [BindingException] should be thrownBy {
+    a [BindingException] should be thrownBy extractCause[BindingException] {
       import chisel3.ExplicitCompileOptions.Strict
 
       class RequireIOWrapModule extends Module {
@@ -101,14 +102,14 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         }
         io.out := io.in(1)
       }
-      elaborate {
+      ChiselStage.elaborate {
         new RequireIOWrapModule()
       }
     }
   }
 
   "A Module connecting output as source to input as sink when compiled with implicit Strict.CompileOption " should "throw an exception" in {
-    a [ChiselException] should be thrownBy {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
       import chisel3.ExplicitCompileOptions.Strict
 
       class SimpleModule extends Module {
@@ -121,7 +122,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         val child = Module(new SimpleModule)
         io.in := child.io.out
       }
-      elaborate { new SwappedConnectionModule() }
+      ChiselStage.elaborate { new SwappedConnectionModule() }
     }
   }
 
@@ -138,11 +139,11 @@ class CompileOptionsSpec extends ChiselFlatSpec {
       val child = Module(new SimpleModule)
       io.in := child.io.out
     }
-    elaborate { new SwappedConnectionModule() }
+    ChiselStage.elaborate { new SwappedConnectionModule() }
   }
 
   "A Module with directionless connections when compiled with implicit Strict.CompileOption " should "throw an exception" in {
-    a [ChiselException] should be thrownBy {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
       // Verify we can suppress the inclusion of default compileOptions
       import Chisel.{defaultCompileOptions => _}
       import chisel3.ExplicitCompileOptions.Strict
@@ -161,7 +162,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         val child = Module(new SimpleModule)
         b := child.noDir
       }
-      elaborate { new DirectionLessConnectionModule() }
+      ChiselStage.elaborate { new DirectionLessConnectionModule() }
     }
   }
 
@@ -182,7 +183,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
       val child = Module(new SimpleModule)
       b := child.noDir
     }
-    elaborate { new DirectionLessConnectionModule() }
+    ChiselStage.elaborate { new DirectionLessConnectionModule() }
   }
   // scalastyle:on line.size.limit
 }

--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.{Analog, FixedPoint}
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 abstract class CrossCheck extends Bundle {
@@ -36,65 +37,93 @@ class CrossConnectTester(inType: Data, outType: Data) extends BasicTester {
   stop()
 }
 
-class ConnectSpec extends ChiselPropSpec {
+class ConnectSpec extends ChiselPropSpec with Utils {
   property("SInt := SInt should succeed") {
     assertTesterPasses{ new CrossConnectTester(SInt(16.W), SInt(16.W)) }
   }
   property("SInt := UInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), SInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(UInt(16.W), SInt(16.W)) } } }
   }
   property("SInt := FixedPoint should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } } }
   }
   property("UInt := UInt should succeed") {
     assertTesterPasses{ new CrossConnectTester(UInt(16.W), UInt(16.W)) }
   }
   property("UInt := SInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), UInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(SInt(16.W), UInt(16.W)) } } }
   }
   property("UInt := FixedPoint should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), UInt(16.W)) } } }
   }
 
   property("Clock := Clock should succeed") {
     assertTesterPasses{ new CrossConnectTester(Clock(), Clock()) }
   }
   property("Clock := UInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(Clock(), UInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(Clock(), UInt(16.W)) } } }
   }
 
   property("FixedPoint := FixedPoint should succeed") {
     assertTesterPasses{ new CrossConnectTester(FixedPoint(16.W, 8.BP), FixedPoint(16.W, 8.BP)) }
   }
   property("FixedPoint := SInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), FixedPoint(16.W, 8.BP)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(SInt(16.W), FixedPoint(16.W, 8.BP)) } } }
   }
   property("FixedPoint := UInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), FixedPoint(16.W, 8.BP)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(UInt(16.W), FixedPoint(16.W, 8.BP)) } } }
   }
 
   property("Analog := Analog should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), Analog(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), Analog(16.W)) } } }
   }
   property("Analog := FixedPoint should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), FixedPoint(16.W, 8.BP)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), FixedPoint(16.W, 8.BP)) } } }
   }
   property("FixedPoint := Analog should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), Analog(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(FixedPoint(16.W, 8.BP), Analog(16.W)) } } }
   }
   property("Analog := UInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), UInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), UInt(16.W)) } } }
   }
   property("Analog := SInt should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(Analog(16.W), SInt(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), SInt(16.W)) } } }
   }
   property("UInt := Analog should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(UInt(16.W), Analog(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(UInt(16.W), Analog(16.W)) } } }
   }
   property("SInt := Analog should fail") {
-    intercept[ChiselException]{ elaborate { new CrossConnectTester(SInt(16.W), Analog(16.W)) } }
+    intercept[ChiselException]{
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new CrossConnectTester(SInt(16.W), Analog(16.W)) } } }
   }
   property("Pipe internal connections should succeed") {
-    elaborate( new PipeInternalWires)
+    ChiselStage.elaborate( new PipeInternalWires)
   }
 }

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -7,6 +7,7 @@ import org.scalatest._
 import chisel3._
 import chisel3.experimental.{ChiselEnum, FixedPoint}
 import chisel3.experimental.BundleLiterals._
+import chisel3.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers
 
 class DataPrintSpec extends ChiselFlatSpec with Matchers {
@@ -20,7 +21,7 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   }
 
   "Data types" should "have a meaningful string representation" in {
-    elaborate { new RawModule {
+    ChiselStage.elaborate { new RawModule {
       UInt().toString should be ("UInt")
       UInt(8.W).toString should be ("UInt<8>")
       SInt(15.W).toString should be ("SInt<15>")
@@ -54,11 +55,11 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   }
 
   "Bound data types" should "have a meaningful string representation" in {
-    elaborate { new BoundDataModule }
+    ChiselStage.elaborate { new BoundDataModule }
   }
 
   "Literals" should "have a meaningful string representation" in {
-    elaborate { new RawModule {
+    ChiselStage.elaborate { new RawModule {
       3.U.toString should be ("UInt<2>(3)")
       3.U(5.W).toString should be ("UInt<5>(3)")
       -1.S.toString should be ("SInt<1>(-1)")

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -3,11 +3,12 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.Decoupled
 
 class DecoupledSpec extends ChiselFlatSpec {
   "Decoupled() and Decoupled.empty" should "give DecoupledIO with empty payloads" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val in = Flipped(Decoupled())
         val out = Decoupled.empty

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 
 class HasDeadCodeChild(withDontTouch: Boolean) extends Module {
   val io = IO(new Bundle {
@@ -31,7 +32,7 @@ class HasDeadCode(withDontTouch: Boolean) extends Module {
   }
 }
 
-class DontTouchSpec extends ChiselFlatSpec {
+class DontTouchSpec extends ChiselFlatSpec with Utils{
   val deadSignals = List(
     "io_c_0",
     "io_c_1",
@@ -50,12 +51,11 @@ class DontTouchSpec extends ChiselFlatSpec {
     }
   }
   "Dont touch" should "only work on bound hardware" in {
-    a [chisel3.BindingException] should be thrownBy {
-      elaborate(new Module {
+    a [chisel3.BindingException] should be thrownBy extractCause[BindingException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle { })
         dontTouch(new Bundle { val a = UInt(32.W) } )
       })
     }
   }
 }
-

--- a/src/test/scala/chiselTests/EnableShiftRegister.scala
+++ b/src/test/scala/chiselTests/EnableShiftRegister.scala
@@ -2,6 +2,7 @@
 
 package chiselTests
 import chisel3._
+import chisel3.stage.ChiselStage
 
 class EnableShiftRegister extends Module {
   val io = IO(new Bundle {
@@ -47,7 +48,7 @@ class EnableShiftRegisterTester(c: EnableShiftRegister) extends Tester(c) {
 class EnableShiftRegisterSpec extends ChiselPropSpec {
 
   property("EnableShiftRegister should elaborate") {
-    elaborate { new EnableShiftRegister }
+    ChiselStage.elaborate { new EnableShiftRegister }
   }
 
   ignore("EnableShiftRegisterTester should return the correct result") { }

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 // Avoid collisions with regular BlackBox tests by putting ExtModule blackboxes
@@ -68,7 +69,7 @@ class ExtModuleSpec extends ChiselFlatSpec {
         Seq("/chisel3/BlackBoxTest.v"))
   }
   "DataMirror.modulePorts" should "work with ExtModule" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle { })
       val m = Module(new ExtModule.BlackBoxPassthrough)
       assert(DataMirror.modulePorts(m) == Seq(

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.internal.firrtl.{BinaryPoint, Width}
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -148,7 +149,7 @@ class FixedPointLitExtractTester extends BasicTester {
   stop()
 }
 
-class FixedPointSpec extends ChiselPropSpec {
+class FixedPointSpec extends ChiselPropSpec with Utils {
   property("should allow set binary point") {
     assertTesterPasses { new SBPTester }
   }
@@ -159,7 +160,9 @@ class FixedPointSpec extends ChiselPropSpec {
     assertTesterPasses { new FixedPointMuxTester }
   }
   property("Negative shift amounts are invalid") {
-    a [ChiselException] should be thrownBy { elaborate(new NegativeShift(FixedPoint(1.W, 0.BP))) }
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new NegativeShift(FixedPoint(1.W, 0.BP)))
+    }
   }
   property("Bit extraction on literals should work for all non-negative indices") {
     assertTesterPasses(new FixedPointLitExtractTester)

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class GCD extends Module {
@@ -47,7 +48,7 @@ class GCDSpec extends ChiselPropSpec {
     ( 48,  64,  16))
 
   property("GCD should elaborate") {
-    elaborate { new GCD }
+    ChiselStage.elaborate { new GCD }
   }
 
   property("GCDTester should return the correct result") {

--- a/src/test/scala/chiselTests/IOCompatibility.scala
+++ b/src/test/scala/chiselTests/IOCompatibility.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 
@@ -35,14 +36,14 @@ class IOCModuleWire extends Module {
   io.out := inc.out
 }
 
-class IOCompatibilitySpec extends ChiselPropSpec with Matchers {
+class IOCompatibilitySpec extends ChiselPropSpec with Matchers with Utils {
 
   property("IOCModuleVec should elaborate") {
-    elaborate { new IOCModuleVec(2) }
+    ChiselStage.elaborate { new IOCModuleVec(2) }
   }
 
   property("IOCModuleWire should elaborate") {
-    elaborate { new IOCModuleWire }
+    ChiselStage.elaborate { new IOCModuleWire }
   }
 
 
@@ -52,8 +53,8 @@ class IOCompatibilitySpec extends ChiselPropSpec with Matchers {
   }
 
   property("Unwrapped IO should generate an exception") {
-    a [BindingException] should be thrownBy {
-      elaborate(new IOUnwrapped)
+    a [BindingException] should be thrownBy extractCause[BindingException] {
+      ChiselStage.elaborate(new IOUnwrapped)
     }
   }
 }

--- a/src/test/scala/chiselTests/InlineSpec.scala
+++ b/src/test/scala/chiselTests/InlineSpec.scala
@@ -3,9 +3,11 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util.experimental.{InlineInstance, FlattenInstance}
 import firrtl.FirrtlExecutionSuccess
 import firrtl.passes.InlineAnnotation
+import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlStage}
 import firrtl.transforms.FlattenAnnotation
 import firrtl.analyses.InstanceGraph
 import firrtl.{ir => fir}
@@ -32,6 +34,9 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
     .fullHierarchy.values.flatten.toSeq
     .map( v => (top.getOrElse(v.head.name) +: v.tail.map(_.name)).mkString(".") )
 
+  val chiselStage = new ChiselStage
+  val firrtlStage = new FirrtlStage
+
   "Module Inlining" - {
     class Top extends Module with Internals {
       val x = Module(new Foo)
@@ -40,16 +45,22 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
       Seq(x, y, z).map(_.io.a := io.a)
     }
     "should compile to low FIRRTL" - {
-      Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new Top) match {
-        case ChiselExecutionSuccess(Some(chiselCircuit), _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
-          "emitting TWO InlineAnnotation at the CHIRRTL level" in {
-            chiselCircuit.annotations.map(_.toFirrtl).collect{ case a: InlineAnnotation => a }.size should be (2)
-          }
-          "low FIRRTL should contain only instance z" in {
-            val instances = collectInstances(firrtlResult.circuitState.circuit, Some("Top")).toSet
-            Set("Top", "Top.x_sub", "Top.y_sub", "Top.z", "Top.z.sub") should be (instances)
-          }
-      }
+      val chiselAnnotations =
+        chiselStage
+          .execute(Array("--no-run-firrtl", "--target-dir", "test_run_dir"),
+                   Seq(ChiselGeneratorAnnotation(() => new Top)))
+
+      chiselAnnotations.collect{ case a: InlineAnnotation => a } should have length (2)
+
+      val instanceNames =
+        firrtlStage
+          .execute(Array("-X", "low"), chiselAnnotations)
+          .collectFirst {
+            case FirrtlCircuitAnnotation(circuit) => circuit
+          }.map(collectInstances(_, Some("Top")))
+          .getOrElse(fail)
+
+      instanceNames should contain theSameElementsAs Set("Top", "Top.x_sub", "Top.y_sub", "Top.z", "Top.z.sub")
     }
   }
 
@@ -59,16 +70,22 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
       x.io.a := io.a
     }
     "should compile to low FIRRTL" - {
-      Driver.execute(Array("-X", "low", "--target-dir", "test_run_dir"), () => new Top) match {
-        case ChiselExecutionSuccess(Some(chiselCircuit), chirrtl, Some(firrtlResult: FirrtlExecutionSuccess)) =>
-          "emitting ONE FlattenAnnotation at the CHIRRTL level" in {
-            chiselCircuit.annotations.map(_.toFirrtl).collect{ case a: FlattenAnnotation => a }.size should be (1)
-          }
-          "low FIRRTL should contain instance x only" in {
-            val instances = collectInstances(firrtlResult.circuitState.circuit, Some("Top")).toSet
-            Set("Top", "Top.x") should be (instances)
-          }
-      }
+      val chiselAnnotations =
+        chiselStage
+          .execute(Array("-X", "low", "--target-dir", "test_run_dir"),
+                   Seq(ChiselGeneratorAnnotation(() => new Top)))
+
+      chiselAnnotations.collect{ case a: FlattenAnnotation => a} should have length(1)
+
+      val instanceNames =
+        firrtlStage
+          .execute(Array("-X", "low"), chiselAnnotations)
+          .collectFirst {
+            case FirrtlCircuitAnnotation(circuit) => circuit
+          }.map(collectInstances(_, Some("Top")))
+          .getOrElse(fail)
+
+      instanceNames should contain theSameElementsAs Set("Top", "Top.x")
     }
   }
 }

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.Queue
 
 class InstanceNameModule extends Module {
@@ -25,7 +26,7 @@ class InstanceNameSpec extends ChiselFlatSpec {
   behavior of "instanceName"
   val moduleName = "InstanceNameModule"
   var m: InstanceNameModule = _
-  elaborate { m = new InstanceNameModule; m }
+  ChiselStage.elaborate { m = new InstanceNameModule; m }
 
   it should "work with module IO" in {
     val io = m.io.pathName

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -32,30 +32,18 @@ object IntervalTestHelper {
     */
   //scalastyle:off cyclomatic.complexity
   def makeFirrtl[T <: RawModule](compilerName: String)(gen: () => T): String = {
-    val c = compilerName match {
-      case "none"     => new NoneCompiler()
-      case "high"     => new HighFirrtlCompiler()
-      case "lo"       => new LowFirrtlCompiler()
-      case "low"      => new LowFirrtlCompiler()
-      case "middle"   => new MiddleFirrtlCompiler()
-      case "verilog"  => new VerilogCompiler()
-      case "mverilog" => new MinimumVerilogCompiler()
-      case "sverilog" => new SystemVerilogCompiler()
-      case _ =>
-        throw new Exception(
-          s"Unknown compiler name '$compilerName'! (Did you misspell it?)"
-        )
-    }
-    val compiler = CompilerAnnotation(c)
-    val annotations = Seq(new ChiselGeneratorAnnotation(gen), TargetDirAnnotation("test_run_dir/IntervalSpec"), compiler)
-    val processed = (new ChiselStage).run(annotations)
-    processed.collectFirst { case FirrtlCircuitAnnotation(source) => source } match {
-      case Some(circuit) => circuit.serialize
-      case _ =>
-        throw new Exception(
-          s"makeFirrtl($compilerName) failed to generate firrtl circuit"
-        )
-    }
+    (new ChiselStage)
+      .execute(Array("--compiler", compilerName,
+                     "--target-dir", "test_run_dir/IntervalSpec"),
+               Seq(ChiselGeneratorAnnotation(gen)))
+      .collectFirst { case FirrtlCircuitAnnotation(source) => source } match {
+        case Some(circuit) => circuit.serialize
+        case _ =>
+          throw new Exception(
+            s"makeFirrtl($compilerName) failed to generate firrtl circuit"
+          )
+      }
+
   }
 }
 
@@ -714,7 +702,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       }
       "squeeze disjoint from Module gives exception" in {
         intercept[DisjointSqueeze] {
-          makeFirrtl("lo")(
+          makeFirrtl("low")(
             () =>
               new Module {
                 val io = IO(new Bundle {
@@ -731,7 +719,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
         }
       }
       "clip disjoint from Module gives no error" in {
-        makeFirrtl("lo")(
+        makeFirrtl("low")(
           () =>
             new Module {
               val io = IO(new Bundle {
@@ -748,7 +736,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       }
       "wrap disjoint from Module wrap with remainder" in {
         intercept[WrapWithRemainder] {
-          makeFirrtl("lo")(
+          makeFirrtl("low")(
             () =>
               new Module {
                 val io = IO(new Bundle {
@@ -779,7 +767,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
   "Intervals should catch assignment of literals outside of range" - {
     "when literal is too small" in {
       intercept[InvalidConnect] {
-        makeFirrtl("lo")(
+        makeFirrtl("low")(
           () =>
             new Module {
               val io = IO(new Bundle { val out = Output(Interval()) })

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.experimental._
 import chisel3.experimental.BundleLiterals._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import scala.collection.immutable.ListMap
 
@@ -50,7 +51,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
   }
 
   "litOption" should "return None for non-literal hardware" in {
-    elaborate { new RawModule {
+    ChiselStage.elaborate { new RawModule {
       val a = Wire(UInt())
       assert(a.litOption == None)
     }}

--- a/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
@@ -5,6 +5,7 @@ package chiselTests
 import java.io.File
 
 import chisel3._
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util.experimental.loadMemoryFromFile
 import chisel3.util.log2Ceil
 import firrtl.FirrtlExecutionSuccess
@@ -126,64 +127,53 @@ class LoadMemoryFromFileSpec extends AnyFreeSpec with Matchers {
   "Users can specify a source file to load memory from" in {
     val testDirName = "test_run_dir/load_memory_spec"
 
-    val result = Driver.execute(
+    val result = (new ChiselStage).execute(
       args = Array("-X", "verilog", "--target-dir", testDirName),
-      dut = () => new UsesMem(memoryDepth = 8, memoryType = UInt(16.W))    )
+      annotations = Seq(ChiselGeneratorAnnotation(() => new UsesMem(memoryDepth = 8, memoryType = UInt(16.W))))
+    )
 
-    result match {
-      case ChiselExecutionSuccess(_, _, Some(FirrtlExecutionSuccess(_, _))) =>
-        val dir = new File(testDirName)
-        fileExistsWithMem(new File(dir, "UsesMem.UsesMem.memory.v"), Some("./mem1"))
-        fileExistsWithMem(new File(dir, "UsesMem.UsesMemLow.memory.v"), Some("./mem2"))
-        fileExistsWithMem(new File(dir, "firrtl_black_box_resource_files.f"))
-      case _=>
-        throw new Exception("Failed compile")
-    }
+    val dir = new File(testDirName)
+    fileExistsWithMem(new File(dir, "UsesMem.UsesMem.memory.v"), Some("./mem1"))
+    fileExistsWithMem(new File(dir, "UsesMem.UsesMemLow.memory.v"), Some("./mem2"))
+    fileExistsWithMem(new File(dir, "firrtl_black_box_resource_files.f"))
+
   }
 
   "Calling a module that loads memories from a file more than once should work" in {
     val testDirName = "test_run_dir/load_three_memory_spec"
 
-    val result = Driver.execute(
+    val result = (new ChiselStage).execute(
       args = Array("-X", "verilog", "--target-dir", testDirName),
-      dut = () => new UsesThreeMems(memoryDepth = 8, memoryType = UInt(16.W))
+      annotations = Seq(ChiselGeneratorAnnotation(() => new UsesThreeMems(memoryDepth = 8, memoryType = UInt(16.W))))
     )
 
-    result match {
-      case ChiselExecutionSuccess(_, _, Some(FirrtlExecutionSuccess(_, _))) =>
-        val dir = new File(testDirName)
-        fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory1.v"), Some("./mem1"))
-        fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory2.v"), Some("./mem1"))
-        fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory3.v"), Some("./mem1"))
-        fileExistsWithMem( new File(dir, "firrtl_black_box_resource_files.f"))
-      case _=>
-        throw new Exception("Failed compile")
-    }  }
+    val dir = new File(testDirName)
+    fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory1.v"), Some("./mem1"))
+    fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory2.v"), Some("./mem1"))
+    fileExistsWithMem( new File(dir, "UsesThreeMems.UsesThreeMems.memory3.v"), Some("./mem1"))
+    fileExistsWithMem( new File(dir, "firrtl_black_box_resource_files.f"))
+
+  }
 
   "In this example the memory has a complex memory type containing a bundle" in {
     val complexTestDirName = "test_run_dir/complex_memory_load"
 
-    val result = Driver.execute(
+    val result = (new ChiselStage).execute(
       args = Array("-X", "verilog", "--target-dir", complexTestDirName),
-      dut = () => new HasComplexMemory(memoryDepth = 8)
+      annotations = Seq(ChiselGeneratorAnnotation(() => new HasComplexMemory(memoryDepth = 8)))
     )
 
-    result match {
-      case ChiselExecutionSuccess(_, _, Some(FirrtlExecutionSuccess(emitType, firrtlEmitted))) =>
-        val dir = new File(complexTestDirName)
-        val memoryElements = Seq("a", "b", "c")
+    val dir = new File(complexTestDirName)
+    val memoryElements = Seq("a", "b", "c")
 
-        memoryElements.foreach { element =>
-          val file = new File(dir, s"HasComplexMemory.HasComplexMemory.memory_$element.v")
-          file.exists() should be (true)
-          val fileText = io.Source.fromFile(file).getLines().mkString("\n")
-          fileText should include (s"""$$readmemh("./mem_$element", HasComplexMemory.memory_$element);""")
-          file.delete()
-        }
-
-      case _=>
-        fail(s"Failed compile")
+    memoryElements.foreach { element =>
+      val file = new File(dir, s"HasComplexMemory.HasComplexMemory.memory_$element.v")
+      file.exists() should be (true)
+      val fileText = io.Source.fromFile(file).getLines().mkString("\n")
+      fileText should include (s"""$$readmemh("./mem_$element", HasComplexMemory.memory_$element);""")
+      file.delete()
     }
+
   }
 
 }

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 
 class MemorySearch extends Module {
   val io = IO(new Bundle {
@@ -50,7 +51,7 @@ class MemorySearchTester(c: MemorySearch) extends Tester(c) {
 class MemorySearchSpec extends ChiselPropSpec {
 
   property("MemorySearch should elaborate") {
-    elaborate { new EnableShiftRegister }
+    ChiselStage.elaborate { new EnableShiftRegister }
   }
 
   ignore("MemorySearch should return the correct result") { }

--- a/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
+++ b/src/test/scala/chiselTests/MissingCloneBindingExceptionSpec.scala
@@ -2,12 +2,13 @@
 
 package chiselTests
 import Chisel.ChiselException
+import chisel3.stage.ChiselStage
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 
-class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
+class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers with Utils {
   behavior of "missing cloneType in Chisel3"
-  ( the[ChiselException] thrownBy {
+  ( the [ChiselException] thrownBy extractCause[ChiselException] {
     import chisel3._
 
     class Test extends Module {
@@ -26,11 +27,11 @@ class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
       })
     }
 
-    elaborate(new TestTop)
+    ChiselStage.elaborate(new TestTop)
   }).getMessage should include("make all parameters immutable")
 
   behavior of "missing cloneType in Chisel2"
-  ( the[ChiselException] thrownBy {
+  ( the [ChiselException] thrownBy extractCause[ChiselException] {
     import Chisel._
 
     class Test extends Module {
@@ -49,6 +50,6 @@ class MissingCloneBindingExceptionSpec extends ChiselFlatSpec with Matchers {
       }
     }
 
-    elaborate(new TestTop)
+    ChiselStage.elaborate(new TestTop)
   }).getMessage should include("make all parameters immutable")
 }

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
 import org.scalacheck.Shrink
@@ -152,7 +153,7 @@ class MixedVecOneBitTester extends BasicTester {
   }
 }
 
-class MixedVecSpec extends ChiselPropSpec {
+class MixedVecSpec extends ChiselPropSpec with Utils {
   // Disable shrinking on error.
   // Not sure why this needs to be here, but the test behaves very weirdly without it (e.g. empty Lists, etc).
   implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
@@ -208,22 +209,22 @@ class MixedVecSpec extends ChiselPropSpec {
   }
 
   property("MixedVecs should not be able to take hardware types") {
-    a [ExpectedChiselTypeException] should be thrownBy {
-      elaborate(new Module {
+    a [ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val hw = Wire(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
-    a [ExpectedChiselTypeException] should be thrownBy {
-      elaborate(new Module {
+    a [ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val hw = Reg(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
-    a [ExpectedChiselTypeException] should be thrownBy {
-      elaborate(new Module {
+    a [ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {
           val v = Input(MixedVec(Seq(UInt(8.W), Bool())))
         })
@@ -257,8 +258,8 @@ class MixedVecSpec extends ChiselPropSpec {
   }
 
   property("Connecting a MixedVec and something of different size should report a ChiselException") {
-    an [IllegalArgumentException] should be thrownBy {
-      elaborate(new Module {
+    an [IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
         })
@@ -266,8 +267,8 @@ class MixedVecSpec extends ChiselPropSpec {
         io.out := seq
       })
     }
-    an [IllegalArgumentException] should be thrownBy {
-      elaborate(new Module {
+    an [IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
         })

--- a/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
+++ b/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
@@ -2,6 +2,8 @@
 
 package chiselTests
 
+import chisel3.stage.ChiselStage
+
 class ModuleExplicitResetSpec extends ChiselFlatSpec  {
 
   "A Module with an explicit reset in compatibility mode" should "elaborate" in {
@@ -15,7 +17,7 @@ class ModuleExplicitResetSpec extends ChiselFlatSpec  {
       io.done := false.B
     }
 
-    elaborate {
+    ChiselStage.elaborate {
       new ModuleExplicitReset(myReset)
     }
   }

--- a/src/test/scala/chiselTests/MultiAssign.scala
+++ b/src/test/scala/chiselTests/MultiAssign.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.testers.BasicTester
+import chisel3.stage.ChiselStage
 import chisel3.util._
 
 class LastAssignTester() extends BasicTester {
@@ -30,36 +31,52 @@ class MultiAssignSpec extends ChiselFlatSpec {
   }
 }
 
-class IllegalAssignSpec extends ChiselFlatSpec {
+class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Reassignments to literals" should "be disallowed" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate{ new BasicTester {
-        15.U := 7.U
-      }}
+      extractCause[ChiselException] {
+        ChiselStage.elaborate{
+          new BasicTester {
+            15.U := 7.U
+          }
+        }
+      }
     }
   }
 
   "Reassignments to ops" should "be disallowed" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate{ new BasicTester {
-        (15.U + 1.U) := 7.U
-      }}
+      extractCause[ChiselException] {
+        ChiselStage.elaborate{
+          new BasicTester {
+            (15.U + 1.U) := 7.U
+          }
+        }
+      }
     }
   }
 
   "Reassignments to bit slices" should "be disallowed" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate{ new BasicTester {
-        (15.U)(1, 0) := 7.U
-      }}
+      extractCause[ChiselException] {
+        ChiselStage.elaborate{
+          new BasicTester {
+            (15.U)(1, 0) := 7.U
+          }
+        }
+      }
     }
   }
 
   "Bulk-connecting two read-only nodes" should "be disallowed" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate{ new BasicTester {
-        (15.U + 1.U) <> 7.U
-      }}
+      extractCause[ChiselException] {
+        ChiselStage.elaborate{
+          new BasicTester {
+            (15.U + 1.U) <> 7.U
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.util.Counter
 import chisel3.testers.BasicTester
+import chisel3.stage.ChiselStage
 
 /** Multi-clock test of a Reg using a different clock via withClock */
 class ClockDividerTest extends BasicTester {
@@ -123,7 +124,7 @@ class MultiClockSpec extends ChiselFlatSpec {
   }
 
   it should "return like a normal Scala block" in {
-    elaborate(new BasicTester {
+    ChiselStage.elaborate(new BasicTester {
       assert(withClock(this.clock) { 5 } == 5)
     })
   }
@@ -137,7 +138,7 @@ class MultiClockSpec extends ChiselFlatSpec {
   }
 
   it should "return like a normal Scala block" in {
-    elaborate(new BasicTester {
+    ChiselStage.elaborate(new BasicTester {
       assert(withReset(this.reset) { 5 } == 5)
     })
   }
@@ -155,7 +156,7 @@ class MultiClockSpec extends ChiselFlatSpec {
   }
 
   "withClockAndReset" should "return like a normal Scala block" in {
-    elaborate(new BasicTester {
+    ChiselStage.elaborate(new BasicTester {
       assert(withClockAndReset(this.clock, this.reset) { 5 } == 5)
     })
   }

--- a/src/test/scala/chiselTests/MuxSpec.scala
+++ b/src/test/scala/chiselTests/MuxSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.{MuxLookup, log2Ceil}
 import chisel3.testers.BasicTester
 
@@ -37,34 +38,35 @@ class MuxLookupWrapper(keyWidth: Int, default: Int, mapping: () => Seq[(UInt, UI
 class MuxLookupExhaustiveSpec extends ChiselPropSpec {
   val keyWidth = 2
   val default = 9 // must be less than 10 to avoid hex/decimal mismatches
-  val firrtlLit = s"""UInt<4>("h0$default")"""
+  val firrtlLit = s"""UInt<4>("h$default")"""
+  val stage = new ChiselStage
 
   // Assumes there are no literals with 'UInt<4>("h09")' in the output FIRRTL
   // Assumes no binary recoding in output
 
   val incomplete = () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U)
   property("The default value should not be optimized away for an incomplete MuxLookup") {
-    Driver.emit { () => new MuxLookupWrapper(keyWidth, default, incomplete) } should include (firrtlLit)
+    stage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, incomplete)) should include (firrtlLit)
   }
 
   val exhaustive = () => (3.U -> 0.U) +: incomplete()
   property("The default value should be optimized away for an exhaustive MuxLookup") {
-    Driver.emit { () => new MuxLookupWrapper(keyWidth, default, exhaustive) } should not include (firrtlLit)
+    stage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, exhaustive)) should not include (firrtlLit)
   }
 
   val overlap = () => (4096.U -> 0.U) +: incomplete()
   property("The default value should not be optimized away for a MuxLookup with 2^{keyWidth} non-distinct mappings") {
-    Driver.emit { () => new MuxLookupWrapper(keyWidth, default, overlap) } should include (firrtlLit)
+    stage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, overlap)) should include (firrtlLit)
   }
 
   val nonLiteral = () => { val foo = Wire(UInt()); (foo -> 1.U) +: incomplete() }
   property("The default value should not be optimized away for a MuxLookup with a non-literal") {
-    Driver.emit { () => new MuxLookupWrapper(keyWidth, default, nonLiteral) } should include (firrtlLit)
+    stage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, nonLiteral)) should include (firrtlLit)
   }
 
   val nonLiteralStillFull = () => { val foo = Wire(UInt()); (foo -> 1.U) +: exhaustive() }
   property("The default value should be optimized away for a MuxLookup with a non-literal that is still full") {
-    Driver.emit { () => new MuxLookupWrapper(keyWidth, default, nonLiteralStillFull) } should not include (firrtlLit)
+    stage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, nonLiteralStillFull)) should not include (firrtlLit)
   }
 
 }

--- a/src/test/scala/chiselTests/NamingAnnotationTest.scala
+++ b/src/test/scala/chiselTests/NamingAnnotationTest.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.chiselName
 import chisel3.internal.InstanceId
+import chisel3.stage.ChiselStage
 
 import scala.collection.mutable.ListBuffer
 
@@ -102,7 +103,7 @@ class NamedModule extends NamedModuleTester {
   val test = expectName(FunctionMockup(), "test")
   val test2 = expectName(test +& 2.U, "test2")
   val test3 = expectName(ImplicitlyNamed(), "test3")
-  
+
   val test4 = new NonModule
   expectName(test4.value, "test4_value")
   expectName(test4.inner.value, "test4_inner_value")
@@ -237,30 +238,30 @@ class NamingAnnotationSpec extends ChiselPropSpec {
   property("NamedModule should have function hierarchical names") {
     // TODO: clean up test style
     var module: NamedModule = null
-    elaborate { module = new NamedModule; module }
+    ChiselStage.elaborate { module = new NamedModule; module }
     assert(module.getNameFailures() == Nil)
   }
 
   property("NameCollisionModule should disambiguate collisions") {
     // TODO: clean up test style
     var module: NameCollisionModule = null
-    elaborate { module = new NameCollisionModule; module }
+    ChiselStage.elaborate { module = new NameCollisionModule; module }
     assert(module.getNameFailures() == Nil)
   }
 
   property("PartialNamedModule should have partial names") {
     // TODO: clean up test style
     var module: PartialNamedModule = null
-    elaborate { module = new PartialNamedModule; module }
+    ChiselStage.elaborate { module = new PartialNamedModule; module }
     assert(module.getNameFailures() == Nil)
   }
 
   property("NonNamedModule should elaborate") {
-    elaborate { new NonNamedModule }
+    ChiselStage.elaborate { new NonNamedModule }
   }
 
   property("NonNamedFunction should elaborate") {
-    elaborate { new NonNamedFunction }
+    ChiselStage.elaborate { new NonNamedFunction }
   }
 
   property("NonBuilderFunction should run outside a Builder context") {
@@ -269,7 +270,7 @@ class NamingAnnotationSpec extends ChiselPropSpec {
 
   property("NoChiselNamePrefix should prevent prefixing when using @chiselName") {
     var module: NoChiselNamePrefixTester = null
-    elaborate { module = new NoChiselNamePrefixTester; module }
+    ChiselStage.elaborate { module = new NoChiselNamePrefixTester; module }
     assert(module.getNameFailures().isEmpty)
   }
 }

--- a/src/test/scala/chiselTests/OptionBundle.scala
+++ b/src/test/scala/chiselTests/OptionBundle.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class OptionBundle(val hasIn: Boolean) extends Bundle {
@@ -43,7 +44,7 @@ class InvalidOptionBundleTester() extends BasicTester {
   stop()
 }
 
-class OptionBundleSpec extends ChiselFlatSpec {
+class OptionBundleSpec extends ChiselFlatSpec with Utils {
   "A Bundle with an Option field" should "work properly if the Option field is not None" in {
     assertTesterPasses { new SomeOptionBundleTester(true) }
     assertTesterPasses { new SomeOptionBundleTester(false) }
@@ -54,8 +55,8 @@ class OptionBundleSpec extends ChiselFlatSpec {
   }
 
   "A Bundle with an Option field" should "assert out accessing a None Option field" in {
-    a [Exception] should be thrownBy {
-      elaborate { new InvalidOptionBundleTester() }
+    a [Exception] should be thrownBy extractCause[Exception] {
+      ChiselStage.elaborate { new InvalidOptionBundleTester() }
     }
   }
 }

--- a/src/test/scala/chiselTests/Padding.scala
+++ b/src/test/scala/chiselTests/Padding.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 
 class Padder extends Module {
   val io = IO(new Bundle {
@@ -35,7 +36,7 @@ class PadsTester(c: Pads) extends Tester(c) {
 class PadderSpec extends ChiselPropSpec {
 
   property("Padder should elaborate") {
-    elaborate { new Padder }
+    ChiselStage.elaborate { new Padder }
   }
 
   ignore("PadderTester should return the correct result") { }

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -37,7 +38,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyModule extends BasicTester {
       printf(p"An exact string")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("An exact string", Seq())) =>
       case e => fail()
@@ -47,7 +48,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyModule extends BasicTester {
       printf(p"First " + PString("Second ") + "Third")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("First Second Third", Seq())) =>
       case e => fail()
@@ -58,7 +59,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       val myInt = 1234
       printf(p"myInt = $myInt")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("myInt = 1234", Seq())) =>
       case e => fail()
@@ -69,7 +70,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       val myWire = WireDefault(1234.U)
       printf(p"myWire = ${Decimal(myWire)}")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("myWire = %d", Seq("myWire"))) =>
       case e => fail()
@@ -79,7 +80,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyModule extends BasicTester {
       printf(Decimal(10.U(32.W)))
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("%d", Seq(lit))) =>
         assert(lit contains "UInt<32>")
@@ -90,7 +91,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyModule extends BasicTester {
       printf(p"%")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("%%", Seq())) =>
       case e => fail()
@@ -100,7 +101,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyModule extends BasicTester {
       printf(p"\t")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("\\t", Seq())) =>
       case e => fail()
@@ -126,7 +127,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       printf(p"${FullName(myWire.foo)}")
       printf(p"${FullName(myInst.io.fizz)}")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     println(firrtl) // scalastyle:ignore regex
     getPrintfs(firrtl) match {
       case Seq(Printf("foo", Seq()),
@@ -145,7 +146,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       val myInst = Module(new MySubModule)
       printf(p"${myInst.io.fizz}")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("%d", Seq("myInst.io.fizz"))) =>
       case e => fail()
@@ -157,7 +158,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       val mySInt = WireDefault(-1.S)
       printf(p"$myUInt & $mySInt")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("%d & %d", Seq("myUInt", "mySInt"))) =>
       case e => fail()
@@ -169,7 +170,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       myVec foreach (_ := 0.U)
       printf(p"$myVec")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("Vec(%d, %d, %d, %d)",
                Seq("myVec[0]", "myVec[1]", "myVec[2]", "myVec[3]"))) =>
@@ -186,7 +187,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
       myBun.bar := 0.U
       printf(p"$myBun")
     }
-    val firrtl = Driver.emit(() => new MyModule)
+    val firrtl = (new ChiselStage).emitChirrtl(new MyModule)
     getPrintfs(firrtl) match {
       case Seq(Printf("AnonymousBundle(foo -> %d, bar -> %d)",
                Seq("myBun.foo", "myBun.bar"))) =>

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class UnclockedPlusOne extends RawModule {
@@ -58,9 +59,9 @@ class ImplicitModuleDirectlyInRawModuleTester extends BasicTester {
   stop()
 }
 
-class RawModuleSpec extends ChiselFlatSpec {
+class RawModuleSpec extends ChiselFlatSpec with Utils {
   "RawModule" should "elaborate" in {
-    elaborate { new RawModuleWithImplicitModule }
+    ChiselStage.elaborate { new RawModuleWithImplicitModule }
   }
 
   "RawModule" should "work" in {
@@ -74,13 +75,17 @@ class RawModuleSpec extends ChiselFlatSpec {
 
   "ImplicitModule directly in a RawModule" should "fail" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate { new RawModuleWithDirectImplicitModule }
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new RawModuleWithDirectImplicitModule }
+      }
     }
   }
 
   "ImplicitModule directly in a RawModule in an ImplicitModule" should "fail" in {
     intercept[chisel3.internal.ChiselException] {
-      elaborate { new ImplicitModuleDirectlyInRawModuleTester }
+      extractCause[ChiselException] {
+        ChiselStage.elaborate { new ImplicitModuleDirectlyInRawModuleTester }
+      }
     }
   }
 }

--- a/src/test/scala/chiselTests/RebindingSpec.scala
+++ b/src/test/scala/chiselTests/RebindingSpec.scala
@@ -3,11 +3,12 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 
-class RebindingSpec extends ChiselFlatSpec {
+class RebindingSpec extends ChiselFlatSpec with Utils {
   "Rebinding a literal" should "fail" in {
-    a [BindingException] should be thrownBy {
-      elaborate { new Module {
+    a [BindingException] should be thrownBy extractCause[BindingException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {
           val a = 4.U
         })
@@ -16,8 +17,8 @@ class RebindingSpec extends ChiselFlatSpec {
   }
 
   "Rebinding a hardware type" should "fail" in {
-    a [BindingException] should be thrownBy {
-      elaborate { new Module {
+    a [BindingException] should be thrownBy extractCause[BindingException] {
+      ChiselStage.elaborate { new Module {
         val io = IO(new Bundle {
           val a = Reg(UInt(32.W))
         })

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
 import chisel3.experimental.{DataMirror, requireIsChiselType}
@@ -109,15 +110,15 @@ trait RecordSpecUtils {
   }
 }
 
-class RecordSpec extends ChiselFlatSpec with RecordSpecUtils {
+class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   behavior of "Records"
 
   they should "bulk connect similarly to Bundles" in {
-    elaborate { new MyModule(fooBarType, fooBarType) }
+    ChiselStage.elaborate { new MyModule(fooBarType, fooBarType) }
   }
 
   they should "bulk connect to Bundles" in {
-    elaborate { new MyModule(new MyBundle, fooBarType) }
+    ChiselStage.elaborate { new MyModule(new MyBundle, fooBarType) }
   }
 
   they should "follow UInt serialization/deserialization API" in {
@@ -137,17 +138,17 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils {
   }
 
   "Bulk connect on Record" should "check that the fields match" in {
-    (the [ChiselException] thrownBy {
-      elaborate { new MyModule(fooBarType, new CustomBundle("bar" -> UInt(32.W))) }
+    (the [ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new MyModule(fooBarType, new CustomBundle("bar" -> UInt(32.W))) }
     }).getMessage should include ("Right Record missing field")
 
-    (the [ChiselException] thrownBy {
-      elaborate { new MyModule(new CustomBundle("bar" -> UInt(32.W)), fooBarType) }
+    (the [ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new MyModule(new CustomBundle("bar" -> UInt(32.W)), fooBarType) }
     }).getMessage should include ("Left Record missing field")
   }
 
   "CustomBundle" should "work like built-in aggregates" in {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val gen = new CustomBundle("foo" -> UInt(32.W))
       val io = IO(Output(gen))
       val wire = Wire(gen)
@@ -156,6 +157,6 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils {
   }
 
   "CustomBundle" should "check the types" in {
-    elaborate { new RecordTypeTester }
+    ChiselStage.elaborate { new RecordTypeTester }
   }
 }

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.DataMirror
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class RegSpec extends ChiselFlatSpec {
@@ -13,7 +14,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg = Reg(UInt(2.W))
       DataMirror.widthOf(reg) should be (2.W)
     }
-    elaborate{ new RegOutTypeWidthTester }
+    ChiselStage.elaborate{ new RegOutTypeWidthTester }
   }
 
   "RegNext" should "be of unknown width" in {
@@ -25,7 +26,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg3 = RegNext(2.U(3.W), 4.U(5.W))
       DataMirror.widthOf(reg3).known should be (false)
     }
-    elaborate { new RegUnknownWidthTester }
+    ChiselStage.elaborate { new RegUnknownWidthTester }
   }
 
   "RegInit" should "have width only if specified in the literal" in {
@@ -35,7 +36,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg2 = RegInit(20.U(7.W))
       DataMirror.widthOf(reg2) should be (7.W)
     }
-    elaborate{ new RegForcedWidthTester }
+    ChiselStage.elaborate{ new RegForcedWidthTester }
   }
 }
 

--- a/src/test/scala/chiselTests/Risc.scala
+++ b/src/test/scala/chiselTests/Risc.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util._
 
 class Risc extends Module {
@@ -117,7 +118,7 @@ class RiscTester(c: Risc) extends Tester(c) {
 class RiscSpec extends ChiselPropSpec {
 
   property("Risc should elaborate") {
-    elaborate { new Risc }
+    ChiselStage.elaborate { new Risc }
   }
 
   ignore("RiscTester should return the correct result") { }

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 class SIntOps extends Module {
@@ -97,14 +98,16 @@ class SIntLitExtractTester extends BasicTester {
   stop()
 }
 
-class SIntOpsSpec extends ChiselPropSpec {
+class SIntOpsSpec extends ChiselPropSpec with Utils {
 
   property("SIntOps should elaborate") {
-    elaborate { new SIntOps }
+    ChiselStage.elaborate { new SIntOps }
   }
 
   property("Negative shift amounts are invalid") {
-    a [ChiselException] should be thrownBy { elaborate(new NegativeShift(SInt())) }
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new NegativeShift(SInt()))
+    }
   }
 
   ignore("SIntOpsTester should return the correct result") { }

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util._
 
 class ChiselStack(val depth: Int) extends Module {
@@ -69,7 +70,7 @@ class StackTester(c: Stack) extends Tester(c) {
 class StackSpec extends ChiselPropSpec {
 
   property("Stack should elaborate") {
-    elaborate { new ChiselStack(2) }
+    ChiselStage.elaborate { new ChiselStack(2) }
   }
 
   ignore("StackTester should return the correct result") { }

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -3,12 +3,13 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util._
 
-class SwitchSpec extends ChiselFlatSpec {
+class SwitchSpec extends ChiselFlatSpec with Utils {
   "switch" should "require literal conditions" in {
-    a [java.lang.IllegalArgumentException] should be thrownBy {
-      elaborate(new Module {
+    a [java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)
         val wire = WireDefault(0.U)
@@ -19,8 +20,8 @@ class SwitchSpec extends ChiselFlatSpec {
     }
   }
   it should "require mutually exclusive conditions" in {
-    a [java.lang.IllegalArgumentException] should be thrownBy {
-      elaborate(new Module {
+    a [java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)
         switch (state) {

--- a/src/test/scala/chiselTests/TransitNameSpec.scala
+++ b/src/test/scala/chiselTests/TransitNameSpec.scala
@@ -3,6 +3,7 @@ package chiselTests
 
 
 import chisel3._
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util.TransitName
 
 import firrtl.FirrtlExecutionSuccess
@@ -38,18 +39,17 @@ class TransitNameSpec extends AnyFlatSpec with Matchers {
 
   it should "transit a name" in {
 
-    Driver.execute(Array("-X", "high", "--target-dir", "test_run_dir/TransitNameSpec"), () => new Top) match {
-      case ChiselExecutionSuccess(_,_,Some(FirrtlExecutionSuccess(_,a))) =>
-        info("""output FIRRTL includes "inst MyModule"""")
-        a should include ("inst MyModule of MyModule")
+    val firrtl = (new ChiselStage)
+      .emitFirrtl(new Top, Array("--target-dir", "test_run_dir/TransitNameSpec"))
 
-        info("""output FIRRTL includes "inst bar"""")
-        a should include ("inst bar of MyModule")
+    info("""output FIRRTL includes "inst MyModule"""")
+    firrtl should include ("inst MyModule of MyModule")
 
-        info("""output FIRRTL includes "inst baz_generated"""")
-        a should include ("inst baz_generated of MyModule")
-      case _ => fail
-    }
+    info("""output FIRRTL includes "inst bar"""")
+    firrtl should include ("inst bar of MyModule")
+
+    info("""output FIRRTL includes "inst baz_generated"""")
+    firrtl should include ("inst baz_generated of MyModule")
   }
 
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import org.scalatest._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import org.scalacheck.Shrink
 import org.scalatest.matchers.should.Matchers
@@ -112,21 +113,21 @@ class UIntLitExtractTester extends BasicTester {
   stop()
 }
 
-class UIntOpsSpec extends ChiselPropSpec with Matchers {
+class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
   // Disable shrinking on error.
   implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
   implicit val noShrinkInt = Shrink[Int](_ => Stream.empty)
 
   property("Bools can be created from 1 bit UInts") {
-    elaborate(new GoodBoolConversion)
+    ChiselStage.elaborate(new GoodBoolConversion)
   }
 
   property("Bools cannot be created from >1 bit UInts") {
-    a [Exception] should be thrownBy { elaborate(new BadBoolConversion) }
+    a [Exception] should be thrownBy extractCause[Exception] { ChiselStage.elaborate(new BadBoolConversion) }
   }
 
   property("UIntOps should elaborate") {
-    elaborate { new UIntOps }
+    ChiselStage.elaborate { new UIntOps }
   }
 
   property("UIntOpsTester should return the correct result") {
@@ -134,7 +135,9 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers {
   }
 
   property("Negative shift amounts are invalid") {
-    a [ChiselException] should be thrownBy { elaborate(new NegativeShift(UInt())) }
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new NegativeShift(UInt()))
+    }
   }
 
   property("Bit extraction on literals should work for all non-negative indices") {
@@ -142,7 +145,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers {
   }
 
   property("asBools should support chained apply") {
-    elaborate(new Module {
+    ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))
         val out = Output(Bool())
@@ -151,4 +154,3 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers {
     })
   }
 }
-

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
 
@@ -91,7 +92,7 @@ class SubmoduleWhenTester extends BasicTester {
   }
 }
 
-class WhenSpec extends ChiselFlatSpec {
+class WhenSpec extends ChiselFlatSpec with Utils {
   "When, elsewhen, and otherwise with orthogonal conditions" should "work" in {
     assertTesterPasses{ new WhenTester }
   }
@@ -106,8 +107,8 @@ class WhenSpec extends ChiselFlatSpec {
   }
 
   "Returning in a when scope" should "give a reasonable error message" in {
-    val e = the [ChiselException] thrownBy {
-      elaborate(new Module {
+    val e = the [ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new Module {
         val io = IO(new Bundle {
           val foo = Input(UInt(8.W))
           val bar = Input(UInt(8.W))

--- a/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
+++ b/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 package experimental
 
 import chisel3._
+import chisel3.stage.ChiselStage
 
 // NOTE This is currently an experimental API and subject to change
 // Example using a private port
@@ -31,11 +32,11 @@ class PortsWinTester extends NamedModuleTester {
   val output = expectName(IO(Output(UInt())).suggestName("wire"), "wire")
 }
 
-class ProgrammaticPortsSpec extends ChiselFlatSpec {
+class ProgrammaticPortsSpec extends ChiselFlatSpec with Utils {
 
   private def doTest(testMod: => NamedModuleTester): Unit = {
     var module: NamedModuleTester = null
-    elaborate { module = testMod; module }
+    ChiselStage.elaborate { module = testMod; module }
     assert(module.getNameFailures() == Nil)
   }
 
@@ -63,12 +64,11 @@ class ProgrammaticPortsSpec extends ChiselFlatSpec {
   }
 
   "SuggestName collisions on ports" should "be illegal" in {
-    a [ChiselException] should be thrownBy {
-      elaborate(new MultiIOModule {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new MultiIOModule {
         val foo = IO(UInt(8.W)).suggestName("apple")
         val bar = IO(UInt(8.W)).suggestName("apple")
       })
     }
   }
 }
-

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -69,7 +69,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
   }
 
   def runStageExpectFiles(p: ChiselMainTest): Unit = {
-    scenario(s"""User runs Chisel Stage with '${p.argsString}'""") {
+    Scenario(s"""User runs Chisel Stage with '${p.argsString}'""") {
       val f = new ChiselMainFixture
       val td = new TargetDirectoryFixture(p.testName)
 
@@ -123,7 +123,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
 
   info("As a Chisel user")
   info("I screw up and compile some bad code")
-  feature("Stack trace trimming") {
+  Feature("Stack trace trimming") {
     Seq(
       ChiselMainTest(args = Array("-X", "low"),
                      generator = Some(classOf[DifferentTypesModule]),
@@ -135,7 +135,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
                      result = 1)
     ).foreach(runStageExpectFiles)
   }
-  feature("Report properly trimmed stack traces") {
+  Feature("Report properly trimmed stack traces") {
     Seq(
       ChiselMainTest(args = Array("-X", "low"),
                      generator = Some(classOf[FailingRequirementModule]),
@@ -150,7 +150,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
 
   info("As an aspect writer")
   info("I write an aspect")
-  feature("Running aspects via the command line") {
+  Feature("Running aspects via the command line") {
     Seq(
       ChiselMainTest(args = Array( "-X", "high", "--with-aspect", "chiselTests.stage.TestClassAspect" ),
         generator = Some(classOf[SameTypesModule]),

--- a/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
@@ -8,16 +8,18 @@ import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.stage.phases.{Convert, Elaborate}
 
-import firrtl.{AnnotationSeq, CircuitForm, CircuitState, Transform, UnknownForm}
+import firrtl.{AnnotationSeq, CircuitForm, CircuitState, DependencyAPIMigration, Transform, UnknownForm}
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
 import firrtl.options.Phase
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ConvertSpecFirrtlTransform extends Transform {
-  def inputForm: CircuitForm = UnknownForm
-  def outputForm: CircuitForm = UnknownForm
+class ConvertSpecFirrtlTransform extends Transform with DependencyAPIMigration {
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Transform) = false
   def execute(state: CircuitState): CircuitState = state
 }
 

--- a/src/test/scala/chiselTests/util/random/LFSRSpec.scala
+++ b/src/test/scala/chiselTests/util/random/LFSRSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests.util.random
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.util.{Cat, Counter, Enum}
 import chisel3.util.random._
 import chisel3.testers.BasicTester
@@ -105,7 +106,7 @@ class LFSRResetTester(gen: => LFSR, lockUpValue: BigInt) extends BasicTester {
 
 }
 
-class LFSRSpec extends ChiselFlatSpec {
+class LFSRSpec extends ChiselFlatSpec with Utils {
 
   def periodCheck(gen: (Int, Set[Int], LFSRReduce) => PRNG, reduction: LFSRReduce, range: Range): Unit = {
     it should s"have a maximal period over a range of widths (${range.head} to ${range.last}) using ${reduction.getClass}" in {
@@ -122,13 +123,15 @@ class LFSRSpec extends ChiselFlatSpec {
   behavior of "LFSR"
 
   it should "throw an exception if initialized to a seed of zero for XOR configuration" in {
-    { the [IllegalArgumentException] thrownBy elaborate(new FooLFSR(XOR, Some(0))) }
-      .getMessage should include ("Seed cannot be zero")
+    { the [IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
+       ChiselStage.elaborate(new FooLFSR(XOR, Some(0))) }
+    }.getMessage should include ("Seed cannot be zero")
   }
 
   it should "throw an exception if initialized to a seed of all ones for XNOR configuration" in {
-    { the [IllegalArgumentException] thrownBy elaborate(new FooLFSR(XNOR, Some(15))) }
-      .getMessage should include ("Seed cannot be all ones")
+    { the [IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
+       ChiselStage.elaborate(new FooLFSR(XNOR, Some(15))) }
+    }.getMessage should include ("Seed cannot be all ones")
   }
 
   it should "reset correctly without a seed for XOR configuration" in {
@@ -142,8 +145,9 @@ class LFSRSpec extends ChiselFlatSpec {
   behavior of "MaximalPeriodGaloisLFSR"
 
   it should "throw an exception if no LFSR taps are known" in {
-    { the [IllegalArgumentException] thrownBy elaborate(new MaxPeriodGaloisLFSR(787)) }
-      .getMessage should include ("No max period LFSR taps stored for requested width")
+    { the [IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
+       ChiselStage.elaborate(new MaxPeriodGaloisLFSR(787)) }
+    }.getMessage should include ("No max period LFSR taps stored for requested width")
   }
 
   periodCheck((w: Int, t: Set[Int], r: LFSRReduce) => new GaloisLFSR(w, t, reduction=r), XOR, 2 to 16)

--- a/src/test/scala/chiselTests/util/random/PRNGSpec.scala
+++ b/src/test/scala/chiselTests/util/random/PRNGSpec.scala
@@ -3,11 +3,12 @@
 package chiselTests.util.random
 
 import chisel3._
+import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util.Counter
 import chisel3.util.random.PRNG
 
-import chiselTests.ChiselFlatSpec
+import chiselTests.{ChiselFlatSpec, Utils}
 
 class CyclePRNG(width: Int, seed: Option[BigInt], step: Int, updateSeed: Boolean)
     extends PRNG(width, seed, step, updateSeed) {
@@ -61,18 +62,20 @@ class PRNGUpdateSeedTest(updateSeed: Boolean, seed: BigInt, expected: BigInt) ex
 
 }
 
-class PRNGSpec extends ChiselFlatSpec {
+class PRNGSpec extends ChiselFlatSpec with Utils {
 
   behavior of "PRNG"
 
   it should "throw an exception if the step size is < 1" in {
-    { the [IllegalArgumentException] thrownBy elaborate(new CyclePRNG(0, Some(1), 1, true)) }
-      .getMessage should include ("Width must be greater than zero!")
+    { the [IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
+       ChiselStage.elaborate(new CyclePRNG(0, Some(1), 1, true)) }
+    }.getMessage should include ("Width must be greater than zero!")
   }
 
   it should "throw an exception if the step size is <= 0" in {
-    { the [IllegalArgumentException] thrownBy elaborate(new CyclePRNG(1, Some(1), 0, true)) }
-      .getMessage should include ("Step size must be greater than one!")
+    { the [IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
+       ChiselStage.elaborate(new CyclePRNG(1, Some(1), 0, true)) }
+    }.getMessage should include ("Step size must be greater than one!")
   }
 
   it should "handle non-unary steps" in {


### PR DESCRIPTION
Converts all tests to not use Chisel 3.3/FIRRTL 1.3 deprecated features, including:

- `ChiselStage` methods are used instead of those in the `BackendCompilationUtilities` trait, e.g., for elaboration
- Any custom transforms in tests are converted to use the Dependency API
- All usages of `chisel3.Driver` are removed

In doing this, a new utility is added to extract a specific cause type from a stack trace:

- A new utility, `extractCause[A <: Throwable : ClassTag]`, is added that rethrows a nested `A` if it exists

A few deprecations are added:

- Some lingering `Driver` infrastructure (e.g., `ChiselExecutionResult`) is deprecated


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.