### PR TITLE
Relax plugin scalac phase order

### DIFF
--- a/plugin/src/main/scala-2.12/chisel3/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala-2.12/chisel3/plugin/ChiselPlugin.scala
@@ -21,7 +21,6 @@ class ChiselPlugin(val global: Global) extends Plugin {
 class ChiselComponent(val global: Global) extends PluginComponent with TypingTransformers {
   import global._
   val runsAfter = List[String]("typer")
-  override val runsRightAfter: Option[String] = Some("typer")
   val phaseName: String = "chiselcomponent"
   def newPhase(_prev: Phase): ChiselComponentPhase = new ChiselComponentPhase(_prev)
   class ChiselComponentPhase(prev: Phase) extends StdPhase(prev) {


### PR DESCRIPTION
It must run after the typer, but doesn't need to "run right after". The
stricter dependency conflicted with the semanticdb-typer.

h/t Øyvind for finding this bug https://groups.google.com/g/chisel-users/c/K_vuliudgLg/m/IYx-QPd4AQAJ

I locally verified that I could reproduce the bug and this fixes it. Unfortunately this is a pretty hard thing to test for (in this repo at least)

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix

#### API Impact

No change

#### Backend Code Generation Impact

No change

#### Desired Merge Strategy

  - Squash

#### Release Notes

Relax plugin scalac phase order. This makes the plugin work with tools like Scala Metals.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
