### PR TITLE
Fix broken mdoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
 
       - run:
           command: |
-            sbt $SBT_ARGS "docs/mdoc"
+            (cd chisel3 && cat /dev/null | sbt $SBT_ARGS "docs/mdoc")
 
   test-chisel-2_11:
     executor: chisel-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,4 +180,6 @@ workflows:
           requires:
             - build-treadle
       - test-chisel-docs
+          requires:
+            - build-treadle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
 
   test-chisel-docs:
     executor: chisel-executor
+
     steps:
       - attach_workspace:
           at: /home/chisel
@@ -178,4 +179,5 @@ workflows:
       - test-chisel-2_12:
           requires:
             - build-treadle
+      - test-chisel-docs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
       - test-chisel-2_12:
           requires:
             - build-treadle
-      - test-chisel-docs
+      - test-chisel-docs:
           requires:
             - build-treadle
 

--- a/docs/src/cookbooks/naming.md
+++ b/docs/src/cookbooks/naming.md
@@ -58,5 +58,5 @@ class ExampleNoPrefix extends MultiIOModule {
   out := add
 }
 
-println(ChiselStage.emitVerilog(new Example7))
+println(ChiselStage.emitVerilog(new ExampleNoPrefix))
 ```

--- a/docs/src/explanations/naming.md
+++ b/docs/src/explanations/naming.md
@@ -213,7 +213,7 @@ reflection naming cannot:
 ```scala mdoc
 class Example10 extends MultiIOModule {
   {
-    val in = IO(Input(UInt(width.W)))
+    val in = IO(Input(UInt(3.W)))
     val out = IO(Output(UInt()))
 
     val add = in + in


### PR DESCRIPTION
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [NA] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
No change.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes

Fixed bug in docs/mdoc, where they aren't building properly.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
