### PR TITLE
Fix Mergify Backport labeling for 3.2.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -57,7 +57,6 @@ pull_request_rules:
 
   - name: label Mergify backport PR
     conditions:
-      - base=3.3.x
       - body~=This is an automated backport of pull request \#\d+ done by Mergify
     actions:
       label:


### PR DESCRIPTION
Brings it inline with the config used in FIRRTL

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
