### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,20 @@ This section describes how to get started developing Chisel itself, including ho
 
 ### Compiling and Testing Chisel
 
-In the chisel3 repository directory compile the Chisel library:
+First, clone and build the master branch of [FIRRTL](https://github.com/freechipsproject/firrtl) and [Treadle](https://github.com/freechipsproject/treadle), as the master branch of Chisel may depend on unreleased changes in those projects:
 
 ```
+git clone https://github.com/freechipsproject/firrtl.git
+git clone https://github.com/freechipsproject/treadle.git
+pushd firrtl; sbt publishLocal; popd
+pushd treadle; sbt publishLocal; popd
+```
+
+Clone and build the Chisel library:
+
+```
+git clone https://github.com/freechipsproject/chisel3.git
+cd chisel3
 sbt compile
 ```
 


### PR DESCRIPTION
The instructions for building Chisel locally don't include anything about firrtl or treadle.

I have updated the README to reflect the real steps.

**Related issue**: https://github.com/freechipsproject/chisel3/issues/1523
**Type of change**: documentation

Fixes https://github.com/freechipsproject/chisel3/issues/1523
