### PR TITLE
Memoize the hashcode of the ChiselCircuitAnnotation

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -90,7 +90,12 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
 /** Stores a Chisel Circuit
   * @param circuit a Chisel Circuit
   */
-case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption
+case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption {
+  /* Caching the hashCode for a large circuit is necessary due to repeated queries.
+   * Not caching the hashCode will cause severe performance degredations for large [[Circuit]]s.
+   */
+  override lazy val hashCode: Int = circuit.hashCode
+}
 
 case class ChiselOutputFileAnnotation(file: String) extends NoTargetAnnotation with ChiselOption
 


### PR DESCRIPTION
We hash all of the annotations between phases so this makes that *much* faster after Chisel elaboration. @seldridge discussed changing the hashcode to be either a constant or just hash the name of the top-module or something so that we don't even both hashing the circuit, but I'll leave that for a later change. I would really like this in 3.3.2 because it's costing a lot of runtime.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Memoize hashcode of ChiselCircuitAnnotation, improves performance of multi-phase generators
