### PR TITLE
Fix load memory from file to work with binary

### DIFF
--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -112,7 +112,7 @@ object loadMemoryFromFile {
     fileName: String,
     hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
   ): Unit = {
-    annotate(ChiselLoadMemoryAnnotation(memory, fileName))
+    annotate(ChiselLoadMemoryAnnotation(memory, fileName, hexOrBinary))
   }
 }
 


### PR DESCRIPTION
Passed in hexOrBinary parameter to ChiselLoadMemoryAnnotation

Test included

Fixes #1582

#### API Impact
No change in API

#### Backend Code Generation Impact
Allows $readmemb to be generated when the user specifies MemoryLoadFileType.Binary.

#### Desired Merge Strategy

Squash

#### Release Notes
Fixed bug in loadMemoryFromFile that caused the hexOrBinary parameter to be ignored.
