### PR TITLE
Better Building of FIRRTL From Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ sbt test
 ### Running Projects Against Local Chisel
 
 To use the development version of Chisel (`master` branch), you will need to build from source and `publishLocal`.
-The repository version can be found in the build.sbt file.
+The repository version can be found in the [build.sbt](build.sbt) file.
 As of the time of writing it was:
 
 ```
-version := "3.2-SNAPSHOT"
+version := "3.4-SNAPSHOT"
 ```
 
 To publish your version of Chisel to the local Ivy (sbt's dependency manager) repository, run:
@@ -188,8 +188,31 @@ If you need to un-publish your local copy of Chisel, remove the directory genera
 In order to have your projects use this version of Chisel, you should update the `libraryDependencies` setting in your project's build.sbt file to:
 
 ```
-libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.2-SNAPSHOT"
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4-SNAPSHOT"
 ```
+
+### Building Chisel with FIRRTL in the same SBT Project
+
+While we recommend using the library dependency approach as described above, it is possible to build Chisel and FIRRTL in a single SBT project.
+
+**Caveats**
+* This only works for the "main" configuration; you cannot build the Chisel tests this way because `treadle` is only supported as a library dependency.
+* Do not `publishLocal` when building this way. The published artifact will be missing the FIRRTL dependency.
+
+This works by using [sbt-sriracha](http://eed3si9n.com/hot-source-dependencies-using-sbt-sriracha), an SBT plugin for toggling between source and library dependencies.
+It provides two JVM system properties that, when set, will tell SBT to include FIRRTL as a source project:
+* `sbt.sourcemode` - when set to true, SBT will look for FIRRTL in the workspace
+* `sbt.workspace` - sets the root directory of the workspace
+
+Example use:
+```bash
+# From root of this repo
+git clone git@github.com:freechipsproject/firrtl.git
+sbt -Dsbt.sourcemode=true -Dsbt.workspace=$PWD
+```
+
+This is primarily useful for building projects that themselves want to include Chisel as a source dependency.
+As an example, see [Rocket Chip](https://github.com/chipsalliance/rocket-chip)
 
 ### Chisel3 Architecture Overview
 

--- a/build.sbt
+++ b/build.sbt
@@ -195,10 +195,7 @@ lazy val core = (project in file("core")).
 // This will always be the root project, even if we are a sub-project.
 lazy val root = RootProject(file("."))
 
-lazy val treadleRef = ProjectRef(workspaceDirectory / "treadle", "treadle")
-
 lazy val chisel = (project in file(".")).
-  sourceDependency(treadleRef % "test", defaultVersions("treadle") % "test").
   enablePlugins(ScalaUnidocPlugin).
   settings(commonSettings: _*).
   settings(chiselSettings: _*).
@@ -208,6 +205,7 @@ lazy val chisel = (project in file(".")).
   dependsOn(core).
   aggregate(macros, core, plugin).
   settings(
+    libraryDependencies += defaultVersions("treadle") % "test",
     scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
     scalacOptions in Compile in doc ++= Seq(
       "-diagrams",

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,9 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
-val defaultVersions = Seq(
-  "edu.berkeley.cs" %% "firrtl" % "1.4-SNAPSHOT"
+val defaultVersions = Map(
+  "firrtl" -> "edu.berkeley.cs" %% "firrtl" % "1.4-SNAPSHOT",
+  "treadle" -> "edu.berkeley.cs" %% "treadle" % "1.3-SNAPSHOT"
 )
 
 lazy val commonSettings = Seq (
@@ -45,20 +46,6 @@ lazy val commonSettings = Seq (
   scalacOptions := Seq("-deprecation", "-feature") ++ scalacOptionsVersion(scalaVersion.value),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-  // Use the root project's unmanaged base for all sub-projects.
-  unmanagedBase := (unmanagedBase in root).value,
-  // Since we want to examine the classpath to determine if a dependency on firrtl is required,
-  //  this has to be a Task setting.
-  //  Fortunately, allDependencies is a Task Setting, so we can modify that.
-  allDependencies := {
-    allDependencies.value ++ defaultVersions.collect {
-      // If we have an unmanaged jar file on the classpath, assume we're to use that,
-      case m: ModuleID if !(unmanagedClasspath in Compile).value.toString.contains(s"${m.name}.jar") =>
-        //  otherwise let sbt fetch the appropriate artifact, possibly with a specific revision.
-        val mWithRevision = m.withRevision(sys.props.getOrElse(m.name + "Version", m.revision))
-        mWithRevision
-    }
-  }
 )
 
 lazy val publishSettings = Seq (
@@ -109,7 +96,6 @@ lazy val chiselSettings = Seq (
     "junit" % "junit" % "4.13" % "test",
     "org.scalatest" %% "scalatest" % "3.1.2" % "test",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.1.1.1" % "test",
-    "edu.berkeley.cs" %% "treadle" % "1.3-SNAPSHOT" % "test",
     "com.github.scopt" %% "scopt" % "3.7.1"
   ),
   javacOptions ++= javacOptionsVersion(scalaVersion.value)
@@ -179,7 +165,10 @@ lazy val macros = (project in file("macros")).
   settings(commonSettings: _*).
   settings(publishSettings: _*)
 
+lazy val firrtlRef = ProjectRef(workspaceDirectory / "firrtl", "firrtl")
+
 lazy val core = (project in file("core")).
+  sourceDependency(firrtlRef, defaultVersions("firrtl")).
   settings(commonSettings: _*).
   enablePlugins(BuildInfoPlugin).
   settings(
@@ -206,7 +195,10 @@ lazy val core = (project in file("core")).
 // This will always be the root project, even if we are a sub-project.
 lazy val root = RootProject(file("."))
 
+lazy val treadleRef = ProjectRef(workspaceDirectory / "treadle", "treadle")
+
 lazy val chisel = (project in file(".")).
+  sourceDependency(treadleRef % "test", defaultVersions("treadle") % "test").
   enablePlugins(ScalaUnidocPlugin).
   settings(commonSettings: _*).
   settings(chiselSettings: _*).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
@@ -17,3 +17,8 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )
+
+addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")
+
+// From FIRRTL for building from source
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")


### PR DESCRIPTION
This allows you to build FIRRTL from source in a much cleaner way. In this repo you can do so in the following way:
```bash
# From root of this repo
git clone git@github.com:freechipsproject/firrtl.git
sbt -Dsbt.sourcemode=true -Dsbt.workspace=$PWD
```
This will use the source checkout of firrtl, having SBT manage both (much better for use with IDEs and other tooling). You can commit those `-D` arguments in `.sbtopts` and SBT will pick it up automatically.

There is a companion rocket-chip PR to come.

TODO
- [x] Write doc for this new behavior

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - new feature/API    (in the build at least)

#### API Impact

This breaks the `firrtl.jar` unmanaged dependency technique for building chisel3 with firrtl from source. This new API works a lot better

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy
-   - Squash

#### Release Notes

Improve chisel3 support for building against firrtl from source

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
