### PR TITLE
Restore Counter.n API

### DIFF
--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -8,8 +8,10 @@ import chisel3.util._
 
 class CountTester(max: Int) extends BasicTester {
   val cnt = Counter(max)
+  assert(cnt.n == max)
   when(true.B) { cnt.inc() }
-  when(cnt.value === (max-1).asUInt) {
+  val expected = if (max == 0) 0.U else (max - 1).U
+  when(cnt.value === expected) {
     stop()
   }
 }
@@ -50,7 +52,9 @@ class RangeTester(r: Range) extends BasicTester {
 
 class CounterSpec extends ChiselPropSpec {
   property("Counter should count up") {
-    forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new CountTester(max) } }
+    for (i <- 0 until 4) {
+      assertTesterPasses(new CountTester(i))
+    }
   }
 
   property("Counter can be en/disabled") {


### PR DESCRIPTION
Includes special case support for Counter(0) which has identical
behavior to Counter(1) except for the value of n.

Restore API accidentally deleted in https://github.com/freechipsproject/chisel3/pull/1515. I'm a bit unsure about the `oldN` which is added only to support the case of `Counter(0)`. It's private so not a big deal to add or remove, but it shows that the API when passed `0` is funky.

Also, `Counter.n` makes sense to me for ranges starting at 0 with step 1, but it's unclear what it *should* mean for other cases so I made it throw an exception in those cases.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API ~modification~ restoration

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
