### PR TITLE
Deprecate Module.io and BlackBox.io

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -133,23 +133,27 @@ package experimental {
   * @note The parameters API is experimental and may change
   */
 abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param])(implicit compileOptions: CompileOptions) extends BaseBlackBox {
+  @deprecated("For type-safe interfaces, provide your own trait. For reflective API, use DataMirror", "Chisel 3.4")
   def io: Record
 
+  // Private accessor to reduce number of deprecation warnings
+  private[chisel3] def _io: Record = io
+
   // Allow access to bindings from the compatibility package
-  protected def _compatIoPortBound() = portsContains(io)
+  protected def _compatIoPortBound() = portsContains(_io)
 
   private[chisel3] override def generateComponent(): Component = {
     _compatAutoWrapPorts()  // pre-IO(...) compatibility hack
 
     // Restrict IO to just io, clock, and reset
-    require(io != null, "BlackBox must have io")
-    require(portsContains(io), "BlackBox must have io wrapped in IO(...)")
+    require(_io != null, "BlackBox must have io")
+    require(portsContains(_io), "BlackBox must have io wrapped in IO(...)")
     require(portsSize == 1, "BlackBox must only have io as IO")
 
     require(!_closed, "Can't generate module more than once")
     _closed = true
 
-    val namedPorts = io.elements.toSeq.reverse  // ListMaps are stored in reverse order
+    val namedPorts = _io.elements.toSeq.reverse  // ListMaps are stored in reverse order
 
     // setRef is not called on the actual io.
     // There is a risk of user improperly attempting to connect directly with io
@@ -163,18 +167,18 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     // of the io bundle, but NOT on the io bundle itself.
     // Doing so would cause the wrong names to be assigned, since their parent
     // is now the module itself instead of the io bundle.
-    for (id <- getIds; if id ne io) {
+    for (id <- getIds; if id ne _io) {
       id._onModuleClose
     }
 
     val firrtlPorts = namedPorts map {namedPort => Port(namedPort._2, namedPort._2.specifiedDirection)}
-    val component = DefBlackBox(this, name, firrtlPorts, io.specifiedDirection, params)
+    val component = DefBlackBox(this, name, firrtlPorts, _io.specifiedDirection, params)
     _component = Some(component)
     component
   }
 
   private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
-    for ((_, port) <- io.elements) {
+    for ((_, port) <- _io.elements) {
       pushCommand(DefInvalid(UnlocatableSourceInfo, port.ref))
     }
   }

--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -133,7 +133,12 @@ package experimental {
   * @note The parameters API is experimental and may change
   */
 abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param])(implicit compileOptions: CompileOptions) extends BaseBlackBox {
-  @deprecated("For type-safe interfaces, provide your own trait. For reflective API, use DataMirror", "Chisel 3.4")
+
+  @deprecated("Removed for causing issues in Scala 2.12+. You remain free to define io Bundles " +
+    "in your BlackBoxes, but you cannot rely on an io field in every BlackBox. " +
+    "For more information, see: https://github.com/freechipsproject/chisel3/pull/1550.",
+    "Chisel 3.4"
+  )
   def io: Record
 
   // Private accessor to reduce number of deprecation warnings

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -200,10 +200,14 @@ package internal {
 
     // IO for this Module. At the Scala level (pre-FIRRTL transformations),
     // connections in and out of a Module may only go through `io` elements.
+    @deprecated("For type-safe interfaces, provide your own trait. For reflective API, use DataMirror", "Chisel 3.4")
     def io: Record
 
+    // Private accessor to reduce number of deprecation warnings
+    private[chisel3] def _io: Record = io
+
     // Allow access to bindings from the compatibility package
-    protected def _compatIoPortBound() = portsContains(io)
+    protected def _compatIoPortBound() = portsContains(_io)
 
     private[chisel3] override def namePorts(names: HashMap[HasId, String]): Unit = {
       for (port <- getModulePorts) {
@@ -218,8 +222,8 @@ package internal {
       _compatAutoWrapPorts()  // pre-IO(...) compatibility hack
 
       // Restrict IO to just io, clock, and reset
-      require(io != null, "Module must have io")
-      require(portsContains(io), "Module must have io wrapped in IO(...)")
+      require(_io != null, "Module must have io")
+      require(portsContains(_io), "Module must have io wrapped in IO(...)")
       require((portsContains(clock)) && (portsContains(reset)), "Internal error, module did not have clock or reset as IO")
       require(portsSize == 3, "Module must only have io, clock, and reset as IO")
 
@@ -232,7 +236,7 @@ package internal {
       implicit val sourceInfo = UnlocatableSourceInfo
 
       if (!parentCompileOptions.explicitInvalidate) {
-        pushCommand(DefInvalid(sourceInfo, io.ref))
+        pushCommand(DefInvalid(sourceInfo, _io.ref))
       }
 
       clock := override_clock.getOrElse(Builder.forcedClock)

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -200,7 +200,11 @@ package internal {
 
     // IO for this Module. At the Scala level (pre-FIRRTL transformations),
     // connections in and out of a Module may only go through `io` elements.
-    @deprecated("For type-safe interfaces, provide your own trait. For reflective API, use DataMirror", "Chisel 3.4")
+    @deprecated("Removed for causing issues in Scala 2.12+. You remain free to define io Bundles " +
+      "in your Modules, but you cannot rely on an io field in every Module. " +
+      "For more information, see: https://github.com/freechipsproject/chisel3/pull/1550.",
+      "Chisel 3.4"
+    )
     def io: Record
 
     // Private accessor to reduce number of deprecation warnings


### PR DESCRIPTION
### Why?

I was experimenting with some stuff in Scala 2.13 and realized that `-Xsource:2.11` is no longer supported in 2.13. In fact, it was never recommended as an option to Scalac for anything but debugging, let alone our recommended way of supporting Scala 2.12. Thus I had a [discussion](https://gitter.im/scala/contributors?at=5f3324e82aa0fd6b0aa9e92b) on the Scala Contributors Gitter to figure out what to do.

For a long time, we thought the issue only had to do with structural typing. This was incorrect, there were actually *2* different problems:
1. Structural Typing
    * [formerly unsupported](https://contributors.scala-lang.org/t/better-type-inference-for-scala-send-us-your-problematic-cases/2410/73?u=jackkoenig) in Scala 3, [now supported](https://github.com/lampepfl/dotty/issues/7920#issuecomment-672720332), it always worked in Scala 2.12/13
2. Type Inference for overridden definitions defaults to overridden type (as opposed to overriding type)
    * [Strict in Scala 3,](https://gitter.im/scala/contributors?at=5f3328023cf046461e2c1626) weaker in Scala 2.12/13

The thing that made this confusing was that fixing either (1) or (2) is sufficient to no longer need `-Xsource:2.11`, but we generally only talked about solutions to (1). To be more precise, if we stopped using the pattern `val io = IO(new Bundle { ... })`, we would no longer need `-Xsource:2.11` in Scala 2.12.

This solution could work as a ScalaFix rewrite rule:
```scala
class MyModule extends Module {
  val io = IO(new Bundle { ... })
}
```
Becomes
```scala
class MyModule extends Module {
  class MyModuleIntf extends Bundle { ... }
  val io = IO(new MyModuleIntf)
}
```
Unfortunately, due to (2) where Scala 3 is stricter, you would also need to annotate the type of `io` in Scala 3:
```scala
class MyModule extends Module {
  class MyModuleIntf extends Bundle { ... }
  val io: MyModuleIntf = IO(new MyModuleIntf)
}
```
While this is a solution, there is a massive downside that we have to encourage all of our users to rewrite all of their code (potentially ScalaFix assisted), and purge documentation of this bad style.

It turns out that removing `io` as a virtual method solves both (1) and (2). The exact same style of Modules with anonymous `Bundle`s for `io` will work in Scala 2.12, 2.13, and 3.

### Implications

#### What does this actually do?

This deprecation warning only shows up for when `io` is used _as a field of `Module` or `BlackBox` itself_. That is, only when relying on the common interface of those abstract classes will cause the warning. Some examples:

```scala
class Foo extends Module {
  // No warning
  val io = IO(new Bundle {
    val in = Input(Bool())
    val out = Output(Bool())
  })

  io.out := ~io.in // No warning
}

object Util {
  def connect(mod1: Foo, mod2: Foo): Unit = {
    println(s"mod1 has io: ${mod1.io}") // No warning
    mod1.io.in := mod2.io.out           // No warning
  }

  def connect2(mod1: Module, mod2: Module): Unit = {
    println(s"mod1 has io: ${mod1.io}") // Warning!
    mod1.io <> mod2.io                  // Warning!
  }
}
```

Thus, this warning is actually fairly rare because most people either rely on more type-safe APIs (some common `trait` defining a more precise type for `IO`), or use `DataMirror.fullModulePorts` since they want to be able to get the IO from `MultiIOModules` and `RawModules` as well.

#### Module

The virtual method allowed us to use the type system to enforce the single-source of ports via `val io`. We can still enforce that through `DataMirror.fullModulePorts` if we want. We could alternatively unify `Module` and `MultiIOModule` and relegate `val io` to a stylistic choice.

#### BlackBox

`BlackBox` has special behavior where the `io` prefix is dropped. While it's still an open-question for how to provide this behavior in a less hacky way, it needs to be maintained. The `io` virtual method is currently used to find the ports, but we could use the `DataMirror.fullModulePorts` "reflective" API to find them and ensure the `io` prefix is dropped.

#### Compatibility-mode

`import Chisel._` does not require `IO` wrapping of `io` for `Module` and `BlackBox`. It uses the virtual method to apply the binding to them. 2 possible solutions:
1. Use reflection to find `io`
2. Use the compiler plugin to wrap them


<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Deprecate `Module.io` and `BlackBox.io` virtual methods
