### PR TITLE
Deprecate support for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,6 +180,12 @@ lazy val macros = (project in file("macros")).
 
 lazy val core = (project in file("core")).
   settings(commonSettings: _*).
+  enablePlugins(BuildInfoPlugin).
+  settings(
+    buildInfoPackage := "chisel3",
+    buildInfoUsePackageAsPath := true,
+    buildInfoKeys := Seq[BuildInfoKey](buildInfoPackage, version, scalaVersion, sbtVersion)
+  ).
   settings(publishSettings: _*).
   settings(
     name := "chisel3-core",
@@ -200,13 +206,7 @@ lazy val core = (project in file("core")).
 lazy val root = RootProject(file("."))
 
 lazy val chisel = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
   enablePlugins(ScalaUnidocPlugin).
-  settings(
-    buildInfoPackage := name.value,
-    buildInfoUsePackageAsPath := true,
-    buildInfoKeys := Seq[BuildInfoKey](buildInfoPackage, version, scalaVersion, sbtVersion)
-  ).
   settings(commonSettings: _*).
   settings(chiselSettings: _*).
   settings(publishSettings: _*).

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -603,8 +603,24 @@ private[chisel3] object Builder {
     throwException(m)
   }
 
+  def getScalaMajorVersion: Int = {
+    val "2" :: major :: _ :: Nil = chisel3.BuildInfo.scalaVersion.split("\\.").toList
+    major.toInt
+  }
+
+  def checkScalaVersion(): Unit = {
+    if (getScalaMajorVersion == 11) {
+      val url = _root_.firrtl.stage.transforms.CheckScalaVersion.migrationDocumentLink
+      val msg = s"Chisel 3.4 is the last version that will support Scala 2.11. " +
+                s"Please upgrade to Scala 2.12. See $url"
+      deprecated(msg, Some(""))
+    }
+  }
+
+
   def build[T <: RawModule](f: => T): (Circuit, T) = {
     dynamicContextVar.withValue(Some(new DynamicContext())) {
+      checkScalaVersion()
       errors.info("Elaborating design...")
       val mod = f
       mod.forceName(None, mod.name, globalNamespace)


### PR DESCRIPTION
Leverages chiselRuntimeDeprecated infrastructure. As such it is not
currently suppressible.

Related to https://github.com/freechipsproject/firrtl/pull/1842. This doesn't have suppression because nothing in Chisel elaboration does. I looked at adding suppression via annotations like in the FIRRTL PR, but some invocations of the Builder don't have annotations to propagate (like aspects). Also nothing else is suppressible so I figured this needs further thought.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Deprecate support for Scala 2.11
