### PR TITLE
Add emitSystemVerilog method to ChiselStage

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -73,7 +73,7 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
     * @param gen a call-by-name Chisel module
     * @param args additional command line arguments to pass to Chisel
     * param annotations additional annotations to pass to Chisel
-    * @return a string containing the Verilog output
+    * @return a string containing the FIRRTL output
     */
   final def emitFirrtl(
     gen: => RawModule,
@@ -108,6 +108,24 @@ class ChiselStage extends Stage with PreservesAll[Phase] {
       .value
   }
 
+  /** Convert a Chisel module to SystemVerilog
+    * @param gen a call-by-name Chisel module
+    * @param args additional command line arguments to pass to Chisel
+    * param annotations additional annotations to pass to Chisel
+    * @return a string containing the SystemVerilog output
+    */
+  final def emitSystemVerilog(
+                         gen: => RawModule,
+                         args: Array[String] = Array.empty,
+                         annotations: AnnotationSeq = Seq.empty): String = {
+
+    execute(Array("-X", "sverilog") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
+      .collectFirst {
+        case DeletedAnnotation(_, EmittedVerilogCircuitAnnotation(a)) => a
+      }
+      .get
+      .value
+  }
 }
 
 object ChiselMain extends StageMain(new ChiselStage)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Adds a method for emitting SystemVerilog to the top level API, which previously required a workaround of a few lines of code.