### PR TITLE
Fix crosslinks in mdoc. Can't use md suffix

### DIFF
--- a/docs/src/cookbooks/naming.md
+++ b/docs/src/cookbooks/naming.md
@@ -31,12 +31,12 @@ renaming these signals with more context-dependent names, but it is a work in pr
 
 This is the infamous `Queue` instability problem. In general, these cases are best solved at the source - the module
 itself! If you overwrite `desiredName` to include parameter information (see the
-[explanation](../explanations/naming.md#set-a-module-name) for more info), then this can avoid this problem permanantly.
+[explanation](../explanations/naming#set-a-module-name) for more info), then this can avoid this problem permanantly.
 We've done this with some Chisel utilities with great results!
 
 ### I want to add some hardware or assertions, but each time I do all the signal names get bumped!
 
-This is the classic "ECO" problem, and we provide descriptions in [explanation](../explanations/naming.md). In short,
+This is the classic "ECO" problem, and we provide descriptions in [explanation](../explanations/naming). In short,
 we recommend wrapping all additional logic in a prefix scope, which enables a unique namespace. This should prevent
 name collisions, which are what triggers all those annoying signal name bumps!
 

--- a/docs/src/explanations/blackboxes.md
+++ b/docs/src/explanations/blackboxes.md
@@ -79,7 +79,7 @@ endmodule
 ```
 
 ### Blackboxes with Verilog in a Resource File
-In order to deliver the verilog snippet above to the backend simulator, chisel3 provides the following tools based on the chisel/firrtl [annotation system](../explanations/annotations.md).  Add the trait ```HasBlackBoxResource``` to the declaration, and then call a function in the body to say where the system can find the verilog.  The Module now looks like
+In order to deliver the verilog snippet above to the backend simulator, chisel3 provides the following tools based on the chisel/firrtl [annotation system](../explanations/annotations).  Add the trait ```HasBlackBoxResource``` to the declaration, and then call a function in the body to say where the system can find the verilog.  The Module now looks like
 ```mdoc scala:silent:reset
 class BlackBoxRealAdd extends BlackBox with HasBlackBoxResource {
   val io = IO(new Bundle() {

--- a/docs/src/explanations/bundles-and-vecs.md
+++ b/docs/src/explanations/bundles-and-vecs.md
@@ -77,7 +77,7 @@ Note that the builtin Chisel primitive and aggregate classes do not
 require the `new` when creating an instance, whereas new user
 datatypes will.  A Scala `apply` constructor can be defined so
 that a user datatype also does not require `new`, as described in
-[Function Constructor](../wiki-deprecated/functional-module-creation.md).
+[Function Constructor](../wiki-deprecated/functional-module-creation).
 
 ### Flipping Bundles
 

--- a/docs/src/explanations/naming.md
+++ b/docs/src/explanations/naming.md
@@ -12,7 +12,7 @@ they are declared. In addition, this release includes prolific use of a new pref
 naming of signals programmatically generated from function calls.
 
 This document explains how naming now works in Chisel for signal and module names. For cookbook examples on how to fix
-systemic name-stability issues, please refer to the naming [cookbook](../cookbooks/naming.md).
+systemic name-stability issues, please refer to the naming [cookbook](../cookbooks/naming).
 
 ### Compiler Plugin
 

--- a/docs/src/wiki-deprecated/chisel3-vs-chisel2.md
+++ b/docs/src/wiki-deprecated/chisel3-vs-chisel2.md
@@ -89,7 +89,7 @@ for instructions on preparing your Chisel2 designs for Chisel3.
 ## Unsupported constructs
 *  `Mem(..., orderedWrites)` is no longer supported,
 *  masked writes are only supported for `Mem[Vec[_]]`,
-* Chisel3 Vecs must all have the same type, unlike with Chisel2. Use `MixedVec` (see [Bundles and Vecs](bundles-and-vecs.md)) for Vecs where the elements are of different types.
+* Chisel3 Vecs must all have the same type, unlike with Chisel2. Use `MixedVec` (see [Bundles and Vecs](bundles-and-vecs)) for Vecs where the elements are of different types.
 *  connections between `UInt` and `SInt` are illegal.
 *  the `Node` class and object no longer exist (the class should have been private in Chisel2)
 *  `printf()` is defined in the Chisel object and produces simulation printf()'s.

--- a/docs/src/wiki-deprecated/cookbook.md
+++ b/docs/src/wiki-deprecated/cookbook.md
@@ -6,7 +6,7 @@ section: "chisel3"
 
 Welcome to the Chisel cookbook. This cookbook is still in early stages. If you have any requests or examples to share, please [file an issue](https://github.com/ucb-bar/chisel3/issues/new) and let us know!
 
-Please note that these examples make use of [Chisel's scala-style printing](printing.md#scala-style).
+Please note that these examples make use of [Chisel's scala-style printing](printing#scala-style).
 
 * Converting Chisel Types to/from UInt
   * [How do I create a UInt from an instance of a Bundle?](#how-do-i-create-a-uint-from-an-instance-of-a-bundle)

--- a/docs/src/wiki-deprecated/data-types.md
+++ b/docs/src/wiki-deprecated/data-types.md
@@ -17,7 +17,7 @@ format.  Boolean values are represented as type ```Bool```.  Note
 that these types are distinct from Scala's builtin types such as
 ```Int``` or ```Boolean```.
 
-> There is a new experimental type **Interval** which gives the developer more control of the type by allowing the definition of an IntervalRange.  See: [Interval Type](interval-type.md)
+> There is a new experimental type **Interval** which gives the developer more control of the type by allowing the definition of an IntervalRange.  See: [Interval Type](interval-type)
 
 Additionally, Chisel defines `Bundles` for making
 collections of values with named fields (similar to ```structs``` in

--- a/docs/src/wiki-deprecated/developers.md
+++ b/docs/src/wiki-deprecated/developers.md
@@ -7,5 +7,5 @@ section: "chisel3"
 
 Tips and tricks for Chisel developers.
 
-* [Embedding Chisel as an sbt subproject](sbt-subproject.md)
-* [Test Coverage](test-coverage.md)
+* [Embedding Chisel as an sbt subproject](sbt-subproject)
+* [Test Coverage](test-coverage)

--- a/docs/src/wiki-deprecated/faqs.md
+++ b/docs/src/wiki-deprecated/faqs.md
@@ -24,7 +24,7 @@ We recommend the [Chisel Bootcamp](https://github.com/freechipsproject/chisel-bo
 
 ### How do I do ... (e.g. like that in Verilog) in Chisel?
 
-See the [cookbook](cookbook.md).
+See the [cookbook](cookbook).
 
 ### How can I contribute to Chisel?
 
@@ -78,7 +78,7 @@ Chisel Modules are written by defining a [Scala class](http://docs.scala-lang.or
 
 ### Why Chisel?
 
-Borrowed from [Chisel Introduction](introduction.md)
+Borrowed from [Chisel Introduction](introduction)
 
 >We were motivated to develop a new hardware language by years of
 struggle with existing hardware description languages in our research
@@ -226,7 +226,7 @@ res3: java.io.File = output.fir
 ### Why doesn't Chisel tell me which wires aren't connected?
 
 As of commit [c313e13](https://github.com/freechipsproject/chisel3/commit/c313e137d4e562ef20195312501840ceab8cbc6a) it can!
-Please visit the wiki page [Unconnected Wires](unconnected-wires.md) for details.
+Please visit the wiki page [Unconnected Wires](unconnected-wires) for details.
 
 ### What does `Reference ... is not fully initialized.` mean?
 
@@ -235,7 +235,7 @@ It means that you have unconnected wires in your design which could be an indica
 In Chisel2 compatibility mode (`NotStrict` compile options), chisel generates firrtl code that disables firrtl's initialized wire checks.
 In pure chisel3 (`Strict` compile options), the generated firrtl code does not contain these disablers (`is invalid`).
 Output wires that are not driven (not connected) are reported by firrtl as `not fully initialized`.
-Please visit the wiki page [Unconnected Wires](unconnected-wires.md) for details on solving the problem.
+Please visit the wiki page [Unconnected Wires](unconnected-wires) for details on solving the problem.
 
 ### Can I specify behavior before and after generated initial blocks?
 Users may define the following macros if they wish to specify behavior before or after emitted initial blocks.

--- a/docs/src/wiki-deprecated/memories.md
+++ b/docs/src/wiki-deprecated/memories.md
@@ -101,7 +101,7 @@ class RWSmem extends Module {
 }
 ```
 
-(The `DontCare` is there to make Chisel's [unconnected wire detection](unconnected-wires.md) aware that reading while writing is undefined.)
+(The `DontCare` is there to make Chisel's [unconnected wire detection](unconnected-wires) aware that reading while writing is undefined.)
 
 Here is an example single read/write port waveform, with [masks](#masks) (again, generated signal names and number of arrays may differ):
 

--- a/docs/src/wiki-deprecated/reset.md
+++ b/docs/src/wiki-deprecated/reset.md
@@ -117,7 +117,7 @@ You can also cast to force the concrete type of reset.
 * `.asAsyncReset` will reinterpret a `Reset` as `AsyncReset`.
 
 You can then use `withReset` to use a cast reset as the implicit reset.
-See ["Multiple Clock Domains"](multi-clock.md) for more information about `withReset`.
+See ["Multiple Clock Domains"](multi-clock) for more information about `withReset`.
 
 
 The following will make `myReg` as well as both `resetAgnosticReg`s synchronously reset:

--- a/docs/src/wiki-deprecated/supported-hardware.md
+++ b/docs/src/wiki-deprecated/supported-hardware.md
@@ -3,6 +3,6 @@ layout: docs
 title:  "Supported Hardware"
 section: "chisel3"
 ---
-While Chisel focuses on binary logic, Chisel can support analog and tri-state wires with the `Analog` type - see [Datatypes in Chisel](data-types.md).
+While Chisel focuses on binary logic, Chisel can support analog and tri-state wires with the `Analog` type - see [Datatypes in Chisel](data-types).
 
 We focus on binary logic designs as they constitute the vast majority of designs in practice. Tri-state logic are poorly supported standard industry flows and require special/controlled hard macros in order to be done.


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [ N/A Did you add at least one test demonstrating the PR?
- [N/A] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [N/A] Did you state the API impact?
- [N/A] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [N/A] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
