### PR TITLE
Don't run FIRRTL in FlattenSpec's ChiselStage

### DIFF
--- a/src/test/scala/chiselTests/InlineSpec.scala
+++ b/src/test/scala/chiselTests/InlineSpec.scala
@@ -72,7 +72,7 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
     "should compile to low FIRRTL" - {
       val chiselAnnotations =
         chiselStage
-          .execute(Array("-X", "low", "--target-dir", "test_run_dir"),
+          .execute(Array("--no-run-firrtl", "--target-dir", "test_run_dir"),
                    Seq(ChiselGeneratorAnnotation(() => new Top)))
 
       chiselAnnotations.collect{ case a: FlattenAnnotation => a} should have length(1)


### PR DESCRIPTION
Fix a bug in FlattenSpec where ChiselStage was running the FIRRTL
compiler in ChiselStage and then re-running the FIRRTL compiler. This
changes it to be like InlineSpec and to not run FIRRTL during
ChiselStage.

This produced a bug in 3.3.x, but not in the master branch slated for 3.4.0.

This was manually backported to 3.3.x as part of https://github.com/freechipsproject/chisel3/pull/1492.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.