### PR TITLE
Restore and deprecate Chisel.Driver

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -85,7 +85,7 @@ case class ChiselExecutionSuccess(
 @deprecated("This will be removed in Chisel 3.5", "Chisel 3.4")
 case class ChiselExecutionFailure(message: String) extends ChiselExecutionResult
 
-@deprecated("Please switch to chisel3.stage.ChiselStage. Driver will be removed in 3.4.", "3.2.4")
+@deprecated("Please switch to chisel3.stage.ChiselStage", "3.2.4")
 object Driver extends BackendCompilationUtilities {
 
   /**

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -396,6 +396,8 @@ package object Chisel {
   implicit class fromIntToWidth(x: Int) extends chisel3.fromIntToWidth(x)
 
   type BackendCompilationUtilities = firrtl.util.BackendCompilationUtilities
+  @deprecated("Please switch to chisel3.stage.ChiselStage", "3.4")
+  val Driver = chisel3.Driver
   val ImplicitConversions = chisel3.util.ImplicitConversions
 
   // Deprecated as of Chisel3


### PR DESCRIPTION
It shouldn't be removed until we also remove underlying chisel3.Driver

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix 

#### API Impact

`Chisel.Driver` will continue to work, for the time being

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

   - Squash

#### Release Notes

Restore `Chisel.Driver`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
