### PR TITLE
Improve source locators for switch statements.

### DIFF
--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -10,6 +10,7 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox._
 
 import chisel3._
+import chisel3.internal.sourceinfo.{SourceInfo}
 
 @deprecated("The unless conditional is deprecated, use when(!condition){...} instead", "3.2")
 object unless {
@@ -25,7 +26,7 @@ object unless {
   * @note DO NOT USE. This API is subject to change without warning.
   */
 class SwitchContext[T <: Element](cond: T, whenContext: Option[WhenContext], lits: Set[BigInt]) {
-  def is(v: Iterable[T])(block: => Any): SwitchContext[T] = {
+  def is(v: Iterable[T])(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SwitchContext[T] = {
     if (!v.isEmpty) {
       val newLits = v.map { w =>
         require(w.litOption.isDefined, "is condition must be literal")
@@ -43,8 +44,8 @@ class SwitchContext[T <: Element](cond: T, whenContext: Option[WhenContext], lit
       this
     }
   }
-  def is(v: T)(block: => Any): SwitchContext[T] = is(Seq(v))(block)
-  def is(v: T, vr: T*)(block: => Any): SwitchContext[T] = is(v :: vr.toList)(block)
+  def is(v: T)(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SwitchContext[T] = is(Seq(v))(block)
+  def is(v: T, vr: T*)(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SwitchContext[T] = is(v :: vr.toList)(block)
 }
 
 /** Use to specify cases in a [[switch]] block, equivalent to a [[when$ when]] block comparing to

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -10,7 +10,7 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox._
 
 import chisel3._
-import chisel3.internal.sourceinfo.{SourceInfo}
+import chisel3.internal.sourceinfo.SourceInfo
 
 @deprecated("The unless conditional is deprecated, use when(!condition){...} instead", "3.2")
 object unless {

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -32,4 +32,23 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
       })
     }
   }
+  it should "provide useful source locators" in {
+    val verilog = ChiselStage.emitVerilog(new Module {
+      val io = IO(new Bundle {
+        val in = Input(UInt(2.W))
+        val out = Output(UInt(2.W))
+      })
+
+      io.out := 0.U
+      switch (io.in) {
+        is (0.U) { io.out := 3.U }
+        is (1.U) { io.out := 0.U }
+        is (2.U) { io.out := 1.U }
+        is (3.U) { io.out := 3.U }
+      }
+    })
+
+    assert(!verilog.contains("Conditional.scala"))
+    println(verilog)
+  }
 }

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -49,6 +49,5 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
     })
 
     assert(!verilog.contains("Conditional.scala"))
-    println(verilog)
   }
 }

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -33,7 +33,7 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
     }
   }
   it should "provide useful source locators" in {
-    val verilog = ChiselStage.emitVerilog(new Module {
+    val chirrtl = ChiselStage.emitChirrtl(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(2.W))
         val out = Output(UInt(2.W))
@@ -48,6 +48,6 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
       }
     })
 
-    assert(!verilog.contains("Conditional.scala"))
+    chirrtl should not include "Conditional.scala"
   }
 }


### PR DESCRIPTION
This fixes #1648.

### Contributor Checklist

- [ ] N/A ~~Did you add Scaladoc to every public function/method?~~
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] N/A ~~Did you add appropriate documentation in `docs/src`?~~
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] N/A ~~Did you add text to be included in the Release Notes for this change?~~

#### Type of Improvement

  - bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

The source locators in the code generated from the `switch` statements will no longer reference `Conditional.scala`. They will now reference the source line of the `is` statement.

#### Desired Merge Strategy
 
- Squash

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
N/A

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
