### PR TITLE
Check whether signals escape their when scopes

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -376,16 +376,16 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   // TODO Is this okay for sample_element? It *shouldn't* be visible to users
   protected def bindingToString: String = topBindingOpt match {
     case None => ""
-    case Some(OpBinding(enclosure)) => s"(OpResult in ${enclosure.desiredName})"
-    case Some(MemoryPortBinding(enclosure)) => s"(MemPort in ${enclosure.desiredName})"
+    case Some(OpBinding(enclosure, _)) => s"(OpResult in ${enclosure.desiredName})"
+    case Some(MemoryPortBinding(enclosure, _)) => s"(MemPort in ${enclosure.desiredName})"
     case Some(PortBinding(enclosure)) if !enclosure.isClosed => s"(IO in unelaborated ${enclosure.desiredName})"
     case Some(PortBinding(enclosure)) if enclosure.isClosed =>
       DataMirror.fullModulePorts(enclosure).find(_._2 eq this) match {
         case Some((name, _)) => s"(IO $name in ${enclosure.desiredName})"
         case None => s"(IO (unknown) in ${enclosure.desiredName})"
       }
-    case Some(RegBinding(enclosure)) => s"(Reg in ${enclosure.desiredName})"
-    case Some(WireBinding(enclosure)) => s"(Wire in ${enclosure.desiredName})"
+    case Some(RegBinding(enclosure, _)) => s"(Reg in ${enclosure.desiredName})"
+    case Some(WireBinding(enclosure, _)) => s"(Wire in ${enclosure.desiredName})"
     case Some(DontCareBinding()) => s"(DontCare)"
     case Some(ElementLitBinding(litArg)) => s"(unhandled literal)"
     case Some(BundleLitBinding(litMap)) => s"(unhandled bundle literal)"
@@ -595,7 +595,7 @@ trait WireFactory {
     val x = t.cloneTypeFull
 
     // Bind each element of x to being a Wire
-    x.bind(WireBinding(Builder.forcedUserModule))
+    x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen()))
 
     pushCommand(DefWire(sourceInfo, x))
     if (!compileOptions.explicitInvalidate) {

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -127,7 +127,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt) extends H
        t.cloneTypeFull, Node(this), dir, i.ref, Builder.forcedClock.ref)
     ).id
     // Bind each element of port to being a MemoryPort
-    port.bind(MemoryPortBinding(Builder.forcedUserModule))
+    port.bind(MemoryPortBinding(Builder.forcedUserModule, Builder.currentWhen()))
     port
   }
 }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -37,7 +37,7 @@ object Module extends SourceInfoDoc {
     Builder.readyForModuleConstr = true
 
     val parent = Builder.currentModule
-    val whenDepth: Int = Builder.whenDepth
+    val parentWhenStack = Builder.whenStack
 
     // Save then clear clock and reset to prevent leaking scope, must be set again in the Module
     val (saveClock, saveReset)  = (Builder.currentClock, Builder.currentReset)
@@ -49,7 +49,7 @@ object Module extends SourceInfoDoc {
     // Execute the module, this has the following side effects:
     //   - set currentModule
     //   - unset readyForModuleConstr
-    //   - reset whenDepth to 0
+    //   - reset whenStack to be empty
     //   - set currentClockAndReset
     val module: T = bc  // bc is actually evaluated here
 
@@ -62,7 +62,7 @@ object Module extends SourceInfoDoc {
                      sourceInfo.makeMessage(" See " + _))
     }
     Builder.currentModule = parent // Back to parent!
-    Builder.whenDepth = whenDepth
+    Builder.whenStack = parentWhenStack
     Builder.currentClock = saveClock   // Back to clock and reset scope
     Builder.currentReset = saveReset
 
@@ -137,7 +137,7 @@ package internal {
     private[chisel3] def cloneIORecord(proto: BaseModule)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): ClonePorts = {
       require(proto.isClosed, "Can't clone a module before module close")
       val clonePorts = new ClonePorts(proto.getModulePorts: _*)
-      clonePorts.bind(WireBinding(Builder.forcedUserModule))
+      clonePorts.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen()))
       val cloneInstance = new DefInstance(sourceInfo, proto, proto._component.get.ports) {
         override def name = clonePorts.getRef.name
       }
@@ -169,7 +169,7 @@ package experimental {
     readyForModuleConstr = false
 
     Builder.currentModule = Some(this)
-    Builder.whenDepth = 0
+    Builder.whenStack = Nil
 
     //
     // Module Construction Internals

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -80,15 +80,15 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
         case id: Data  =>
           if (id.isSynthesizable) {
             id.topBinding match {
-              case OpBinding(_) =>
+              case OpBinding(_, _) =>
                 id.forceName(Some(""), default="T", _namespace)
-              case MemoryPortBinding(_) =>
+              case MemoryPortBinding(_, _) =>
                 id.forceName(None, default="MPORT", _namespace)
               case PortBinding(_) =>
                 id.forceName(None, default="PORT", _namespace)
-              case RegBinding(_) =>
+              case RegBinding(_, _) =>
                 id.forceName(None, default="REG", _namespace)
-              case WireBinding(_) =>
+              case WireBinding(_, _) =>
                 id.forceName(Some(""), default="WIRE", _namespace)
               case _ =>  // don't name literals
             }

--- a/core/src/main/scala/chisel3/Reg.scala
+++ b/core/src/main/scala/chisel3/Reg.scala
@@ -41,7 +41,7 @@ object Reg {
     val reg = t.cloneTypeFull
     val clock = Node(Builder.forcedClock)
 
-    reg.bind(RegBinding(Builder.forcedUserModule))
+    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen()))
     pushCommand(DefReg(sourceInfo, reg, clock))
     reg
   }
@@ -174,7 +174,7 @@ object RegInit {
     val clock = Builder.forcedClock
     val reset = Builder.forcedReset
 
-    reg.bind(RegBinding(Builder.forcedUserModule))
+    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen()))
     requireIsHardware(init, "reg initializer")
     pushCommand(DefRegInit(sourceInfo, reg, clock.ref, reset.ref, init.ref))
     reg

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -88,13 +88,20 @@ sealed trait ConstrainedBinding extends TopBinding {
 // A binding representing a data that cannot be (re)assigned to.
 sealed trait ReadOnlyBinding extends TopBinding
 
+// A component that can potentially be declared inside a 'when'
+sealed trait ConditionalDeclarable extends TopBinding {
+  def visibility: Option[WhenContext]
+}
+
 // TODO(twigg): Ops between unenclosed nodes can also be unenclosed
 // However, Chisel currently binds all op results to a module
-case class OpBinding(enclosure: RawModule) extends ConstrainedBinding with ReadOnlyBinding
-case class MemoryPortBinding(enclosure: RawModule) extends ConstrainedBinding
+
 case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
-case class RegBinding(enclosure: RawModule) extends ConstrainedBinding
-case class WireBinding(enclosure: RawModule) extends ConstrainedBinding
+
+case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext]) extends ConstrainedBinding with ReadOnlyBinding with ConditionalDeclarable
+case class MemoryPortBinding(enclosure: RawModule, visibility: Option[WhenContext]) extends ConstrainedBinding with ConditionalDeclarable
+case class RegBinding(enclosure: RawModule, visibility: Option[WhenContext]) extends ConstrainedBinding with ConditionalDeclarable
+case class WireBinding(enclosure: RawModule, visibility: Option[WhenContext]) extends ConstrainedBinding with ConditionalDeclarable
 
 case class ChildBinding(parent: Data) extends Binding {
   def location: Option[BaseModule] = parent.topBinding.location

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -64,6 +64,7 @@ private[chisel3] object MonoConnect {
 
   def checkWhenVisibility(x: Data): Boolean = {
     x.topBinding match {
+      case mp: MemoryPortBinding => true // TODO (albert-magyar): remove this "bridge" for odd enable logic of current CHIRRTL memories
       case cd: ConditionalDeclarable => cd.visibility.map(_.active()).getOrElse(true)
       case _ => true
     }

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -40,6 +40,10 @@ private[chisel3] object MonoConnect {
     MonoConnectException(": Source is unreadable from current module.")
   def UnwritableSinkException =
     MonoConnectException(": Sink is unwriteable by current module.")
+  def SourceEscapedWhenScopeException =
+    MonoConnectException(": Source has escaped the scope of the when in which it was constructed.")
+  def SinkEscapedWhenScopeException =
+    MonoConnectException(": Sink has escaped the scope of the when in which it was constructed.")
   def UnknownRelationException =
     MonoConnectException(": Sink or source unavailable to current module.")
   // These are when recursing down aggregate types
@@ -57,6 +61,13 @@ private[chisel3] object MonoConnect {
     MonoConnectException(": Analog cannot participate in a mono connection (source - RHS)")
   def AnalogMonoConnectionException =
     MonoConnectException(": Analog cannot participate in a mono connection (source and sink)")
+
+  def checkWhenVisibility(x: Data): Boolean = {
+    x.topBinding match {
+      case cd: ConditionalDeclarable => cd.visibility.map(_.active()).getOrElse(true)
+      case _ => true
+    }
+  }
 
   /** This function is what recursively tries to connect a sink and source together
   *
@@ -183,6 +194,14 @@ private[chisel3] object MonoConnect {
 
     val sink_direction = BindingDirection.from(sink.topBinding, sink.direction)
     val source_direction = BindingDirection.from(source.topBinding, source.direction)
+
+    if (!checkWhenVisibility(sink)) {
+      throw SinkEscapedWhenScopeException
+    }
+
+    if (!checkWhenVisibility(source)) {
+      throw SourceEscapedWhenScopeException
+    }
 
     // CASE: Context is same module that both left node and right node are in
     if( (context_mod == sink_mod) && (context_mod == source_mod) ) {

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -252,25 +252,6 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
     ChiselStage.elaborate { new SwappedConnectionModule() }
   }
 
-  "A Module with directionless connections when compiled with the Chisel compatibility package" should "not throw an exception" in {
-
-    class SimpleModule extends Module {
-      val io = new Bundle {
-        val in = (UInt(width = 3)).asInput
-        val out = (UInt(width = 4)).asOutput
-      }
-      val noDir = Wire(UInt(width = 3))
-    }
-
-    class DirectionLessConnectionModule extends SimpleModule {
-      val a = UInt(0, width = 3)
-      val b = Wire(UInt(width = 3))
-      val child = Module(new SimpleModule)
-      b := child.noDir
-    }
-    ChiselStage.elaborate { new DirectionLessConnectionModule() }
-  }
-
   "Vec ports" should "give default directions to children so they can be used in chisel3.util" in {
     import Chisel._
     ChiselStage.elaborate(new Module {

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -165,23 +165,4 @@ class CompileOptionsSpec extends ChiselFlatSpec with Utils {
     }
   }
 
-  "A Module with directionless connections when compiled with implicit NotStrict.CompileOption " should "not throw an exception" in {
-    import chisel3.ExplicitCompileOptions.NotStrict
-
-    class SimpleModule extends Module {
-      val io = IO(new Bundle {
-        val in = Input(UInt(3.W))
-        val out = Output(UInt(4.W))
-      })
-      val noDir = Wire(UInt(3.W))
-    }
-
-    class DirectionLessConnectionModule extends SimpleModule {
-      val a = 0.U(3.W)
-      val b = Wire(UInt(3.W))
-      val child = Module(new SimpleModule)
-      b := child.noDir
-    }
-    ChiselStage.elaborate { new DirectionLessConnectionModule() }
-  }
 }

--- a/src/test/scala/chiselTests/IllegalRefSpec.scala
+++ b/src/test/scala/chiselTests/IllegalRefSpec.scala
@@ -1,0 +1,74 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.stage.ChiselStage
+
+object IllegalRefSpec {
+  class IllegalRefInner extends RawModule {
+    val io = IO(new Bundle {
+      val i = Input(Bool())
+      val o = Output(Bool())
+    })
+    val x = io.i & io.i
+    io.o := io.i
+  }
+
+  class IllegalRefOuter(useConnect: Boolean) extends RawModule {
+    val io = IO(new Bundle {
+      val a = Input(Bool())
+      val b = Input(Bool())
+      val out = Output(Bool())
+    })
+
+    val inst = Module(new IllegalRefInner)
+    io.out := inst.io.o
+    inst.io.i := io.a
+    val x = WireInit(io.b)
+    if (useConnect) {
+      val z = WireInit(inst.x) // oops
+    } else {
+      val z = inst.x & inst.x // oops
+    }
+  }
+
+  class CrossWhenConnect(useConnect: Boolean) extends RawModule {
+    val io = IO(new Bundle {
+      val i = Input(Bool())
+      val o = Output(Bool())
+    })
+    private var tmp: Option[Bool] = None
+    when (io.i) {
+      val x = io.i & io.i
+      tmp = Some(x)
+    }
+    if (useConnect) {
+      io.o := tmp.get
+    } else {
+      val z = tmp.get & tmp.get
+      io.o := io.i
+    }
+  }
+}
+
+class IllegalRefSpec extends ChiselFlatSpec with Utils {
+  import IllegalRefSpec._
+
+  val variants = Map("a connect" -> true, "an op" -> false)
+
+  variants.foreach {
+    case (k, v) =>
+      s"Illegal cross-module references in ${k}" should "fail" in {
+        a [ChiselException] should be thrownBy extractCause[ChiselException] {
+          ChiselStage.elaborate { new IllegalRefOuter(v) }
+        }
+      }
+
+      s"Using a signal that has escaped its enclosing when scope in ${k}" should "fail" in {
+        a [ChiselException] should be thrownBy extractCause[ChiselException] {
+          ChiselStage.elaborate { new CrossWhenConnect(v) }
+        }
+      }
+  }
+}


### PR DESCRIPTION
**Related issue**: #1409 freechipsproject/firrtl#1505 #1512 
**Type of change**: improvement
**Impact**: freechipsproject/firrtl#1528 will make code that violates when scopes illegal. This will help enforce this at the Chisel level, but some code (like the old counter implementation from before #1408) will now fail to elaborate.
**Development Phase**:  implementation

**Release Notes**:
Previous versions of Chisel and FIRRTL did not adequately enforce the scoping of declarations to `when` blocks. Using a reference to a signal that has escaped a closed scope will result in an elaboration-time error.