### PR TITLE
Provide user source locators in Builder.error errors

### DIFF
--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -164,6 +164,7 @@ private[chisel3] class ErrorLog {
       val chiselPrefixes = Set(
           "java.",
           "scala.",
+          "chisel3.",
           "chisel3.internal.",
           "chisel3.experimental.",
           "chisel3.package$"  // for some compatibility / deprecated types

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -35,6 +35,11 @@ object ChiselMainSpec {
     require(false)
   }
 
+  /** A module that triggers a Builder.error (as opposed to exception) */
+  class BuilderErrorModule extends RawModule {
+    val w = Wire(UInt(8.W))
+    w(3, -1)
+  }
 }
 
 case class TestClassAspect() extends InspectorAspect[RawModule] ({
@@ -150,6 +155,14 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
                      generator = Some(classOf[FailingRequirementModule]),
                      stdout = Some("chisel3.internal.ChiselException"),
                      result = 1)
+    ).foreach(runStageExpectFiles)
+  }
+  Feature("Builder.error source locator") {
+    Seq(
+      ChiselMainTest(args = Array("-X", "none"),
+        generator = Some(classOf[BuilderErrorModule]),
+        stdout = Some("ChiselMainSpec.scala:41: Invalid bit range (3,-1) in class chiselTests.stage.ChiselMainSpec$BuilderErrorModule"),
+        result = 1)
     ).foreach(runStageExpectFiles)
   }
 


### PR DESCRIPTION
Package chisel3 was not properly marked as an internal package so source
locators in reported errors would point to files like Bits.scala.

This issue has existed since 3.2.0.

Example showing the issue: https://scastie.scala-lang.org/ujhmuUv4RjWklwY7KtiToA

```
[info] [0.000] Elaborating design...
[error] Bits.scala:159: Invalid bit range (3,-1) in class chisel3.Bits
[error] There were 1 error(s) during hardware elaboration.
```

`Bits.scala` is not a very useful source locator, this PR fixes it.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Fix bug where some error messages would give source locators inside Chisel's code instead of user code

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
