### PR TITLE
SeqUtils asUInt endian-ness: hi/lo instead of right/left

### DIFF
--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -26,13 +26,13 @@ private[chisel3] object SeqUtils {
     } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
-      val left = prefix("left") {
+      val lo = prefix("lo") {
         asUInt(in.slice(0, in.length/2))
-      }.autoSeed("left")
-      val right = prefix("right") {
+      }.autoSeed("lo")
+      val hi = prefix("hi") {
         asUInt(in.slice(in.length/2, in.length))
-      }.autoSeed("right")
-      right ## left
+      }.autoSeed("hi")
+      hi ## lo
     }
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- backend code generation

#### API Impact
this changes the Chisel Naming from https://github.com/freechipsproject/chisel3/pull/1448 to notate endianness as "hi/lo" instead of "right/left", because Scala and Verilog use opposite endianness in lists/arrays

#### Backend Code Generation Impact
With https://github.com/freechipsproject/chisel3/pull/1448, this Chisel
```
val out2 = Seq(signalname(0), signalname(1)).asUInt
val out4 = Seq(signalname(0), signalname(1), signalname(2), signalname(3)).asUInt
```
would generate this Verilog:
```
wire [1:0] out2 = {signalname_right, signalname_left};
wire [3:0] out4 = {signalname_right_right, signalname_right_left, signalname_left_right, signalname_left_left};
```
This looks backwards to me when reading the Verilog: the rights and lefts are reversed.  So instead, with this change:
```
wire [1:0] out2 = {signalname_hi, signalname_lo};
wire [3:0] out4 = {signalname_hi_hi, signalname_hi_lo, signalname_lo_hi, signalname_lo_lo};
```

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.)

#### Release Notes
Verilog generation: asUInt endianness "hi/lo" instead of "right/left"

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
