### PR TITLE
Enable Cat of Zero Element Vec

### DIFF
--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -15,12 +15,15 @@ private[chisel3] object SeqUtils {
     * in the sequence forms the most significant bits.
     *
     * Equivalent to r(n-1) ## ... ## r(1) ## r(0).
+    * @note This returns a `0.U` if applied to a zero-element `Vec`.
     */
   def asUInt[T <: Bits](in: Seq[T]): UInt = macro SourceInfoTransform.inArg
 
   /** @group SourceInfoTransformMacros */
   def do_asUInt[T <: Bits](in: Seq[T])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = {
-    if (in.tail.isEmpty) {
+    if (in.isEmpty) {
+      0.U
+    } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
       val left = prefix("left") {

--- a/src/main/scala/chisel3/util/Cat.scala
+++ b/src/main/scala/chisel3/util/Cat.scala
@@ -25,6 +25,7 @@ object Cat {
     * in the sequence forms the least significant bits.
     *
     * Equivalent to r(0) ## r(1) ## ... ## r(n-1).
+    * @note This returns a `0.U` if applied to a zero-element `Vec`.
     */
   def apply[T <: Bits](r: Seq[T]): UInt = SeqUtils.asUInt(r.reverse)
 }

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chisel3.util.Cat
+
+import chiselTests.ChiselFlatSpec
+
+object CatSpec {
+
+  class JackIsATypeSystemGod extends MultiIOModule {
+    val in  = IO(Input (Vec(0, UInt(8.W))))
+    val out = IO(Output(UInt(8.W)))
+
+    out := Cat(in)
+  }
+
+}
+
+class CatSpec extends ChiselFlatSpec {
+
+  import CatSpec._
+
+  behavior of "util.Cat"
+
+  it should "not fail to elaborate a zero-element Vec" in {
+
+    ChiselStage.elaborate(new JackIsATypeSystemGod)
+
+  }
+
+}


### PR DESCRIPTION
Prevent an exception thrown if you apply `Cat` to a zero-element `Vec`. This will now return `0.U` if you do that.

Fixes #1622 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                            
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None. This enables new behavior which was previously an error.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No change to existing Verilog.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Cat of a zero-element Vec now returns 0.U

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
