### PR TITLE
Fix bug where refs may not get set for Records

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -493,7 +493,6 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
     try {
       super.bind(target, parentDirection)
-      setElementRefs()
     } catch {  // nasty compatibility mode shim, where anything flies
       case e: MixedDirectionAggregateException if !compileOptions.dontAssumeDirectionality =>
         val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
@@ -503,6 +502,7 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
           case _ => ActualDirection.Bidirectional(ActualDirection.Default)
         }
     }
+    setElementRefs()
   }
 
   /** Creates a Bundle literal of this type with specified values. this must be a chisel type.


### PR DESCRIPTION
This requires a combination of things, but it happens to be a
combination used by Diplomacy in Rocket Chip. It must be a Record in
compatibility code with Vecs as fields and a mix of components with and
without set directions.

Bug introduced in https://github.com/freechipsproject/chisel3/pull/1616, not yet released so no need for release notes

h/t to @azidar for helping me debug this, I seriously thought I was losing my mind. I never use `try-catch` to recover from exceptions (only to report more precise errors) so I just wasn't expecting it to be skipping over a critical line of code and continuing. Might be better to replace this pattern with a more explicit `Try` but in any case the fix is simple.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
