### PR TITLE
Support using switch without importing SwitchContext

### DIFF
--- a/docs/src/wiki-deprecated/cookbook.md
+++ b/docs/src/wiki-deprecated/cookbook.md
@@ -128,7 +128,7 @@ State transitions are then handled with [`switch`](https://www.chisel-lang.org/a
 
 ```scala mdoc:silent:reset
 import chisel3._
-import chisel3.util._
+import chisel3.util.{switch, is}
 import chisel3.experimental.ChiselEnum
 
 object DetectTwoOnes {

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -94,7 +94,7 @@ object switch {
   def apply[T <: Element](cond: T)(x: => Any): Unit = macro impl
   def impl(c: Context)(cond: c.Tree)(x: c.Tree): c.Tree = { import c.universe._
     val q"..$body" = x
-    val res = body.foldLeft(q"""new SwitchContext($cond, None, Set.empty)""") {
+    val res = body.foldLeft(q"""new chisel3.util.SwitchContext($cond, None, Set.empty)""") {
       case (acc, tree) => tree match {
         // TODO: remove when Chisel compatibility package is removed
         case q"Chisel.`package`.is.apply( ..$params )( ..$body )" => q"$acc.is( ..$params )( ..$body )"

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.stage.ChiselStage
-import chisel3.util._
+import chisel3.util.{switch, is}
 
 class SwitchSpec extends ChiselFlatSpec with Utils {
   "switch" should "require literal conditions" in {


### PR DESCRIPTION
Fixes https://github.com/ucb-bar/chisel-tutorial/issues/166

Just a minor issue where `switch` basically assumes you're always doing `import chisel3.util._`. Simple fix.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix  

#### API Impact

Fixes a bug in API

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix bug where using `chisel3.util.switch` required the user to import `chisel3.util.SwitchContext`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
