### PR TITLE
Ignore tests using System.setSecurityManager

### DIFF
--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -281,6 +281,7 @@ trait Utils {
     * or doesn't try to write at all.
     */
   def catchWrites[T](thunk: => T): Either[String, T] = {
+    throw new Exception("Do not use, not thread-safe")
     try {
       System.setSecurityManager(new ExceptOnWrite())
       Right(thunk)

--- a/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselStageSpec.scala
@@ -72,21 +72,21 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
 
   behavior of "ChiselStage$.elaborate"
 
-  it should "generate a Chisel circuit from a Chisel module" in {
+  ignore should "generate a Chisel circuit from a Chisel module" in {
     info("no files were written")
     catchWrites { ChiselStage.elaborate(new Foo) } shouldBe a[Right[_, _]]
   }
 
   behavior of "ChiselStage$.convert"
 
-  it should "generate a CHIRRTL circuit from a Chisel module" in {
+  ignore should "generate a CHIRRTL circuit from a Chisel module" in {
     info("no files were written")
     catchWrites { ChiselStage.convert(new Foo) } shouldBe a[Right[_, _]]
   }
 
   behavior of "ChiselStage$.emitChirrtl"
 
-  it should "generate a CHIRRTL string from a Chisel module" in {
+  ignore should "generate a CHIRRTL string from a Chisel module" in {
     val wrapped = catchWrites { ChiselStage.emitChirrtl(new Foo) }
 
     info("no files were written")
@@ -98,7 +98,7 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
 
   behavior of "ChiselStage$.emitFirrtl"
 
-  it should "generate a FIRRTL string from a Chisel module" in {
+  ignore should "generate a FIRRTL string from a Chisel module" in {
     val wrapped = catchWrites { ChiselStage.emitFirrtl(new Foo) }
 
     info("no files were written")
@@ -110,7 +110,7 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
 
   behavior of "ChiselStage$.emitVerilog"
 
-  it should "generate a Verilog string from a Chisel module" in {
+  ignore should "generate a Verilog string from a Chisel module" in {
     val wrapped = catchWrites { ChiselStage.emitVerilog(new Foo) }
 
     info("no files were written")
@@ -122,7 +122,7 @@ class ChiselStageSpec extends AnyFlatSpec with Matchers with Utils {
 
   behavior of "ChiselStage$.emitSystemVerilog"
 
-  it should "generate a SystemvVerilog string from a Chisel module" in {
+  ignore should "generate a SystemvVerilog string from a Chisel module" in {
     val wrapped = catchWrites { ChiselStage.emitSystemVerilog(new Foo) }
     info("no files were written")
     wrapped shouldBe a[Right[_, _]]


### PR DESCRIPTION
The SecurityManager is global so is not thread-safe. This is the source
of flaky tests in FIRRTL CI.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

None

#### Type of Improvement

 - bug fix (flaky tests)

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
