### PR TITLE
Refine autonaming to have more intuitive behavior

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -59,6 +59,7 @@ private[chisel3] class IdGen {
     counter += 1
     counter
   }
+  def value: Long = counter
 }
 
 /** Public API to access Node/Signal names.
@@ -119,7 +120,9 @@ private[chisel3] trait HasId extends InstanceId {
     * @param seed Seed for the name of this component
     * @return this object
     */
-  private [chisel3] def autoSeed(seed: String): this.type = {
+  private[chisel3] def autoSeed(seed: String): this.type = forceAutoSeed(seed)
+  // Bypass the overridden behavior of autoSeed in [[Data]], apply autoSeed even to ports
+  private[chisel3] def forceAutoSeed(seed: String): this.type = {
     auto_seed = Some(seed)
     for(hook <- auto_postseed_hooks) { hook(seed) }
     prefix_seed = Builder.getPrefix()

--- a/core/src/main/scala/chisel3/internal/plugin/package.scala
+++ b/core/src/main/scala/chisel3/internal/plugin/package.scala
@@ -10,6 +10,7 @@ package object plugin {
     * @param nameMe The thing to be named
     * @tparam T The type of the thing to be named
     * @return The thing, but now named
+    * @note This is the version called by chisel3-plugin prior to v3.4.1
     */
   def autoNameRecursively[T <: Any](name: String, nameMe: T): T = {
     chisel3.internal.Builder.nameRecursively(
@@ -18,5 +19,55 @@ package object plugin {
       (id: chisel3.internal.HasId, n: String) => id.autoSeed(n)
     )
     nameMe
+  }
+
+  // The actual implementation
+  // Cannot be unified with (String, T) => T (v3.4.0 version) because of special behavior of ports
+  // in .autoSeed
+  private def _autoNameRecursively[T <: Any](prevId: Long, name: String, nameMe: T): T = {
+    chisel3.internal.Builder.nameRecursively(
+      name,
+      nameMe,
+      (id: chisel3.internal.HasId, n: String) => {
+        // Name override only if result was created in this scope
+        if (id._id > prevId) {
+          id.forceAutoSeed(n)
+        }
+      }
+    )
+    nameMe
+  }
+
+  /** Used by Chisel's compiler plugin to automatically name signals
+    * DO NOT USE in your normal Chisel code!!!
+    *
+    * @param name The name to use
+    * @param nameMe The thing to be named
+    * @tparam T The type of the thing to be named
+    * @return The thing, but now named
+    */
+  def autoNameRecursively[T <: Any](name: String)(nameMe: => T): T = {
+    // The _id of the most recently constructed HasId
+    val prevId = Builder.idGen.value
+    val result = nameMe
+    _autoNameRecursively(prevId, name, result)
+  }
+
+  /** Used by Chisel's compiler plugin to automatically name signals
+    * DO NOT USE in your normal Chisel code!!!
+    *
+    * @param names The names to use corresponding to interesting fields of the Product
+    * @param nameMe The [[Product]] to be named
+    * @tparam T The type of the thing to be named
+    * @return The thing, but with each member named
+    */
+  def autoNameRecursivelyProduct[T <: Product](names: List[Option[String]])(nameMe: => T): T = {
+    // The _id of the most recently constructed HasId
+    val prevId = Builder.idGen.value
+    val result = nameMe
+    for ((name, t) <- names.iterator.zip(result.productIterator) if name.nonEmpty) {
+      _autoNameRecursively(prevId, name.get, t)
+    }
+    result
   }
 }

--- a/docs/src/cookbooks/naming.md
+++ b/docs/src/cookbooks/naming.md
@@ -42,7 +42,7 @@ name collisions, which are what triggers all those annoying signal name bumps!
 
 ### I want to force a signal (or instance) name to something, how do I do that?
 
-Use the `.suggestName` method, which is on all classes which subtype 'Data'.
+Use the `.suggestName` method, which is on all classes which subtype `Data`.
 
 ### All this prefixing is annoying, how do I fix it?
 

--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -166,11 +166,78 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
     }
   }
 
-  "Multiple names on a non-IO" should "get the last name" in {
+  "Multiple names on a non-IO" should "get the first name" in {
     class Test extends MultiIOModule {
       {
         val a = Wire(UInt(3.W))
         val b = a
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.wires(top).map(_.instanceName) should be (List("a"))
+    }
+  }
+
+  "Outer Expression, First Statement naming" should "apply to IO" in {
+    class Test extends RawModule {
+      {
+        val widthOpt: Option[Int] = Some(4)
+        val out = widthOpt.map { w =>
+          val port = IO(Output(UInt(w.W)))
+          port
+        }
+        val foo = out
+        val bar = out.get
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.ios(top).map(_.instanceName) should be (List("out"))
+    }
+  }
+
+  "Outer Expression, First Statement naming" should "apply to non-IO" in {
+    class Test extends RawModule {
+      {
+        val widthOpt: Option[Int] = Some(4)
+        val fizz = widthOpt.map { w =>
+          val wire = Wire(UInt(w.W))
+          wire
+        }
+        val foo = fizz
+        val bar = fizz.get
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.wires(top).map(_.instanceName) should be (List("fizz"))
+    }
+  }
+
+  "autoSeed" should "NOT override automatic naming for IO" in {
+    class Test extends RawModule {
+      {
+        val a = IO(Output(UInt(3.W)))
+        a.autoSeed("b")
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.ios(top).map(_.instanceName) should be (List("a"))
+    }
+  }
+
+
+  "autoSeed" should "override automatic naming for non-IO" in {
+    class Test extends MultiIOModule {
+      {
+        val a = Wire(UInt(3.W))
+        a.autoSeed("b")
       }
     }
 
@@ -190,6 +257,54 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
     aspectTest(() => new Test) {
       top: Test =>
         Select.wires(top).map(_.instanceName) should be (List("a", "b"))
+    }
+  }
+
+  "Unapply assignments" should "not override already named things" in {
+    class Test extends MultiIOModule {
+      {
+        val x = Wire(UInt(3.W))
+        val (a, b) = (x, Wire(UInt(3.W)))
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.wires(top).map(_.instanceName) should be (List("x", "b"))
+    }
+  }
+
+  "Case class unapply assignments" should "be named" in {
+    case class Foo(x: UInt, y: UInt)
+    class Test extends MultiIOModule {
+      {
+        def func() = Foo(Wire(UInt(3.W)), Wire(UInt(3.W)))
+        val Foo(a, b) = func()
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.wires(top).map(_.instanceName) should be (List("a", "b"))
+    }
+  }
+
+  "Complex unapply assignments" should "be named" in {
+    case class Foo(x: UInt, y: UInt)
+    class Test extends MultiIOModule {
+      {
+        val w = Wire(UInt(3.W))
+        def func() = {
+          val x = Foo(Wire(UInt(3.W)), Wire(UInt(3.W)))
+          (x, w) :: Nil
+        }
+        val ((Foo(a, _), c) :: Nil) = func()
+      }
+    }
+
+    aspectTest(() => new Test) {
+      top: Test =>
+        Select.wires(top).map(_.instanceName) should be (List("w", "a", "_WIRE"))
     }
   }
 


### PR DESCRIPTION
Last name in an Expression wins, while the first Statement to name wins.
This is done via checking the _id of HasIds during autonaming and only
applying a name if the HasId was created in the scope of autonaming.
There is no change to `.autoSeed` or `.suggestName` behavior.

Behavior of chisel3-plugins from before this change is maintained. More precisely, assuming this PR is released with Chisel v3.4.1, if you use Chisel v3.4.1 with the v3.4.0 (or v3.4.0-RC3) plugin, you'll get the v3.4.0 behavior. 

The bulk of the work here was making `unapply` continue to work because it previously worked via overriding names. Now, a signal will only be named by `autoNameRecursively` or `autoNameRecursivelyProduct` calls that wrap the `Expression` within which the `Data` is created.

Fixes https://github.com/freechipsproject/chisel3/issues/1603

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix
  - new feature/API    

#### API Impact

This changes the naming behavior to what I've been calling "Outer Expression, First Statement" wins. For example:

```scala
  val width: Option[Int] = Some(8)
  val debug = width.map { w =>
    val foo = IO(Output(UInt(w.W))) // name: "debug_foo"
    val delay = RegNext(in) // name: "debug_delay"
    foo := delay
    foo
  } // name: "debug"
  val bar = debug // name: "bar"
```
Intuitively, the name of this port should be `debug`. It is useful that things built within the anonymous function should have `debug` as a prefix in addition to their val name (eg. `debug_delay`), but because `foo` is returned, the outer name should win (`debug`). It is also intuitive that `debug` wins over `bar` since `debug` is the name of the declaration rather than an alias.

Prior to this PR, the port would be named `debug_foo` and if it were a non-port, it would be named `bar`. This PR unifies the behavior of ports and non-ports into what is (in my opinion) more intuitive.

#### Backend Code Generation Impact

Change in naming algorithm

#### Desired Merge Strategy

   - Squash

#### Release Notes

Change naming priority to "Outer Expression, First Statement"

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
