### PR TITLE
Remove use of PreservesAll, cleanup dependencies

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -3,7 +3,7 @@
 package chisel3.stage
 
 import firrtl.{ir => fir, AnnotationSeq, EmittedFirrtlCircuitAnnotation, EmittedVerilogCircuitAnnotation}
-import firrtl.options.{Dependency, Phase, PhaseManager, PreservesAll, Shell, Stage, StageError, StageMain}
+import firrtl.options.{Dependency, Phase, PhaseManager, Shell, Stage, StageError, StageMain}
 import firrtl.options.phases.DeletedWrapper
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlCli}
 import firrtl.options.Viewer.view
@@ -13,7 +13,12 @@ import chisel3.internal.{firrtl => cir, ErrorLog}
 
 import java.io.{StringWriter, PrintWriter}
 
-class ChiselStage extends Stage with PreservesAll[Phase] {
+class ChiselStage extends Stage {
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   val shell: Shell = new Shell("chisel") with ChiselCli with FirrtlCli
 

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
@@ -4,14 +4,17 @@ package chisel3.stage.phases
 
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, OutputAnnotationFileAnnotation, Phase, PreservesAll}
+import firrtl.options.{Dependency, OutputAnnotationFileAnnotation, Phase}
 
 /** Adds an [[firrtl.options.OutputAnnotationFileAnnotation]] if one does not exist. This replicates old behavior where
   * an output annotation file was always written.
   */
-class AddImplicitOutputAnnotationFile extends Phase with PreservesAll[Phase] {
+class AddImplicitOutputAnnotationFile extends Phase {
 
-  override val prerequisites = Seq(Dependency[Elaborate])
+  override def prerequisites = Seq(Dependency[Elaborate])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst{ case _: OutputAnnotationFileAnnotation => annotations }

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
@@ -3,16 +3,19 @@
 package chisel3.stage.phases
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselOutputFileAnnotation}
 
 /** Add a output file for a Chisel circuit, derived from the top module in the circuit, if no
   * [[ChiselOutputFileAnnotation]] already exists.
   */
-class AddImplicitOutputFile extends Phase with PreservesAll[Phase] {
+class AddImplicitOutputFile extends Phase {
 
-  override val prerequisites = Seq(Dependency[Elaborate])
+  override def prerequisites = Seq(Dependency[Elaborate])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq =
     annotations.collectFirst{ case _: ChiselOutputFileAnnotation  => annotations }.getOrElse{

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -6,14 +6,17 @@ import chisel3.stage.{ChiselOutputFileAnnotation, NoRunFirrtlCompilerAnnotation,
 
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
-import firrtl.options.{Dependency, OptionsException, Phase, PreservesAll}
+import firrtl.options.{Dependency, OptionsException, Phase}
 
 /** Sanity checks an [[firrtl.AnnotationSeq]] before running the main [[firrtl.options.Phase]]s of
   * [[chisel3.stage.ChiselStage]].
   */
-class Checks extends Phase with PreservesAll[Phase] {
+class Checks extends Phase {
 
-  override val dependents = Seq(Dependency[Elaborate])
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq(Dependency[Elaborate])
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val noF, st, outF = collection.mutable.ListBuffer[Annotation]()

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -6,7 +6,7 @@ import chisel3.experimental.RunFirrtlTransform
 import chisel3.internal.firrtl.Converter
 import chisel3.stage.ChiselCircuitAnnotation
 import firrtl.{AnnotationSeq, Transform}
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 
 /** This prepares a [[ChiselCircuitAnnotation]] for compilation with FIRRTL. This does three things:
@@ -14,9 +14,12 @@ import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
   *   - Extracts all [[firrtl.annotations.Annotation]]s from the [[chisel3.internal.firrtl.Circuit]]
   *   - Generates any needed [[RunFirrtlTransformAnnotation]]s from extracted [[firrtl.annotations.Annotation]]s
   */
-class Convert extends Phase with PreservesAll[Phase] {
+class Convert extends Phase {
 
-  override val prerequisites = Seq(Dependency[Elaborate])
+  override def prerequisites = Seq(Dependency[Elaborate])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -9,11 +9,16 @@ import chisel3.internal.ErrorLog
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselOptions}
 import firrtl.AnnotationSeq
 import firrtl.options.Viewer.view
-import firrtl.options.{OptionsException, Phase, PreservesAll}
+import firrtl.options.{OptionsException, Phase}
 
 /** Elaborate all [[chisel3.stage.ChiselGeneratorAnnotation]]s into [[chisel3.stage.ChiselCircuitAnnotation]]s.
   */
-class Elaborate extends Phase with PreservesAll[Phase] {
+class Elaborate extends Phase {
+
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselGeneratorAnnotation => a.elaborate

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -24,15 +24,14 @@ import java.io.{File, FileWriter}
   */
 class Emitter extends Phase {
 
-  override val prerequisites =
+  override def prerequisites =
     Seq( Dependency[Elaborate],
          Dependency[AddImplicitOutputFile],
          Dependency[AddImplicitOutputAnnotationFile],
          Dependency[MaybeAspectPhase] )
-
+  override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Seq(Dependency[Convert])
-
-  override def invalidates(phase: Phase): Boolean = false
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val copts = view[ChiselOptions](annotations)

--- a/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
@@ -4,13 +4,16 @@ package chisel3.stage.phases
 
 import chisel3.aop.Aspect
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 
 /** Run [[AspectPhase]] if a [[chisel3.aop.Aspect]] is present.
   */
-class MaybeAspectPhase extends Phase with PreservesAll[Phase] {
+class MaybeAspectPhase extends Phase {
 
-  override val prerequisites = Seq(Dependency[Elaborate])
+  override def prerequisites = Seq(Dependency[Elaborate])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     if(annotations.collectFirst { case a: Aspect[_] => annotations }.isDefined) {

--- a/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeFirrtlStage.scala
@@ -5,14 +5,17 @@ package chisel3.stage.phases
 import chisel3.stage.NoRunFirrtlCompilerAnnotation
 
 import firrtl.AnnotationSeq
-import firrtl.options.{Dependency, Phase, PreservesAll}
+import firrtl.options.{Dependency, Phase}
 import firrtl.stage.FirrtlStage
 
 /** Run [[firrtl.stage.FirrtlStage]] if a [[chisel3.stage.NoRunFirrtlCompilerAnnotation]] is not present.
   */
-class MaybeFirrtlStage extends Phase with PreservesAll[Phase] {
+class MaybeFirrtlStage extends Phase {
 
-  override val prerequisites = Seq(Dependency[Convert])
+  override def prerequisites = Seq(Dependency[Convert])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations
     .collectFirst { case NoRunFirrtlCompilerAnnotation => annotations }


### PR DESCRIPTION
Remove usages of the deprecated trait PreservesAll and use an explicit
false invalidates. Additionally, all phases are converted to be more
canonical in there specification of dependencies by:

  1. Overriding all default dependency implementations
  2. Using def instead of val

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None