### PR TITLE
Remove Data.setRef assertion

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -165,8 +165,8 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     // Long term solution will be to define BlackBox IO differently as part of
     //   it not descending from the (current) Module
     for ((name, port) <- namedPorts) {
-      // We have to force override the _ref because it was set during IO binding
-      port.setRef(ModuleIO(this, _namespace.name(name)), force = true)
+      // Override the _ref because it was set during IO binding
+      port.setRef(ModuleIO(this, _namespace.name(name)))
     }
 
     // We need to call forceName and onModuleClose on all of the sub-elements

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -198,8 +198,7 @@ private[chisel3] trait HasId extends InstanceId {
     }
 
   private var _ref: Option[Arg] = None
-  private[chisel3] def setRef(imm: Arg, force: Boolean = false): Unit = {
-    assert(force || _ref.isEmpty, s"Internal Error, setRef for $this called twice! first ${_ref.get}, second $imm")
+  private[chisel3] def setRef(imm: Arg): Unit = {
     _ref = Some(imm)
   }
   private[chisel3] def setRef(parent: HasId, name: String): Unit = setRef(Slot(Node(parent), name))

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -128,4 +128,17 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
       } }
     }).getMessage should include("aliased fields")
   }
+
+  "Unbound bundles sharing a field" should "not error" in {
+    ChiselStage.elaborate {
+      new RawModule {
+        val foo = new Bundle {
+          val x = UInt(8.W)
+        }
+        val bar = new Bundle {
+          val y = foo.x
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
It causes issues for some legal (if awkward) patterns. A larger refactor
of when refs are set could reinstate this check.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

Bug introduced in #1616, no release notes necessary.

#### Type of Improvement

 - bug fix   

#### API Impact

This removes a check added in https://github.com/freechipsproject/chisel3/pull/1616 (not yet released) that causes some legal code to error. See the test for an example. While this check is a good thing to have, it will prevent the use of Chisel v3.4.1 in FireSim which currently uses this pattern. Some of the internals cleanups related to https://github.com/freechipsproject/chisel3/pull/1624 may be able to make the legal cases stay legal while adding this check back, but in the interest of getting v3.4.1 out, the check need to be removed.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
