### PR TITLE
Allow a counter to be manually reset

### DIFF
--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -35,7 +35,7 @@ class Counter private (r: Range) {
   def this(n: Int) { this(0 until math.max(1, n)) }
 
   /** The current value of the counter. */
-  val value = if (r.length > 1) RegInit(r.head.U(width.W)) else r.head.U
+  val value = if (r.length > 1) RegInit(r.head.U(width.W)) else WireInit(r.head.U)
 
   /** The range of the counter values. */
   def range: Range = r
@@ -69,6 +69,11 @@ class Counter private (r: Range) {
       true.B
     }
   }
+
+  /** Resets the counter to its initial value */
+  def reset(): Unit = {
+    value := r.head.U
+  }
 }
 
 object Counter
@@ -96,14 +101,21 @@ object Counter
     *
     * @param r the range of counter values
     * @param enable controls whether the counter increments this cycle
+    * @param reset resets the counter to its initial value during this cycle
     * @return tuple of the counter value and whether the counter will wrap (the value is at
     * maximum and the condition is true).
     */
   @chiselName
-  def apply(r: Range, enable: Bool = true.B): (UInt, Bool) = {
+  def apply(r: Range, enable: Bool = true.B, reset: Bool = false.B): (UInt, Bool) = {
     val c = new Counter(r)
     val wrap = WireInit(false.B)
-    when (enable) { wrap := c.inc() }
+
+    when(reset) {
+      c.reset()
+    }.elsewhen(enable) {
+      wrap := c.inc()
+    }
+
     (c.value, wrap)
   }
 }

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -27,6 +27,19 @@ class EnableTester(seed: Int) extends BasicTester {
   }
 }
 
+class ResetTester(n: Int) extends BasicTester {
+  val triggerReset = WireInit(false.B)
+  val wasReset = RegNext(triggerReset)
+  val (value, _) = Counter(0 until 8, reset = triggerReset)
+
+  triggerReset := value === (n-1).U
+
+  when(wasReset) {
+    assert(value === 0.U)
+    stop()
+  }
+}
+
 class WrapTester(max: Int) extends BasicTester {
   val (cnt, wrap) = Counter(true.B, max)
   when(wrap) {
@@ -55,6 +68,10 @@ class CounterSpec extends ChiselPropSpec {
 
   property("Counter can be en/disabled") {
     forAll(safeUInts) { (seed: Int) => whenever(seed >= 0) { assertTesterPasses{ new EnableTester(seed) } } }
+  }
+
+  property("Counter can be reset") {
+    forAll(smallPosInts) { (seed: Int) => assertTesterPasses{ new ResetTester(seed) } }
   }
 
   property("Counter should wrap") {


### PR DESCRIPTION
- [x] Depends on #1515.

This PR adds a `reset` parameter to the Counter API, that allows a counter to be reset to its initial value.

It is sometimes useful to be able to reset a counter arbitrarily. By default the `reset` parameter is `false`, which means the proposed change is compatible with the existing API.

For example

```scala
val counterReset = WireInit(false.B)
val (value, wrap) = Counter(0 to 3, reset = counterReset)

// Trigger a reset
counterReset := true.B
```

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Allow counters to be reset
