### PR TITLE
When prefixing with a data, eagly get local name

### DIFF
--- a/core/src/main/scala/chisel3/internal/prefix.scala
+++ b/core/src/main/scala/chisel3/internal/prefix.scala
@@ -28,9 +28,11 @@ private[chisel3] object prefix { // scalastyle:ignore
     * @return The return value of the provided function
     */
   def apply[T](name: HasId)(f: => T): T = {
-    Builder.pushPrefix(name)
+    val pushed = Builder.pushPrefix(name)
     val ret = f
-    Builder.popPrefix()
+    if (pushed) {
+      Builder.popPrefix()
+    }
     ret
   }
 


### PR DESCRIPTION
Fixes #1606

Previously, the Data itself would be put on the prefix stack and its
full name would be used as the prefix for subsequent names. This meant
that prefixes would grow quadratically as the prefix is present both on
the Data pushed to the stack, and on the stack itself. This is fixed by
just using the "local" name of the Data being pushed on the stack.

A related issue is deferring the name resolution. This led to unintuitive
behavior when the name of a Data used as a prefix is overridden later
(usually when the Data is a return value). The overriding name would
show up in prefixes twice instead of once. It is much more intuitive to
grab the name at the moment of the connection creating the prefix rather
than deferring to later.

TODO
- [ ] ~Fix linear lookup of aggregate children - proposal is to force the local names of aggregate children, this could violate weird assumptions so need to be careful~ Later
- [ ] ~Switch implementation of prefix stack to List[String] - this will improve memory and performance a decent amount~ Later

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix  

#### API Impact

No impact on API (changing types of methods on a package private object will require MiMa waivers but isn't visible to the user).

#### Backend Code Generation Impact

Improves names from recursive functions where prefixing occurs due to a connection quite a bit

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix quadratic naming in recursive functions (Fixes #1606)  

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
