### PR TITLE
Add new annotation for Chisel Circuit serialization

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselCli.scala
+++ b/src/main/scala/chisel3/stage/ChiselCli.scala
@@ -8,6 +8,7 @@ trait ChiselCli { this: Shell =>
   parser.note("Chisel Front End Options")
   Seq( NoRunFirrtlCompilerAnnotation,
        PrintFullStackTraceAnnotation,
+       ChiselOutputFileAnnotation,
        ChiselGeneratorAnnotation )
     .foreach(_.addOptions(parser))
 }

--- a/src/main/scala/chisel3/stage/ChiselPhase.scala
+++ b/src/main/scala/chisel3/stage/ChiselPhase.scala
@@ -22,6 +22,7 @@ private[chisel3] object ChiselPhase {
          Dependency[chisel3.stage.phases.AddImplicitOutputFile],
          Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
          Dependency[chisel3.stage.phases.MaybeAspectPhase],
+         Dependency[chisel3.stage.phases.AddSerializationAnnotations],
          Dependency[chisel3.stage.phases.Convert],
          Dependency[chisel3.stage.phases.MaybeFirrtlStage] )
 

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -18,6 +18,7 @@ import firrtl.options.Viewer.view
 
 import chisel3.{ChiselException, RawModule}
 import chisel3.internal.{firrtl => cir, ErrorLog}
+import chisel3.stage.CircuitSerializationAnnotation.FirrtlFileFormat
 
 import java.io.{StringWriter, PrintWriter}
 
@@ -72,7 +73,7 @@ class ChiselStage extends Stage {
 
     annos
       .collectFirst {
-        case a: ChiselCircuitAnnotation => a.getBytes
+        case a: ChiselCircuitAnnotation => CircuitSerializationAnnotation(a.circuit, "", FirrtlFileFormat).getBytes
       }
       .get
       .map(_.toChar)

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -6,6 +6,7 @@ import firrtl._
 import firrtl.options.OptionsView
 
 import chisel3.internal.firrtl.{Circuit => ChiselCircuit}
+import chisel3.stage.CircuitSerializationAnnotation.FirrtlFileFormat
 
 package object stage {
 
@@ -31,9 +32,12 @@ package object stage {
       var chirrtlCircuit: Option[String] = None
 
       options.foreach {
-        case a@ ChiselCircuitAnnotation(b) =>
+        case a @ ChiselCircuitAnnotation(b) =>
           chiselCircuit = Some(b)
-          chirrtlCircuit = Some(a.getBytes.map(_.toChar).mkString)
+          chirrtlCircuit = {
+            val anno = CircuitSerializationAnnotation(a.circuit, "", FirrtlFileFormat)
+            Some(anno.getBytes.map(_.toChar).mkString)
+          }
         case _ =>
       }
 

--- a/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
@@ -1,0 +1,34 @@
+// See LICENSE for license details.
+
+package chisel3.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Dependency, Phase}
+import firrtl.options.Viewer.view
+
+import chisel3.stage._
+import chisel3.stage.CircuitSerializationAnnotation._
+import chisel3.internal.ChiselException
+
+/** Adds [[stage.CircuitSerializationAnnotation]]s based on [[ChiselOutputFileAnnotation]]
+  */
+class AddSerializationAnnotations extends Phase {
+
+  override def prerequisites = Seq(Dependency[Elaborate], Dependency[AddImplicitOutputFile])
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val chiselOptions = view[ChiselOptions](annotations)
+    val circuit = chiselOptions.chiselCircuit.getOrElse {
+      throw new ChiselException(s"Unable to locate the elaborated circuit, did ${classOf[Elaborate].getName} run correctly")
+    }
+    val baseFilename = chiselOptions.outputFile.getOrElse(circuit.name)
+
+    val (filename, format) =
+      if (baseFilename.endsWith(".pb")) (baseFilename.stripSuffix(".pb"), ProtoBufFileFormat)
+      else (baseFilename.stripSuffix(".fir"), FirrtlFileFormat)
+    CircuitSerializationAnnotation(circuit, filename, format) +: annotations
+  }
+}

--- a/src/test/scala/chiselTests/stage/phases/AddSerializationAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/AddSerializationAnnotationsSpec.scala
@@ -1,0 +1,61 @@
+// See LICENSE for license details.
+
+package chiselTests.stage.phases
+
+
+import chisel3.RawModule
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselOutputFileAnnotation, CircuitSerializationAnnotation}
+import chisel3.stage.CircuitSerializationAnnotation._
+import chisel3.stage.phases.{AddSerializationAnnotations, AddImplicitOutputFile, Elaborate}
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Phase, PhaseManager, Dependency, TargetDirAnnotation}
+import firrtl.options.Viewer.view
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AddSerializationAnnotationsSpec extends AnyFlatSpec with Matchers {
+
+  class Foo extends RawModule { override val desiredName = "Foo" }
+
+  class Fixture {
+    val phase: Phase = new AddSerializationAnnotations
+    val manager = new PhaseManager(Dependency[AddSerializationAnnotations] :: Nil)
+  }
+
+  behavior of classOf[AddSerializationAnnotations].toString
+
+  it should "default to FirrtlFileFormat" in new Fixture {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      ChiselOutputFileAnnotation("Bar") )
+
+    manager
+      .transform(annotations)
+      .collect { case CircuitSerializationAnnotation(_, filename, format) => (filename, format) }
+      .toSeq should be (Seq(("Bar", FirrtlFileFormat)))
+  }
+
+  it should "support ProtoBufFileFormat" in new Fixture {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      ChiselOutputFileAnnotation("Bar.pb") )
+
+    manager
+      .transform(annotations)
+      .collect { case CircuitSerializationAnnotation(_, filename, format) => (filename, format) }
+      .toSeq should be (Seq(("Bar", ProtoBufFileFormat)))
+  }
+
+  it should "support explicitly asking for FirrtlFileFormat" in new Fixture {
+    val annotations: AnnotationSeq = Seq(
+      ChiselGeneratorAnnotation(() => new Foo),
+      ChiselOutputFileAnnotation("Bar.pb.fir") )
+
+    manager
+      .transform(annotations)
+      .collect { case CircuitSerializationAnnotation(_, filename, format) => (filename, format) }
+      .toSeq should be (Seq(("Bar.pb", FirrtlFileFormat)))
+  }
+
+}


### PR DESCRIPTION
ChiselCircuitAnnotation no longer extends CustomFileEmission, rather it
is Unserializable. Also the --chisel-output-file is added to the
ChiselCli.

New phase AddSerializationAnnotations constructs a
CircuitSerializationAnnotation from ChiselCircuitAnnotation and
ChiselOutputFileAnnotation. Both .fir and .pb file formats are
supported. Default format is .fir unless a --chisel-output-file is
specified with a .pb extension.

This relies on a bugfix in https://github.com/freechipsproject/firrtl/pull/1887 to work.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


 - bug fix 
 - new feature/API  

#### API Impact

This is a binary incompatible modification from RC1, instead of `ChiselCircuitAnnotation` extending `CustomFileEmission` and only serializing to `.fir`, I added a new annotation `CircuitSerializationAnnotation` that can serialize to both `.fir` and `.pb`.

#### Backend Code Generation Impact

No impact to Verilog, but Chisel can now natively emit `.pb`

#### Desired Merge Strategy

   - Squash

#### Release Notes

Add support for direct protobuf serialization from Chisel via `CircuitSerializationAnnotation`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
