### PR TITLE
Make `-e` option work with ChiselStage methods

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -6,7 +6,9 @@ import firrtl.{
   ir => fir,
   AnnotationSeq,
   EmittedFirrtlCircuitAnnotation,
+  EmittedFirrtlModuleAnnotation,
   EmittedVerilogCircuitAnnotation,
+  EmittedVerilogModuleAnnotation,
   HighFirrtlEmitter,
   VerilogEmitter,
   SystemVerilogEmitter
@@ -93,11 +95,11 @@ class ChiselStage extends Stage {
     annotations: AnnotationSeq = Seq.empty): String = {
 
     execute(Array("-X", "high") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
-      .collectFirst {
+      .collect {
         case EmittedFirrtlCircuitAnnotation(a) => a
-      }
-      .get
-      .value
+        case EmittedFirrtlModuleAnnotation(a)  => a
+      }.map(_.value)
+      .mkString("")
 
   }
 
@@ -115,9 +117,10 @@ class ChiselStage extends Stage {
     execute(Array("-X", "verilog") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
       .collectFirst {
         case EmittedVerilogCircuitAnnotation(a) => a
-      }
-      .get
-      .value
+        case EmittedVerilogModuleAnnotation(a)  => a
+      }.map(_.value)
+      .mkString("")
+
   }
 
   /** Convert a Chisel module to SystemVerilog
@@ -134,9 +137,10 @@ class ChiselStage extends Stage {
     execute(Array("-X", "sverilog") ++ args, ChiselGeneratorAnnotation(() => gen) +: annotations)
       .collectFirst {
         case EmittedVerilogCircuitAnnotation(a) => a
-      }
-      .get
-      .value
+        case EmittedVerilogModuleAnnotation(a)  => a
+      }.map(_.value)
+      .mkString("")
+
   }
 }
 

--- a/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
@@ -4,6 +4,7 @@ package chiselTests.stage
 
 import chisel3._
 import chisel3.stage.ChiselStage
+import chisel3.testers.TesterDriver.createTestDirectory
 
 import chiselTests.Utils
 
@@ -52,8 +53,9 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
   }
 
   it should "return a flattened FIRRTL string with '-e high'" in {
+    val args = Array("-e", "high", "-td", createTestDirectory(this.getClass.getSimpleName).toString)
     (new ChiselStage)
-      .emitFirrtl(new Foo, Array("-e", "high", "-td", "test_run_dir/ChiselStageSpec")) should include ("module Bar")
+      .emitFirrtl(new Foo, args) should include ("module Bar")
   }
 
   behavior of "ChiselStage.emitVerilog"
@@ -63,8 +65,9 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
   }
 
   it should "return a flattened Verilog string with '-e verilog'" in {
+    val args = Array("-e", "verilog", "-td", createTestDirectory(this.getClass.getSimpleName).toString)
     (new ChiselStage)
-      .emitVerilog(new Foo, Array("-e", "verilog", "-td", "test_run_dir/ChiselStageSpec")) should include ("module Bar")
+      .emitVerilog(new Foo, args) should include ("module Bar")
   }
 
   behavior of "ChiselStage$.elaborate"


### PR DESCRIPTION
Prevent a `None.get` where a user passes a `-e` (one-file-per-module) option to one of the `ChiselStage` methods. This was previously checking for the only a circuit, but throwing in `-e` would cause modules to be emitted. Append all the modules together and return this string.

Fixes #1629 

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [n/a] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.
#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
