### PR TITLE
update Select.get(IntermediateAnd)Leafs to work with records

### DIFF
--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -21,7 +21,7 @@ object Select {
     * @return
     */
   def getLeafs(d: Data): Seq[Data] = d match {
-    case b: Bundle => b.getElements.flatMap(getLeafs)
+    case r: Record => r.getElements.flatMap(getLeafs)
     case v: Vec[_] => v.getElements.flatMap(getLeafs)
     case other => Seq(other)
   }
@@ -32,7 +32,7 @@ object Select {
     * @return
     */
   def getIntermediateAndLeafs(d: Data): Seq[Data] = d match {
-    case b: Bundle => b +: b.getElements.flatMap(getIntermediateAndLeafs)
+    case r: Record => r +: r.getElements.flatMap(getIntermediateAndLeafs)
     case v: Vec[_] => v +: v.getElements.flatMap(getIntermediateAndLeafs)
     case other => Seq(other)
   }


### PR DESCRIPTION
This PR updates `Select.getLeafs`/`Select.getIntermediateAndLeafs` to match on the broader `Record` type instead of `Bundle`. Necessary for selecting `LazyModule` IOs since the `AutoBundle` that wraps `LazyModule` IOs only extends `Record`.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
