### PR TITLE
Allow a counter to be instantiated using a Scala range

### DIFF
--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -22,16 +22,17 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
   */
 @chiselName
 class Counter private (r: Range) {
+  require(r.length > 0, s"Counter range cannot be empty, got: $r")
   require(r.start >= 0 && r.end >= 0, s"Counter range must be positive, got: $r")
 
-  private val delta = math.abs(r.step)
-  private val width = math.max(log2Up(r.last + 1), log2Up(r.head + 1))
+  private lazy val delta = math.abs(r.step)
+  private lazy val width = math.max(log2Up(r.last + 1), log2Up(r.head + 1))
 
   /** Creates a counter with the specified number of steps.
     *
     * @param n number of steps before the counter resets
     */
-  def this(n: Int) { this(0 until n) }
+  def this(n: Int) { this(0 until math.max(1, n)) }
 
   /** The current value of the counter. */
   val value = if (r.length > 1) RegInit(r.head.U(width.W)) else r.head.U

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -25,7 +25,7 @@ class Counter private (r: Range) {
   require(r.start >= 0 && r.end >= 0, s"Counter range must be positive, got: $r")
 
   private val delta = math.abs(r.step).U
-  private val width = math.max(log2Up(r.start), log2Up(r.end)) + 1
+  private val width = math.max(log2Up(r.head), log2Up(r.last)) + 1
 
   /** Creates a counter with the specified number of steps.
     *

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -147,6 +147,20 @@ class ChiselPropSpec extends PropSpec with ChiselRunners with ScalaCheckProperty
   // Generator for small positive integers.
   val smallPosInts = Gen.choose(1, 4)
 
+  // Generator for positive (ascending or descending) ranges.
+  def posRange: Gen[Range] = for {
+    dir <- Gen.oneOf(true, false)
+    step <- Gen.choose(1, 3)
+    m <- Gen.choose(1, 10)
+    n <- Gen.choose(1, 10)
+  } yield {
+    if (dir) {
+      Range(m, (m+n)*step, step)
+    } else {
+      Range((m+n)*step, m, -step)
+    }
+  }
+
   // Generator for widths considered "safe".
   val safeUIntWidth = Gen.choose(1, 30)
 

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -35,6 +35,14 @@ class WrapTester(max: Int) extends BasicTester {
   }
 }
 
+class RangeTester(r: Range) extends BasicTester {
+  val (cnt, wrap) = Counter(r)
+  when(wrap) {
+    assert(cnt === r.last.U)
+    stop()
+  }
+}
+
 class CounterSpec extends ChiselPropSpec {
   property("Counter should count up") {
     forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new CountTester(max) } }
@@ -46,5 +54,11 @@ class CounterSpec extends ChiselPropSpec {
 
   property("Counter should wrap") {
     forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new WrapTester(max) } }
+  }
+
+  property("Counter should handle a range") {
+    forAll(posRange) { (r: Range) =>
+      assertTesterPasses{ new RangeTester(r) }
+    }
   }
 }

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -37,9 +37,14 @@ class WrapTester(max: Int) extends BasicTester {
 
 class RangeTester(r: Range) extends BasicTester {
   val (cnt, wrap) = Counter(r)
-  when(wrap) {
-    assert(cnt === r.last.U)
+  val checkWrap = RegInit(false.B)
+
+  when(checkWrap) {
+    assert(cnt === r.head.U)
     stop()
+  }.elsewhen(wrap) {
+    assert(cnt === r.last.U)
+    checkWrap := true.B
   }
 }
 


### PR DESCRIPTION
This PR adds the ability for a counter to be instantiated using a Scala range.

The original API has been preserved, but the counter now works internally with a range. Using a range to configure the counter allows us to do interesting things.

Counting upwards:

```scala
val (value, wrap) = Counter(0 to 3)
// 0, 1, 2, 3, 0, 1...
```

Counting downwards:

```scala
val (value, wrap) = Counter(3 to 0)
// 3, 2, 1, 0, 3, 2...
```

Counting upwards by twos:

```scala
val (value, wrap) = Counter(0 to 9 by 2)
// 0, 2, 4, 6, 8, 0, 2...
```

It also allows an optional condition attribute (similar to the existing API):

```scala
val enable = true.B
val (value, wrap) = Counter(0 to 3, enable)
// 0, 1, 2, 3, 0, 1...
```

I'm fairly new to Chisel, but I think that having the condition as the second parameter feels more consistent with the rest of the Chisel API.

I'm happy to scale this PR back if you think it's changing too much at once, but I'm keen to get some feedback on the overall goal. Thoughts?

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
Allow a counter to be instantiated using a Scala range
