### PR TITLE
Fix TesterDriver.scala regression #1481

### DIFF
--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -50,7 +50,7 @@ object TesterDriver extends BackendCompilationUtilities {
                     Dependency[Emitter],
                     Dependency[Convert]))
 
-    val annotationsx = pm.transform(ChiselGeneratorAnnotation(t) +: annotations)
+    val annotationsx = pm.transform(ChiselGeneratorAnnotation(finishWrapper(t)) +: annotations)
 
     val target: String = annotationsx.collectFirst { case FirrtlCircuitAnnotation(cir) => cir.main }.get
     val path = annotationsx.collectFirst { case TargetDirAnnotation(dir) => dir }.map(new File(_)).get


### PR DESCRIPTION
~This reverts changes to `TesterDriver` introduced in #1481 that broke chisel-testers.~

Fix a regression in chisel-iotesters introduced in #1481. This restored a mistakenly removed call to `finishWrapper`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/chisel3/pull/1481#issuecomment-648486923

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.